### PR TITLE
Change "gosh -pload" to show load time excluding subloading

### DIFF
--- a/lib/gauche/vm/profiler.scm
+++ b/lib/gauche/vm/profiler.scm
@@ -93,18 +93,18 @@
         (match stats
           [()  (show-results)]
           [((f . t) . more)
-           (receive (_ rest) (cumulate f t more) (start rest))]
+           (receive (_ rest) (cumulate f t 0 more) (start rest))]
           [(_ . more) (start more)] ;; this can't happen, but tolerate
           ))
-      ;; cumulate :: String, Integer, [Stat] -> Integer, [Stat]
-      (define (cumulate filename start-time stats)
+      ;; cumulate :: String, Integer, Integer, [Stat] -> Integer, [Stat]
+      (define (cumulate filename start-time exclude stats)
         (match stats
           [() (show-results)]  ;; premature stats data; we discard current fn.
           [((f . t) . more)
-           (receive (time-spent rest) (cumulate f t more)
-             (cumulate filename (+ start-time time-spent) rest))]
+           (receive (time-spent rest) (cumulate f t 0 more)
+             (cumulate filename start-time (+ exclude time-spent) rest))]
           [(t . more)
-           (set! results (cons (cons filename (- t start-time)) results))
+           (set! results (cons (cons filename (- t start-time exclude)) results))
            (values (- t start-time) more)]))
       (define (show-results)
         (print "Load statistics:")


### PR DESCRIPTION
I think it makes more sense printing it out this way, i.e. each line shows load time of that module only, not including dependencies's load time. With this I got

      472621 /home/pi/opt/gauche/share/gauche-0.9/0.9.5_pre1/lib/gauche/generator.scm
      383990 /home/pi/opt/gauche/share/gauche-0.9/0.9.5_pre1/lib/rfc/mime.scm
      348499 /home/pi/opt/gauche/share/gauche-0.9/0.9.5_pre1/lib/rfc/822.scm
      282945 /home/pi/w/Gauche-makiki//makiki.sci
    ...
        4090 /home/pi/w/Gauche-makiki/hello.scm
        2139 /home/pi/opt/gauche/share/gauche-0.9/0.9.5_pre1/lib/srfi-31.scm
         801 /home/pi/opt/gauche/share/gauche-0.9/0.9.5_pre1/lib/util/queue.scm

and the sum of all is close to "time" of the "gosh hello.scm".