### PR TITLE
Typo fix in gauche.serializer

### DIFF
--- a/lib/gauche/serializer.scm
+++ b/lib/gauche/serializer.scm
@@ -93,7 +93,7 @@
 (define (input-serializer? obj)
   (and (serializer? obj) (eq? (direction-of obj) :in)))
 (define (output-serializer? obj)
-  (and (serializer? obj) (eq? (direction-of self) :out)))
+  (and (serializer? obj) (eq? (direction-of obj) :out)))
 
 ;; Utility method
 


### PR DESCRIPTION
output-serializer?(gauche.serializer) had a typo.

```
$ ./gosh -ftest -ugauche.test -ugauche.serializer -E"test-module 'gauche.serializer" -Eexit
testing bindings in #<module gauche.serializer> ... ERROR: symbols referenced but not defined: self(output-serializer?)
```
