### PR TITLE
Add :url-safe keyword parameter to base64-{encode,decode}.

### DIFF
--- a/doc/modutil.texi
+++ b/doc/modutil.texi
@@ -7193,16 +7193,16 @@ SRFI-19の@code{<date>}オブジェクト(@ref{SRFI-19 Date}参照)
 @c EN
 This module defines a few functions to encode/decode Base64 format,
 defined in RFC 2045 (@ref{rfc2045, [RFC2045], RFC2045}), section 6.3
-and RFC3548 (@ref{rfc3548, [RFC3548], RFC3548})
+and RFC 4648 (@ref{rfc4648, [RFC4648], RFC4648})
 @c JP
 このモジュールでは、RFC 2045 (@ref{rfc2045, [RFC2045], RFC2045})の6.3節
-およびRFC 3548 (@ref{rfc3548, [RFC3548], RFC3548})で
+およびRFC 4648 (@ref{rfc4648, [RFC4648], RFC4648})で
 定義されている Base64 フォーマットへエンコード/デコードするいくつかの
 手続きを定義しています。
 @c COMMON
 @end deftp
 
-@defun base64-encode :key line-width
+@defun base64-encode :key line-width url-safe?
 @c EN
 Reads byte stream from the current input port, encodes it in Base64
 format and writes the result character stream to the current output port.
