### PR TITLE
Refine if-let1

### DIFF
--- a/lib/gauche/common-macros.scm
+++ b/lib/gauche/common-macros.scm
@@ -177,6 +177,8 @@
 
 (define-syntax if-let1                  ;like aif in On Lisp, but explicit var
   (syntax-rules ()
+    [(if-let1 var exp then)
+     (let ((var exp)) (if var then #f))]
     [(if-let1 var exp then . else)
      (let ((var exp)) (if var then . else))]))
 


### PR DESCRIPTION
It seems better than returning #\<undef\> . I suppose ```(if-let1 x (f) (g x))``` is more readable than ```(and-let* ([x (f)]) (g x))``` .

## Before
```scm
gosh> (if-let1 x #f 0)
#<undef>
```

## After
```scm
gosh> (if-let1 x #f 0)
#f
```