### PR TITLE
Fix: gosh build on old MinGW (32bit) can't start

### DIFF
--- a/src/gauche/win-compat.h
+++ b/src/gauche/win-compat.h
@@ -18,6 +18,10 @@
 #define WINVER 0x0500           /* we support Windows 2000 or later */
 #endif /*WINVER*/
 
+#if defined(UNICODE) && !defined(_UNICODE)
+#define _UNICODE                /* Windows needs both UNICODE and _UNICODE */
+#endif /* UNICODE && !_UNICODE */
+
 #include <winsock2.h>           /* MinGW needs this before windows.h */
 #include <windows.h>
 #include <shlwapi.h>
@@ -34,10 +38,6 @@ typedef unsigned int u_int;
 typedef unsigned long u_long;
 #define _BSDTYPES_DEFINED
 #endif /* _BSDTYPES_DEFINED */
-
-#ifndef _T
-#define _T(x) TEXT(x)   /* unicode macro */
-#endif /* _T */
 
 
 /*======================================================================


### PR DESCRIPTION
In pull request #52, I added '#include \<tchar.h\>' in win-compat.h.
As a result, _T macro became a non-Unicode version.
This caused a followind error when gosh.exe was started.
```
*** Unhandled error occurred during reporting an error.  Process aborted.
```
This error didn't occur if gosh was build on latest MinGW (Runtime v3.21, 2014-12-29 released).

I fixed this problem and checked on old and new MinGW.
- old MinGW : 32bit, GCC v4.8.1, Runtime v4.0.3-1
- new MinGW : 32bit, GCC v4.8.1, Runtime v3.21

make check result is
Total: 15468 tests, 15468 passed,     0 failed,     0 aborted.
