### PR TITLE
Gauche 0.9.4 aborts with "(number->string 1 0)"

### DIFF
--- a/src/number.c
+++ b/src/number.c
@@ -3624,6 +3624,8 @@ void Scm_NumberFormatInit(ScmNumberFormat* fmt)
 /* API */
 ScmObj Scm_NumberToString(ScmObj obj, int radix, u_long flags)
 {
+    if (radix < 2 || radix > SCM_RADIX_MAX)
+        Scm_Error("radix out of range: %d", radix);
     ScmPort *p = SCM_PORT(Scm_MakeOutputStringPort(TRUE));
     ScmNumberFormat fmt;
     Scm_NumberFormatInit(&fmt);


### PR DESCRIPTION
It causes a division by zero.
> $ gosh -V
> Gauche scheme shell, version 0.9.4 [utf-8,pthreads], x86_64-unknown-linux-gnu
> $ gosh
> gosh> (number->string 1 0)
> Received too many signals before processing them.  Exitting for the emergency...
> $ 
