### PR TITLE
Change for MinGW (32bit)

### DIFF
--- a/ext/threads/mutex.c
+++ b/ext/threads/mutex.c
@@ -170,12 +170,12 @@ ScmObj Scm_MakeMutex(ScmObj name)
 ScmObj Scm_MutexLock(ScmMutex *mutex, ScmObj timeout, ScmVM *owner)
 {
 #ifdef GAUCHE_HAS_THREADS
-    struct timespec ts;
+    ScmTimeSpec ts;
     ScmObj r = SCM_TRUE;
     ScmVM *abandoned = NULL;
     int intr = FALSE;
 
-    struct timespec *pts = Scm_GetTimeSpec(timeout, &ts);
+    ScmTimeSpec *pts = Scm_GetTimeSpec(timeout, &ts);
     SCM_INTERNAL_MUTEX_SAFE_LOCK_BEGIN(mutex->mutex);
     while (mutex->locked) {
         if (mutex->owner && mutex->owner->state == SCM_VM_TERMINATED) {
@@ -212,10 +212,10 @@ ScmObj Scm_MutexUnlock(ScmMutex *mutex, ScmConditionVariable *cv, ScmObj timeout
 {
     ScmObj r = SCM_TRUE;
 #ifdef GAUCHE_HAS_THREADS
-    struct timespec ts;
+    ScmTimeSpec ts;
     int intr = FALSE;
 
-    struct timespec *pts = Scm_GetTimeSpec(timeout, &ts);
+    ScmTimeSpec *pts = Scm_GetTimeSpec(timeout, &ts);
     SCM_INTERNAL_MUTEX_SAFE_LOCK_BEGIN(mutex->mutex);
     mutex->locked = FALSE;
     mutex->owner = NULL;

--- a/ext/threads/threads.c
+++ b/ext/threads/threads.c
@@ -203,11 +203,11 @@ ScmObj Scm_ThreadStart(ScmVM *vm)
 ScmObj Scm_ThreadJoin(ScmVM *target, ScmObj timeout, ScmObj timeoutval)
 {
 #ifdef GAUCHE_HAS_THREADS
-    struct timespec ts;
+    ScmTimeSpec ts;
     ScmObj result = SCM_FALSE, resultx = SCM_FALSE;
     int intr = FALSE, tout = FALSE;
 
-    struct timespec *pts = Scm_GetTimeSpec(timeout, &ts);
+    ScmTimeSpec *pts = Scm_GetTimeSpec(timeout, &ts);
     SCM_INTERNAL_MUTEX_SAFE_LOCK_BEGIN(target->vmlock);
     while (target->state != SCM_VM_TERMINATED) {
         if (pts) {
@@ -268,12 +268,12 @@ ScmObj Scm_ThreadJoin(ScmVM *target, ScmObj timeout, ScmObj timeoutval)
 ScmObj Scm_ThreadStop(ScmVM *target, ScmObj timeout, ScmObj timeoutval)
 {
 #ifdef GAUCHE_HAS_THREADS
-    struct timespec ts;
+    ScmTimeSpec ts;
     ScmVM *vm = Scm_VM();
     ScmVM *taker = NULL;
     int timedout;
     int invalid_state = FALSE;
-    struct timespec *pts = Scm_GetTimeSpec(timeout, &ts);
+    ScmTimeSpec *pts = Scm_GetTimeSpec(timeout, &ts);
 
  retry:
     timedout = FALSE;
@@ -360,14 +360,14 @@ ScmObj Scm_ThreadCont(ScmVM *target)
 ScmObj Scm_ThreadSleep(ScmObj timeout)
 {
 #ifdef GAUCHE_HAS_THREADS
-    struct timespec ts;
+    ScmTimeSpec ts;
     ScmInternalCond dummyc;
     ScmInternalMutex dummym;
     int intr = FALSE;
 
     SCM_INTERNAL_COND_INIT(dummyc);
     SCM_INTERNAL_MUTEX_INIT(dummym);
-    struct timespec *pts = Scm_GetTimeSpec(timeout, &ts);
+    ScmTimeSpec *pts = Scm_GetTimeSpec(timeout, &ts);
     if (pts == NULL) Scm_Error("thread-sleep! can't take #f as a timeout value");
     SCM_INTERNAL_MUTEX_LOCK(dummym);
     if (SCM_INTERNAL_COND_TIMEDWAIT(dummyc, dummym, pts) == SCM_INTERNAL_COND_INTR) {
@@ -398,7 +398,7 @@ ScmObj Scm_ThreadSleep(ScmObj timeout)
    gracefully. */
 static int wait_for_termination(ScmVM *target)
 {
-    struct timespec ts;
+    ScmTimeSpec ts;
     int r;
     ScmObj t = Scm_MakeFlonum(0.001); /* 1ms. somewhat arbitrary */
     Scm_GetTimeSpec(t, &ts);

--- a/src/gauche.h
+++ b/src/gauche.h
@@ -130,6 +130,20 @@ SCM_DECL_BEGIN
    unified keyword-symbol system */
 #define GAUCHE_KEEP_DISJOINT_KEYWORD_OPTION 1
 
+
+/* (moved from system.h) */
+/* struct timespec compatibility handling.  Mingw 3.21, at least, has
+   incompatible struct timespec. */
+#if defined(HAVE_STRUCT_TIMESPEC) || !defined(GAUCHE_WINDOWS)
+typedef struct timespec ScmTimeSpec;
+#else
+typedef struct {
+    time_t tv_sec;
+    long   tv_nsec;
+} ScmTimeSpec;
+#endif /*!HAVE_STRUCT_TIMESPEC && GAUCHE_WINDOWS*/
+
+
 /* Include appropriate threading interface.  Threading primitives are
    abstracted with SCM_INTERNAL_* macros and ScmInternal* typedefs.
    See gauche/uthread.h for the semantics of these primitives. */

--- a/src/gauche/system.h
+++ b/src/gauche/system.h
@@ -147,6 +147,8 @@ SCM_EXTERN ScmObj Scm_Int64SecondsToTime(ScmInt64 sec);
 SCM_EXTERN ScmObj Scm_RealSecondsToTime(double sec);
 SCM_EXTERN ScmObj Scm_TimeToSeconds(ScmTime *t);
 
+
+#if 0 /* (moved to gauche.h) */
 /* struct timespec compatibility handling.  Mingw 3.21, at least, has
    incompatible struct timespec. */
 #if defined(HAVE_STRUCT_TIMESPEC) || !defined(GAUCHE_WINDOWS)
@@ -157,6 +159,8 @@ typedef struct {
     long   tv_nsec;
 } ScmTimeSpec;
 #endif /*!HAVE_STRUCT_TIMESPEC && GAUCHE_WINDOWS*/
+#endif
+
 
 SCM_EXTERN ScmTimeSpec *Scm_GetTimeSpec(ScmObj t, ScmTimeSpec *spec);
 

--- a/src/gauche/wthread.h
+++ b/src/gauche/wthread.h
@@ -148,7 +148,7 @@ typedef HANDLE ScmInternalFastlock;
 #define SCM_INTERNAL_SYNC()                     \
     do {                                        \
         long dummy = 0;                         \
-        InterLockExchange(&dummy, 1);           \
+        InterlockedExchange(&dummy, 1);         \
     } while (0)
 #endif
 


### PR DESCRIPTION
Change for MinGW (32bit)

1. InterLockExchange → InterlockedExchange
     src/gauche/wthread.h

2. struct timespec → ScmTimeSpec
     ext/data/queue.scm
     ext/threads/mutex.c
     ext/threads/threads.c

3. ScmTimeSpec definition was moved.
     src/gauche/system.h → src/gauche.h

make check result is
Total: 15428 tests, 15428 passed,     0 failed,     0 aborted.
