### PR TITLE
Consistently drop final newline from format string of Scm_Error etc.

### DIFF
--- a/ext/threads/threads.c
+++ b/ext/threads/threads.c
@@ -236,7 +236,7 @@ ScmObj Scm_ThreadJoin(ScmVM *target, ScmObj timeout, ScmObj timeoutval)
     }
     return result;
 #else  /*!GAUCHE_HAS_THREADS*/
-    Scm_Error("not implemented!\n");
+    Scm_Error("not implemented!");
     return SCM_UNDEFINED;
 #endif /*!GAUCHE_HAS_THREADS*/
 }
@@ -320,7 +320,7 @@ ScmObj Scm_ThreadStop(ScmVM *target, ScmObj timeout, ScmObj timeoutval)
     if (timedout == SCM_INTERNAL_COND_TIMEDOUT) return timeoutval;
     return SCM_OBJ(target);
 #else  /*!GAUCHE_HAS_THREADS*/
-    Scm_Error("not implemented!\n");
+    Scm_Error("not implemented!");
     return SCM_UNDEFINED;
 #endif /*!GAUCHE_HAS_THREADS*/
 }
@@ -351,7 +351,7 @@ ScmObj Scm_ThreadCont(ScmVM *target)
                                     target, stopped_by_other);
     return SCM_OBJ(target);
 #else  /*!GAUCHE_HAS_THREADS*/
-    Scm_Error("not implemented!\n");
+    Scm_Error("not implemented!");
     return SCM_UNDEFINED;
 #endif /*!GAUCHE_HAS_THREADS*/
 }
@@ -378,7 +378,7 @@ ScmObj Scm_ThreadSleep(ScmObj timeout)
     SCM_INTERNAL_COND_DESTROY(dummyc);
     if (intr) Scm_SigCheck(Scm_VM());
 #else  /*!GAUCHE_HAS_THREADS*/
-    Scm_Error("not implemented!\n");
+    Scm_Error("not implemented!");
 #endif /*!GAUCHE_HAS_THREADS*/
     return SCM_UNDEFINED;
 }

