### PR TITLE
Fix incorrect zeroing

### DIFF
--- a/ext/digest/sha2.c
+++ b/ext/digest/sha2.c
@@ -698,7 +698,7 @@ void SHA1_Final(sha_byte digest[], SHA_CTX* context) {
 		 * No digest buffer, so we can do nothing
 		 * except clean up and go home
 		 */
-		MEMSET_BZERO(context, sizeof(context));
+		MEMSET_BZERO(context, sizeof(*context));
 		return;
 	}
 
@@ -754,7 +754,7 @@ void SHA1_Final(sha_byte digest[], SHA_CTX* context) {
 #endif
 
 	/* Clean up: */
-	MEMSET_BZERO(context, sizeof(context));
+	MEMSET_BZERO(context, sizeof(*context));
 }
 
 char *SHA1_End(SHA_CTX* context, char buffer[]) {
@@ -774,7 +774,7 @@ char *SHA1_End(SHA_CTX* context, char buffer[]) {
 		}
 		*buffer = (char)0;
 	} else {
-		MEMSET_BZERO(context, sizeof(context));
+		MEMSET_BZERO(context, sizeof(*context));
 	}
 	MEMSET_BZERO(digest, SHA1_DIGEST_LENGTH);
 	return buffer;
@@ -1093,7 +1093,7 @@ void SHA256_Final(sha_byte digest[], SHA_CTX* context) {
 	}
 
 	/* Clean up state data: */
-	MEMSET_BZERO(context, sizeof(context));
+	MEMSET_BZERO(context, sizeof(*context));
 }
 
 char *SHA256_End(SHA_CTX* context, char buffer[]) {
@@ -1113,7 +1113,7 @@ char *SHA256_End(SHA_CTX* context, char buffer[]) {
 		}
 		*buffer = (char)0;
 	} else {
-		MEMSET_BZERO(context, sizeof(context));
+		MEMSET_BZERO(context, sizeof(*context));
 	}
 	MEMSET_BZERO(digest, SHA256_DIGEST_LENGTH);
 	return buffer;
@@ -1167,7 +1167,7 @@ void SHA224_Final(sha_byte digest[], SHA_CTX* context) {
 	}
 
 	/* Clean up state data: */
-	MEMSET_BZERO(context, sizeof(context));
+	MEMSET_BZERO(context, sizeof(*context));
 }
 
 char *SHA224_End(SHA_CTX* context, char buffer[]) {
@@ -1187,7 +1187,7 @@ char *SHA224_End(SHA_CTX* context, char buffer[]) {
 		}
 		*buffer = (char)0;
 	} else {
-		MEMSET_BZERO(context, sizeof(context));
+		MEMSET_BZERO(context, sizeof(*context));
 	}
 	MEMSET_BZERO(digest, SHA224_DIGEST_LENGTH);
 	return buffer;
@@ -1502,7 +1502,7 @@ void SHA512_Final(sha_byte digest[], SHA_CTX* context) {
 	}
 
 	/* Zero out state data */
-	MEMSET_BZERO(context, sizeof(context));
+	MEMSET_BZERO(context, sizeof(*context));
 }
 
 char *SHA512_End(SHA_CTX* context, char buffer[]) {
@@ -1522,7 +1522,7 @@ char *SHA512_End(SHA_CTX* context, char buffer[]) {
 		}
 		*buffer = (char)0;
 	} else {
-		MEMSET_BZERO(context, sizeof(context));
+		MEMSET_BZERO(context, sizeof(*context));
 	}
 	MEMSET_BZERO(digest, SHA512_DIGEST_LENGTH);
 	return buffer;
@@ -1572,7 +1572,7 @@ void SHA384_Final(sha_byte digest[], SHA_CTX* context) {
 	}
 
 	/* Zero out state data */
-	MEMSET_BZERO(context, sizeof(context));
+	MEMSET_BZERO(context, sizeof(*context));
 }
 
 char *SHA384_End(SHA_CTX* context, char buffer[]) {
@@ -1592,7 +1592,7 @@ char *SHA384_End(SHA_CTX* context, char buffer[]) {
 		}
 		*buffer = (char)0;
 	} else {
-		MEMSET_BZERO(context, sizeof(context));
+		MEMSET_BZERO(context, sizeof(*context));
 	}
 	MEMSET_BZERO(digest, SHA384_DIGEST_LENGTH);
 	return buffer;


### PR DESCRIPTION
clang reports the following warnings:

```
sha2.c:701:32: warning: argument to 'sizeof' in 'memset' call is the same expression as the destination; did you mean to dereference it? [-Wsizeof-pointer-memaccess]
sha2.c:757:31: warning: argument to 'sizeof' in 'memset' call is the same expression as the destination; did you mean to dereference it? [-Wsizeof-pointer-memaccess]
...
```
