### PR TITLE
fix cygwin64 gc

### DIFF
--- a/gc/include/gc.h
+++ b/gc/include/gc.h
@@ -1385,14 +1385,22 @@ GC_API int GC_CALL GC_get_force_unmap_on_gcollect(void);
 /* THREAD_LOCAL_ALLOC defined and the initial allocation call is not    */
 /* to GC_malloc() or GC_malloc_atomic().                                */
 
-#ifdef __CYGWIN32__
+#if defined(__CYGWIN32__) || defined(__CYGWIN__)
   /* Similarly gnu-win32 DLLs need explicit initialization from the     */
   /* main program, as does AIX.                                         */
+# ifdef __x86_64__
+  extern int __data_start__[], __data_end__[], __bss_start__[], __bss_end__[];
+#  define GC_DATASTART (__data_start__ < __bss_start__ ? \
+			 (void *)__data_start__ : (void *)__bss_start__)
+#  define GC_DATAEND (__data_end__ > __bss_end__ ? \
+		       (void *)__data_end__ : (void *)__bss_end__)
+# else
   extern int _data_start__[], _data_end__[], _bss_start__[], _bss_end__[];
-# define GC_DATASTART (_data_start__ < _bss_start__ ? \
-                       (void *)_data_start__ : (void *)_bss_start__)
-# define GC_DATAEND (_data_end__ > _bss_end__ ? \
-                     (void *)_data_end__ : (void *)_bss_end__)
+#  define GC_DATASTART (_data_start__ < _bss_start__ ? \
+			 (void *)_data_start__ : (void *)_bss_start__)
+#  define GC_DATAEND (_data_end__ > _bss_end__ ? \
+		       (void *)_data_end__ : (void *)_bss_end__)
+# endif
 # define GC_INIT_CONF_ROOTS GC_add_roots(GC_DATASTART, GC_DATAEND); \
                                  GC_gcollect() /* For blacklisting. */
         /* Required at least if GC is in a DLL.  And doesn't hurt. */

--- a/gc/include/private/gcconfig.h
+++ b/gc/include/private/gcconfig.h
@@ -433,7 +433,11 @@
 #   define mach_type_known
 # endif
 # if defined(__CYGWIN32__) || defined(__CYGWIN__)
-#   define I386
+#   if defined(__LP64__)
+#     define X86_64
+#   else
+#     define I386
+#   endif
 #   define CYGWIN32
 #   define mach_type_known
 # endif

--- a/gc/os_dep.c
+++ b/gc/os_dep.c
@@ -772,7 +772,12 @@ GC_INNER word GC_page_size = 0;
     /* gcc version of boehm-gc).                                        */
     GC_API int GC_CALL GC_get_stack_base(struct GC_stack_base *sb)
     {
-      extern void * _tlsbase __asm__ ("%fs:4");
+#  ifdef __x86_64__
+      PNT_TIB pTib = NtCurrentTeb();
+      void * _tlsbase = pTib->StackBase;
+#  else
+      extern void * _tlsbase __asm__ "%fs:4";
+#  endif
       sb -> mem_base = _tlsbase;
       return GC_SUCCESS;
     }

--- a/src/gauche/extend.h
+++ b/src/gauche/extend.h
@@ -43,13 +43,23 @@ extern "C" {
 #endif
 
 #if defined(__CYGWIN__)
-#define SCM_INIT_EXTENSION(name)                \
-    do {                                        \
-        Scm_RegisterDL((void*)&_data_start__,   \
-                       (void*)&_data_end__,     \
-                       (void*)&_bss_start__,    \
-                       (void*)&_bss_end__);     \
-    } while (0)
+# ifdef __x86_64__
+#  define SCM_INIT_EXTENSION(name)                 \
+      do {                                         \
+          Scm_RegisterDL((void*)&__data_start__,   \
+                         (void*)&__data_end__,     \
+                         (void*)&__bss_start__,    \
+                         (void*)&__bss_end__);     \
+      } while (0)
+# else
+#  define SCM_INIT_EXTENSION(name)                \
+      do {                                        \
+          Scm_RegisterDL((void*)&_data_start__,   \
+                         (void*)&_data_end__,     \
+                         (void*)&_bss_start__,    \
+                         (void*)&_bss_end__);     \
+      } while (0)
+# endif
 #else /* !__CYGWIN__ */
 #define SCM_INIT_EXTENSION(name) /* nothing */
 #endif /* !__CYGWIN__ */


### PR DESCRIPTION
http://cygwin.com/ml/cygwin-apps/2013-04/msg00281.html

`make check` freezed on some test although.

```
test sigalrm4 (interrupting syscall), expects 14 ==> ERROR: GOT #<<unhandled-signal-error> "unhandled signal 2 (SIGINT)">
test sigalrm5 (interrupting syscall - restart), expects (a) ==> ERROR: GOT #<<unhandled-signal-error> "unhandled signal 2 (SIGINT)">
```