--- a/src/gauche/collection.h
+++ b/src/gauche/collection.h
@@ -68,11 +68,11 @@ extern ScmClass *Scm__SequenceCPL[];
 #define SCM_CHECK_START_END(start, end, len)                            \
     do {                                                                \
         if ((start) < 0 || (start) > (len)) {                           \
-            Scm_Error("start argument out of range: %d\n", (start));    \
+            Scm_Error("start argument out of range: %d", (start));      \
         }                                                               \
         if ((end) < 0) (end) = (len);                                   \
         else if ((end) > (len)) {                                       \
-            Scm_Error("end argument out of range: %d\n", (end));        \
+            Scm_Error("end argument out of range: %d", (end));          \
         } else if ((end) < (start)) {                                   \
             Scm_Error("end argument (%d) must be greater than or "      \
                       "equal to the start argument (%d)",               \

--- a/src/load.c
+++ b/src/load.c
@@ -1095,7 +1095,7 @@ ScmObj Scm_ResolveAutoload(ScmAutoload *adata, int flags)
            just in case we raise an error. */
         adata->locker = NULL;
         SCM_INTERNAL_COND_BROADCAST(adata->cv);
-        Scm_Error("Attempted to trigger the same autoload %S#%S recursively.  Maybe circular autoload dependency?\n",
+        Scm_Error("Attempted to trigger the same autoload %S#%S recursively.  Maybe circular autoload dependency?",
                   adata->module, adata->name);
     }
 

--- a/src/main.c
+++ b/src/main.c
@@ -526,7 +526,7 @@ void enter_repl()
     if (load_initfile) {
         ScmLoadPacket lpak;
         if (Scm_Require(SCM_MAKE_STR("gauche/interactive"), 0, &lpak) < 0) {
-            Scm_Warn("couldn't load gauche.interactive\n");
+            Scm_Warn("couldn't load gauche.interactive");
         } else {
             Scm_ImportModule(SCM_CURRENT_MODULE(),
                              SCM_INTERN("gauche.interactive"), SCM_FALSE, 0);

--- a/src/prof.c
+++ b/src/prof.c
@@ -139,7 +139,7 @@ void collect_samples(ScmVMProfiler *prof)
                                     prof->samples[i].func, SCM_UNBOUND);
         if (SCM_UNBOUNDP(e)) {
             /* NB: just for now */
-            Scm_Warn("profiler: uncounted object appeared in a sample: %p (%S)\n",
+            Scm_Warn("profiler: uncounted object appeared in a sample: %p (%S)",
                      prof->samples[i].func, prof->samples[i].func);
         } else {
             SCM_ASSERT(SCM_PAIRP(e));

--- a/src/read.c
+++ b/src/read.c
@@ -1461,7 +1461,7 @@ ScmObj Scm_DefineReaderCtor(ScmObj symbol, ScmObj proc, ScmObj finisher,
                             ScmObj module /*reserved*/)
 {
     if (!SCM_PROCEDUREP(proc)) {
-        Scm_Error("procedure required, but got %S\n", proc);
+        Scm_Error("procedure required, but got %S", proc);
     }
     ScmObj pair = Scm_Cons(proc, finisher);
     (void)SCM_INTERNAL_MUTEX_LOCK(readCtorData.mutex);

--- a/src/regexp.c
+++ b/src/regexp.c
@@ -411,7 +411,7 @@ static ScmObj rc1_lex(regcomp_ctx *ctx)
     case '\\':
         ch = Scm_GetcUnsafe(ctx->ipat);
         if (ch == SCM_CHAR_INVALID) {
-            Scm_Error("stray backslash at the end of pattern: %S\n",
+            Scm_Error("stray backslash at the end of pattern: %S",
                       ctx->pattern);
         }
         switch (ch) {
@@ -2110,7 +2110,7 @@ void Scm_RegDump(ScmRegexp *rx)
             codep++;
             continue;
         default:
-            Scm_Error("regexp screwed up\n");
+            Scm_Error("regexp screwed up");
         }
     }
 }
@@ -2758,7 +2758,7 @@ static void rex_rec(const unsigned char *code,
         }
         default:
             /* shouldn't be here */
-            Scm_Error("regexp implementation seems broken\n");
+            Scm_Error("regexp implementation seems broken");
         }
     }
 }

--- a/src/string.c
+++ b/src/string.c
@@ -654,7 +654,7 @@ ScmObj Scm_StringAppend(ScmObj strs)
     SCM_FOR_EACH(cp, strs) {
         const ScmStringBody *b;
         if (!SCM_STRINGP(SCM_CAR(cp))) {
-            Scm_Error("string required, but got %S\n", SCM_CAR(cp));
+            Scm_Error("string required, but got %S", SCM_CAR(cp));
         }
         b = SCM_STRING_BODY(SCM_CAR(cp));
         size += SCM_STRING_BODY_SIZE(b);
@@ -714,7 +714,7 @@ ScmObj Scm_StringJoin(ScmObj strs, ScmString *delim, int grammer)
     SCM_FOR_EACH(cp, strs) {
         const ScmStringBody *b;
         if (!SCM_STRINGP(SCM_CAR(cp))) {
-            Scm_Error("string required, but got %S\n", SCM_CAR(cp));
+            Scm_Error("string required, but got %S", SCM_CAR(cp));
         }
         b = SCM_STRING_BODY(SCM_CAR(cp));
         size += SCM_STRING_BODY_SIZE(b);

--- a/src/system.c
+++ b/src/system.c
@@ -375,7 +375,7 @@ static void put_user_home(ScmDString *dst,
         pwd = getpwuid(geteuid());
         if (pwd == NULL) {
             Scm_SigCheck(Scm_VM());
-            Scm_SysError("couldn't get home directory.\n");
+            Scm_SysError("couldn't get home directory.");
         }
     } else {
         int namesiz = (int)(end - name);
@@ -383,7 +383,7 @@ static void put_user_home(ScmDString *dst,
         pwd = getpwnam(uname);
         if (pwd == NULL) {
             Scm_SigCheck(Scm_VM());
-            Scm_Error("couldn't get home directory of user \"%s\".\n", uname);
+            Scm_Error("couldn't get home directory of user \"%s\".", uname);
         }
     }
     int dirlen = (int)strlen(pwd->pw_dir);

--- a/src/write.c
+++ b/src/write.c
@@ -646,7 +646,7 @@ static void write_ss(ScmObj obj, ScmPort *port, ScmWriteContext *ctx)
 /*format is now in Scheme (libfmt.scm).*/
 void Scm_Format(ScmPort *out, ScmString *fmt, ScmObj args, int sharedp)
 {
-    Scm_Error("Scm_Format is obsoleted\n");
+    Scm_Error("Scm_Format is obsoleted");
 }
 
 /*


### PR DESCRIPTION
The newline will be added by the default exception handler or Scm_Warn,
and most of other calls don't have it.