### PR TITLE
One or more expressions besides the test should be given with when/unless

### DIFF
--- a/doc/coresyn.texi
+++ b/doc/coresyn.texi
@@ -1820,17 +1820,17 @@ last expression is returned. If there are no expressions then
 @end example
 @end defspec
 
-@defspec when test body @dots{}
-@defspecx unless test body @dots{}
+@defspec when test expr1 expr2 @dots{}
+@defspecx unless test expr1 expr2 @dots{}
 [R7RS]
 @c EN
 Evaluates @var{test}.  If it yields true value (or false in case of
-@code{unless}), @var{body} @dots{} are evaluated sequentially, and
-the result(s) of the last evaluation is(are) returned.  Otherwise, undefined
-value is returned.
+@code{unless}), @var{expr1} and @var{expr2} @dots{} are evaluated
+sequentially, and the result(s) of the last evaluation is(are) returned.
+Otherwise, undefined value is returned.
 @c JP
 まず@var{test}が評価されます。それが真の値(@code{unless}の場合は偽の値)を返した場合、
-引続き@var{body}が順に評価され、最後の@var{body}の評価値が返されます。
+引続き@var{expr1}および@var{expr2} @dots{}が順に評価され、最後の評価値が返されます。
 そうでなければ、未定義の値が返されます。
 @c COMMON
 @end defspec

--- a/src/compile.scm
+++ b/src/compile.scm
@@ -2187,20 +2187,20 @@
 
 (define-pass1-syntax (when form cenv) :gauche
   (match form
-    [(_ test body ...)
+    [(_ test expr1 expr2 ...)
      (let1 cenv (cenv-sans-name cenv)
        ($if form (pass1 test cenv)
-            ($seq (imap (cut pass1 <> cenv) body))
+            ($seq (imap (cut pass1 <> cenv) (cons expr1 expr2)))
             ($const-undef)))]
     [_ (error "syntax-error: malformed when:" form)]))
 
 (define-pass1-syntax (unless form cenv) :gauche
   (match form
-    [(_ test body ...)
+    [(_ test expr1 expr2 ...)
      (let1 cenv (cenv-sans-name cenv)
        ($if form (pass1 test cenv)
             ($const-undef)
-            ($seq (imap (cut pass1 <> cenv) body))))]
+            ($seq (imap (cut pass1 <> cenv) (cons expr1 expr2)))))]
     [_ (error "syntax-error: malformed unless:" form)]))
 
 (define-pass1-syntax (else form cenv) :null


### PR DESCRIPTION
as R7RS specifies.

The following input should be an error:
> $ gosh -V
> Gauche scheme shell, version 0.9.4 [utf-8,pthreads], x86_64-unknown-linux-gnu
> $ gosh
> gosh> (when #t)
> 0
> gosh> (when #f)
> #\<undef>
> gosh> (unless #t)
> #\<undef>
> gosh> (unless #f)
> 0
> gosh> 