### PR TITLE
Clarify the description of time-tai.

### DIFF
--- a/doc/modsrfi.texi
+++ b/doc/modsrfi.texi
@@ -2258,7 +2258,7 @@ UTC timeです。Gaucheの組み込みの@code{current-time}は常にこのタ�
 International Atomic Time.  This time is a bit larger than UTC, due to
 the leap seconds.
 @c JP
-International Atomic Time。この時間は閏秒を計算に入れており、
+International Atomic Time。この時間は閏秒による調整を受けないため、
 UTCより若干大きな値を取ります。
 @c COMMON
 @end defvr


### PR DESCRIPTION
The phrase "閏秒を計算に入れており" (take leap seconds into account) is ambiguous. Does TAI contain leap seconds, or not? (The answer is, of course, it doesn't.)

I'd suggest changing the phrase to "閏秒による調整を受けない" (is unadjusted by leap seconds) to clarify that TAI has no leap seconds.