### PR TITLE
Fix abs for the minimum negative fixnum

### DIFF
--- a/src/number.c
+++ b/src/number.c
@@ -1464,7 +1464,13 @@ static ScmObj scm_abs(ScmObj obj, int vmp)
 {
     if (SCM_INTP(obj)) {
         long v = SCM_INT_VALUE(obj);
-        if (v < 0) obj = SCM_MAKE_INT(-v);
+        if (v < 0) {
+            if (v == SCM_SMALL_INT_MIN) {
+                obj = Scm_MakeBignumFromSI(-v);
+            } else {
+                obj = SCM_MAKE_INT(-v);
+            }
+        }
     } else if (SCM_BIGNUMP(obj)) {
         if (SCM_BIGNUM_SIGN(obj) < 0) {
             obj = Scm_BignumCopy(SCM_BIGNUM(obj));

--- a/test/number.scm
+++ b/test/number.scm
@@ -1624,6 +1624,13 @@
 
 
 ;;------------------------------------------------------------------
+(test-section "absolute values")
+
+(test* "abs (minimum negative of 30-bit wide fixnum)" (expt 2 29) (abs (- (expt 2 29))))
+(test* "abs (minimum negative of 62-bit wide fixnum)" (expt 2 61) (abs (- (expt 2 61))))
+
+
+;;------------------------------------------------------------------
 (test-section "rounding")
 
 (define (round-tester value exactness cei flo tru rou)


### PR DESCRIPTION
This is a fix for the following issue of `abs`:
> $ gosh -V
> Gauche scheme shell, version 0.9.4 [utf-8,pthreads], x86_64-unknown-linux-gnu
> $ gosh
> gosh> (abs (- (expt 2 61)))
> -2305843009213693952
> gosh> 
