### PR TITLE
Stop Scm_VMUVectorRef from returning #<unbound>

### DIFF
--- a/src/libvec.scm
+++ b/src/libvec.scm
@@ -118,19 +118,12 @@
 ;; this one internally).
 (select-module gauche.internal)
 
-(define-cproc %uvector-ref (v::<uvector> t::<int> k::<integer>
+(define-cproc %uvector-ref (v::<uvector> t::<int> k::<fixnum>
                                          :optional fallback)
   :constant
   (unless (== (Scm_UVectorType (SCM_CLASS_OF v)) t)
     (Scm_TypeError "vec" (Scm_UVectorTypeName t) (SCM_OBJ v)))
-  (cond [(or (SCM_BIGNUMP k)
-             (< (SCM_INT_VALUE k) 0)
-             (>= (SCM_INT_VALUE k) (SCM_UVECTOR_SIZE v)))
-         (when (SCM_UNBOUNDP fallback)
-           (Scm_Error "%s-ref index out of range: %S"
-                      (Scm_UVectorTypeName t) k))
-         (result fallback)]
-        [else (result (Scm_VMUVectorRef v t (SCM_INT_VALUE k) fallback))]))
+  (result (Scm_VMUVectorRef v t (SCM_INT_VALUE k) fallback)))
 
 (select-module gauche)
 (inline-stub

--- a/src/vector.c
+++ b/src/vector.c
@@ -373,7 +373,13 @@ ScmObj Scm_ListToUVector(ScmClass *klass, ScmObj list, int clamp)
 ScmObj Scm_VMUVectorRef(ScmUVector *v, int t, ScmSmallInt k, ScmObj fallback)
 {
     SCM_ASSERT(Scm_UVectorType(SCM_CLASS_OF(v)) == t);
-    if (k < 0 || k >= SCM_UVECTOR_SIZE(v)) return fallback;
+    if (k < 0 || k >= SCM_UVECTOR_SIZE(v)) {
+        if (SCM_UNBOUNDP(fallback)) {
+            Scm_Error("%s-ref index out of range: %ld",
+                      Scm_UVectorTypeName(t), k);
+        }
+        return fallback;
+    }
     switch (t) {
     case SCM_UVECTOR_S8:  return SCM_MAKE_INT(SCM_S8VECTOR_ELEMENT(v, k));
     case SCM_UVECTOR_U8:  return SCM_MAKE_INT(SCM_U8VECTOR_ELEMENT(v, k));


### PR DESCRIPTION
## Before
```scm
gosh> (use gauche.uvector)
#<undef>
gosh> (~ (make-u8vector 0) 0)
#<unbound>
gosh> (+ 1 1)
*** ERROR: unbound variable: *1
Stack Trace:
_______________________________________
  0  *1

  1  (%set-history-expr! r)
        At line 233 of "/usr/local/share/gauche-0.9/0.9.5_pre1/lib/gauche/interactive.scm"
gosh> 0
*** ERROR: unbound variable: *1
Stack Trace:
_______________________________________
  0  *1

  1  (%set-history-expr! r)
        At line 233 of "/usr/local/share/gauche-0.9/0.9.5_pre1/lib/gauche/interactive.scm"
```

## After
```scm
gosh> (use gauche.uvector)
#<undef>
gosh> (~ (make-u8vector 0) 0)
*** ERROR: u8vector-ref index out of range: 0
Stack Trace:
_______________________________________
  0  (eval expr env)
        At line 232 of "/usr/local/share/gauche-0.9/0.9.5_pre1/lib/gauche/interactive.scm"
gosh> (+ 1 1)
2
gosh> 0
0
```