@@ -7222,9 +7222,21 @@ value of @var{line-width} is 76, as specified in RFC2045.  You can give
 RFC2045に従い76となっています。@var{line-width}に@code{#f}または@code{0}
 を与えることで改行を抑制することができます。
 @c COMMON
+@item url-safe?
+@c EN
+If a true value is given, the input bytes will be encoded with an
+alternative encoding table, which substitutes @code{+} instead of
+@code{-} and @code{/} instead of @code{_}. The result will contain
+filename and url safe characters only. Default is false.
+@c JP
+真の値を与えると、標準の Base64 と異なったエンコーディングテーブルを使って
+入力をエンコードします。このエンコーディングでは、@code{+}の代わりに
+@code{-}が、@code{/}の代わりに@code{_}が使われます。このエンコーディングは
+ファイル名やURLの一部として使うのに適しています。
+@c COMMON
 @end defun
 
-@defun base64-encode-string string :key line-width
+@defun base64-encode-string string :key line-width url-safe?
 @c EN
 Converts contents of @var{string} to Base64 encoded format.
 Input string can be either complete or incomplete string;
@@ -7236,7 +7248,7 @@ it is always interpreted as a byte sequence.
 @c COMMON
 @end defun
 
-@defun base64-decode
+@defun base64-decode :key url-safe?
 @c EN
 Reads character stream from the current input port, decodes it from Base64
 format and writes the result byte stream to the current output port.
@@ -7251,7 +7263,7 @@ Base64 でエンコードされた文字として適当でない文字は沈黙�
 @c COMMON
 @end defun
 
-@defun base64-decode-string string
+@defun base64-decode-string string :key url-safe?
 @c EN
 Decodes a Base64 encoded string @var{string} and returns
 the result as a string.

--- a/doc/references.texi
+++ b/doc/references.texi
@@ -86,11 +86,11 @@ US Secure Hash Algorithm 1 (SHA1). @*
 September 2001. @*
 @url{ftp://ftp.isi.edu/in-notes/rfc3174.txt}.
 
-@anchor{rfc3548}
-@item [RFC3548]
+@anchor{rfc4648}
+@item [RFC4648]
 S. Josefsson, Ed.: The Base16, Base32, and Base64 Data Encodings
-July 2003. @*
-@url{ftp://ftp.isi.edu/in-notes/rfc3548.txt}.
+October 2006. @*
+@url{ftp://ftp.isi.edu/in-notes/rfc4648.txt}.
 
 @anchor{srfi-0}
 @item [SRFI-0]

--- a/lib/rfc/base64.scm
+++ b/lib/rfc/base64.scm
@@ -42,7 +42,7 @@
           base64-decode base64-decode-string))
 (select-module rfc.base64)
 
-(define *decode-table*
+(define *standard-decode-table*
   ;;    !   "   #   $   %   &   '   (   )   *   +   ,   -   .   /
   #(#f  #f  #f  #f  #f  #f  #f  #f  #f  #f  #f  62  #f  #f  #f  63
   ;;0   1   2   3   4   5   6   7   8   9   :   ;   <   =   >   ?
@@ -57,7 +57,7 @@
     41  42  43  44  45  46  47  48  49  50  51  #f  #f  #f  #f  #f
   ))
 
-(define *encode-table*
+(define *standard-encode-table*
   ;;0   1   2   3   4   5   6   7   8   9   10  11  12  13  14  15
   #(#\A #\B #\C #\D #\E #\F #\G #\H #\I #\J #\K #\L #\M #\N #\O #\P
   ;;16  17  18  19  20  21  22  23  24  25  26  27  28  29  30  31
@@ -70,12 +70,41 @@
     #\=
   ))
 
-(define (base64-decode)
+(define *url-safe-decode-table*
+  ;;    !   "   #   $   %   &   '   (   )   *   +   ,   -   .   /
+  #(#f  #f  #f  #f  #f  #f  #f  #f  #f  #f  #f  #f  #f  62  #f  #f
+  ;;0   1   2   3   4   5   6   7   8   9   :   ;   <   =   >   ?
+    52  53  54  55  56  57  58  59  60  61  #f  #f  #f  #f  #f  #f
+  ;;@   A   B   C   D   E   F   G   H   I   J   K   L   M   N   O
+    #f  0   1   2   3   4   5   6   7   8   9   10  11  12  13  14
+  ;;P   Q   R   S   T   U   V   W   X   Y   Z   [   \   ]   ^   _
+    15  16  17  18  19  20  21  22  23  24  25  #f  #f  #f  #f  63
+  ;;`   a   b   c   d   e   f   g   h   i   j   k   l   m   n   o
+    #f  26  27  28  29  30  31  32  33  34  35  36  37  38  39  40
+  ;;p   q   r   s   t   u   v   w   x   y   z   {   |   }   ~
+    41  42  43  44  45  46  47  48  49  50  51  #f  #f  #f  #f  #f
+  ))
+
+(define *url-safe-encode-table*
+  ;;0   1   2   3   4   5   6   7   8   9   10  11  12  13  14  15
+  #(#\A #\B #\C #\D #\E #\F #\G #\H #\I #\J #\K #\L #\M #\N #\O #\P
+  ;;16  17  18  19  20  21  22  23  24  25  26  27  28  29  30  31
+    #\Q #\R #\S #\T #\U #\V #\W #\X #\Y #\Z #\a #\b #\c #\d #\e #\f
+  ;;32  33  34  35  36  37  38  39  40  41  42  43  44  45  46  47
+    #\g #\h #\i #\j #\k #\l #\m #\n #\o #\p #\q #\r #\s #\t #\u #\v
+  ;;48  49  50  51  52  53  54  55  56  57  58  59  60  61  62  63
+    #\w #\x #\y #\z #\0 #\1 #\2 #\3 #\4 #\5 #\6 #\7 #\8 #\9 #\- #\_
+  ;;pad
+    #\=
+  ))
+
+(define (base64-decode :key (url-safe #f))
+  (define table (if url-safe *url-safe-decode-table* *standard-decode-table*))
   (let-syntax ([lookup (syntax-rules ()
                          [(_ c)
                           (let1 i (char->integer c)
                             (and (< 32 i 128)
-                                 (vector-ref *decode-table* (- i 32))))])]
+                                 (vector-ref table (- i 32))))])]
                )
     (define (d0 c)
       (cond [(eof-object? c)]
@@ -109,13 +138,12 @@
 
     (d0 (read-char))))
 
-(define (base64-decode-string string)
+(define (base64-decode-string string . opts)
   (with-output-to-string
-    (cut with-input-from-string string base64-decode)))
+    (cut with-input-from-string string (cut apply base64-decode opts))))
 
-
-(define (base64-encode :key (line-width 76))
-
+(define (base64-encode :key (line-width 76) (url-safe #f))
+  (define table (if url-safe *url-safe-encode-table* *standard-encode-table*))
   (define maxcol (and line-width (> line-width 0) (- line-width 1)))
 
   (letrec-syntax ([emit*
@@ -123,7 +151,7 @@
                      [(_ col) col]
                      [(_ col idx idx2 ...)
                       (begin
-                        (write-char (vector-ref *encode-table* idx))
+                        (write-char (vector-ref table idx))
                         (let1 col2 (cond [(eqv? col maxcol) (newline) 0]
                                          [else (+ col 1)])
                           (emit* col2 idx2 ...)))])])
@@ -151,5 +179,3 @@
 
 (define (base64-encode-string string . opts)
   (with-string-io string (cut apply base64-encode opts)))
-
-

--- a/test/rfc.scm
+++ b/test/rfc.scm
@@ -276,6 +276,11 @@ Content-Length: 4349
 (test* "decode" "BAR0er9" (base64-decode-string "QkFSMGVyOQ=="))
 (test* "decode" "BAR0er9" (base64-decode-string "QkFS\r\nMGVyOQ\r\n=="))
 
+(test* "standard encode" "YTA+YTA/" (base64-encode-string "a0>a0?"))
+(test* "standard decode" "a0>a0?" (base64-decode-string "YTA+YTA/"))
+(test* "url-safe encode" "YTA-YTA_" (base64-encode-string "a0>a0?" :url-safe #t))
+(test* "url-safe decode" "a0>a0?" (base64-decode-string "YTA-YTA_" :url-safe #t))
+
 ;;--------------------------------------------------------------------
 (test-section "rfc.quoted-printable")
 (use rfc.quoted-printable)


### PR DESCRIPTION
There are two things that I'd like you get your input for this patch.
- Function naming
  Python provides this feature as a different function (urlsafe_b64encode) than the standard one (b64encode). I've convinced myself that the keyword parameter is more Gauche-like but I'm not 100% sure.
- Keyword naming
  This encoding is referred to as "Base 64 Encoding with URL and Filename Safe Alphabet". Colloquially it's called "websafe" or "urlsafe" base64, I believe. I chose "url-safe" as it's clearer than "web-safe".
