### PR TITLE
Giving gcd/lcm an unexpected argument shows a strange message about error

### DIFF
--- a/src/libnum.scm
+++ b/src/libnum.scm
@@ -274,6 +274,7 @@
 (define-cproc modulo (n1 n2)    :fast-flonum :constant
   (result (Scm_Modulo n1 n2 FALSE)))
 
+(select-module gauche)
 ;; gcd, lcm: these are the simplest ones.  If you need efficiency, consult
 ;; Knuth: "The Art of Computer Programming" Chap. 4.5.2
 (define-in-module scheme (gcd . args)


### PR DESCRIPTION
With Gauche 0.9.4:

```
gosh> (gcd '())
*** ERROR: unbound variable: error
Stack Trace:
_______________________________________
  0  (eval expr env)
        At line 179 of "/home/tabe/opt/share/gauche-0.9/0.9.4/lib/gauche/interactive.scm"
gosh> (lcm '())
*** ERROR: unbound variable: error
Stack Trace:
_______________________________________
  0  (eval expr env)
        At line 179 of "/home/tabe/opt/share/gauche-0.9/0.9.4/lib/gauche/interactive.scm"
gosh> 
```
