### PR TITLE
Fix left shift of negative values

### DIFF
--- a/src/gauche.h
+++ b/src/gauche.h
@@ -311,7 +311,7 @@ SCM_EXTERN int Scm_EqualM(ScmObj x, ScmObj y, int mode);
 
 #define SCM_INTP(obj)        (SCM_TAG2(obj) == 1)
 #define SCM_INT_VALUE(obj)   (((signed long int)SCM_WORD(obj)) >> 2)
-#define SCM_MAKE_INT(obj)    SCM_OBJ(((intptr_t)(obj) << 2) + 1)
+#define SCM_MAKE_INT(obj)    SCM_OBJ(((uintptr_t)(obj) << 2) + 1)
 
 #define SCM_UINTP(obj)       (SCM_INTP(obj)&&((signed long int)SCM_WORD(obj)>=0))
 typedef long ScmSmallInt;    /* C integer type corresponds to Scheme fixnum


### PR DESCRIPTION
Calling SCM_MAKE_INT() with a negative value (e.g. "SCM_MAKE_INT(-1)") causes the left-shift of a negative intptr_t, which seems an undefined behavior in C99.
