### PR TITLE
cartesian-product-right was not fully right-fixed for lists longer than 2

### DIFF
--- a/lib/util/combinations.scm
+++ b/lib/util/combinations.scm
@@ -281,7 +281,7 @@
   (if (null? lol)
       (list '())
       (let ((l (car lol))
-            (rest (cartesian-product (cdr lol))))
+            (rest (cartesian-product-right (cdr lol))))
         (append-map!
          (lambda (sub-prod)
            (map (^x (cons x sub-prod)) l))

--- a/test/util.scm
+++ b/test/util.scm
@@ -308,6 +308,9 @@
        (cartesian-product '((a b) (0 1) (0 1))))
 (test* "cartesian-product-right" '((a 0) (b 0) (c 0) (a 1) (b 1) (c 1))
        (cartesian-product-right '((a b c) (0 1))))
+(test* "cartesian-product-right" '((a 0 0) (b 0 0) (a 1 0) (b 1 0)
+                                   (a 0 1) (b 0 1) (a 1 1) (b 1 1))
+       (cartesian-product-right '((a b) (0 1) (0 1))))
 
 ;;-----------------------------------------------
 (test-section "util.dominator")


### PR DESCRIPTION
```
gosh> (use util.combinations)
#<undef>
gosh> (cartesian-product-right '((a b) (0 1) (0 1)))
((a 0 0) (b 0 0) (a 0 1) (b 0 1) (a 1 0) (b 1 0) (a 1 1) (b 1 1))
```

I think the result should be `(a 0 0) (b 0 0) `**`(a 1 0) (b 1 0)`** ....