### PR TITLE
Code cleanup after -Wall

### DIFF
--- a/ext/net/netlib.scm
+++ b/ext/net/netlib.scm
@@ -87,7 +87,6 @@
      (let* ([a::ScmSockAddrIn6* (cast ScmSockAddrIn6* addr)]
             [p::ScmUInt32*
              (cast ScmUInt32* (ref (-> a addr) sin6_addr s6_addr))]
-            [i::int]
             [n (Scm_MakeIntegerFromUI (ntohl (* (post++ p))))])
        (dotimes [i 3]
          (set! n (Scm_LogIor (Scm_Ash n 32)

--- a/ext/tls/tls.c
+++ b/ext/tls/tls.c
@@ -40,7 +40,6 @@ SCM_DEFINE_BUILTIN_CLASS_SIMPLE(Scm_TLSClass, tls_print);
 
 static void tls_print(ScmObj obj, ScmPort* port, ScmWriteContext* ctx)
 {
-    ScmTLS* t = SCM_TLS(obj);
     Scm_Printf(port, "#<TLS");
     /* at the moment there's not much to print, so we leave this hole
        for future development. */

--- a/ext/uvector/uvector.scm
+++ b/ext/uvector/uvector.scm
@@ -114,10 +114,10 @@
                                   (SCM_OBJ ,type))])
        (,c-fn ,v opt))])
 
- (define-cproc uvector-swap-bytes (v::<uvector> :optional (type::<symbol>? #f))
+ (define-cproc uvector-swap-bytes (v::<uvector> :optional (type::<symbol>? #f)) ::<void>
    (swap-bytes-common Scm_UVectorSwapBytes v type))
 
- (define-cproc uvector-swap-bytes! (v::<uvector> :optional (type::<symbol>? #f))
+ (define-cproc uvector-swap-bytes! (v::<uvector> :optional (type::<symbol>? #f)) ::<void>
    (swap-bytes-common Scm_UVectorSwapBytesX v type))
  )
 

--- a/src/load.c
+++ b/src/load.c
@@ -90,7 +90,6 @@ static struct {
 static ScmObj key_error_if_not_found = SCM_UNBOUND;
 static ScmObj key_macro              = SCM_UNBOUND;
 static ScmObj key_ignore_coding      = SCM_UNBOUND;
-static ScmObj key_main_script        = SCM_UNBOUND;
 static ScmObj key_paths              = SCM_UNBOUND;
 static ScmObj key_environment        = SCM_UNBOUND;
 
@@ -1199,7 +1198,6 @@ ScmObj Scm_LoadMainScript()
 void Scm__InitLoad(void)
 {
     ScmModule *m = Scm_GaucheModule();
-    ScmVM *vm = Scm_VM();
     ScmObj t;
 
     ScmObj init_load_path = t = SCM_NIL;

--- a/src/write.c
+++ b/src/write.c
@@ -576,7 +576,6 @@ static void write_rec(ScmObj obj, ScmPort *port, ScmWriteContext *ctx)
             } else {
                 /* we're processing a list */
                 ScmObj v = SCM_CDR(top);
-                ScmObj e;
                 if (SCM_NULLP(v)) { /* we've done with this list */
                     Scm_PutcUnsafe(')', port);
                     POP();


### PR DESCRIPTION
The actual flags are -Wall -Wno-unused-label -Wno-unused-but-set-variable
-Wno-unused-variable. It's still not warning clean after this patch:

 - Most of warnings in -Wmaybe-uninitialized are probably because
   Scm_Error() is not marked "no return".

 - The ones in -Wunused-function, Wunused-result and -Wunused-value in
   cise-generated code can probably be safely ignored.

 - -Wstrict-aliasing in addr.c was not investigated

PS. Out of curiosity I ran a small script under valgrind (on linux x86-64) and it reported a few "Conditional jump or move depends on uninitialised value" and "Use of uninitialised value of size" in gc code. I'm not familiar with that code to judge if they are false positives. You may want to look into it..