### PR TITLE
Fix bug that topological-sort did not detect cycle

### DIFF
--- a/lib/util/toposort.scm
+++ b/lib/util/toposort.scm
@@ -53,7 +53,9 @@
   (set! queue (append-map (lambda (p) (if (= (cdr p) 0) (list (car p)) '()))
                           table))
   (set! result queue)
-  (when (null? queue) (error "graph has circular dependency" nodes))
   (traverse)
+  (let1 rest (filter (lambda (e) (not (zero? (cdr e)))) table)
+    (unless (null? rest)
+      (error "graph has circular dependency" (map car rest))))
   (reverse result))
 

--- a/test/util.scm
+++ b/test/util.scm
@@ -887,6 +887,15 @@
          (topological-sort (map (cut map symbol->string <>) input) string=?))
   )
 
+;; cycle
+(test* "topological-sort: error" (test-error)
+       (topological-sort '((watch tie)
+                           (tie watch))))
+(test* "topological-sort: error" (test-error)
+       (topological-sort '((shirt watch)
+                           (watch tie)
+                           (tie watch))))
+
 ;;-----------------------------------------------
 (test-section "util.trie")
 (use util.trie)


### PR DESCRIPTION
The previous implementation of cycle detection does not always work because
there's at least one node with no incoming edge does not mean that there's
no cycle in the graph.
