### PR TITLE
cise.scm: support :static-inline in define-cfn

### DIFF
--- a/lib/gauche/cgen/cise.scm
+++ b/lib/gauche/cgen/cise.scm
@@ -459,6 +459,8 @@
     (match body
       [(':static . body) (record-static name args ret-type)
                          (gen-cfn "static" name args ret-type body)]
+      [(':static-inline . body) (record-static name args ret-type)
+                                (gen-cfn "static inline" name args ret-type body)]
       [_                 (gen-cfn "" name args ret-type body)]))
 
   (ensure-toplevel-ctx form env)


### PR DESCRIPTION
This generates C functions with both static and inline attributes,
useful for small functions that may be called many times.

I think this is a useful thing to do but it's not that important. People can workaround it by specifying "inline" as part of the return value already.The patch is more about discussing "should we support something like this" than an actual pull request.