### PR TITLE
Fix for "(negative? +nan.0) => #f"

### DIFF
--- a/src/libnum.scm
+++ b/src/libnum.scm
@@ -66,7 +66,7 @@
 (define-cproc positive? (obj) ::<boolean> :fast-flonum :constant
   (return (> (Scm_Sign obj) 0)))
 (define-cproc negative? (obj) ::<boolean> :fast-flonum :constant
-  (return (< (Scm_Sign obj) 0)))
+  (return (and (not (Scm_NanP obj)) (< (Scm_Sign obj) 0))))
 (define-cproc odd? (obj)  ::<boolean> :fast-flonum :constant Scm_OddP)
 (define-cproc even? (obj) ::<boolean> :fast-flonum :constant
   (return (not (Scm_OddP obj))))

--- a/test/number.scm
+++ b/test/number.scm
@@ -774,6 +774,7 @@
 (test* "zero?" #t (zero? 0+0i))
 (test* "zero?" #f (zero? 1.0))
 (test* "zero?" #f (zero? +5i))
+(test* "zero?" #f (zero? +nan.0))
 (test* "positive?" #t (positive? 1))
 (test* "positive?" #f (positive? -1))
 (test* "positive?" #t (positive? 1/7))
@@ -782,6 +783,7 @@
 (test* "positive?" #f (positive? -3.1416))
 (test* "positive?" #t (positive? 134539485343498539458394))
 (test* "positive?" #f (positive? -134539485343498539458394))
+(test* "positive?" #f (positive? +nan.0))
 (test* "negative?" #f (negative? 1))
 (test* "negative?" #t (negative? -1))
 (test* "negative?" #f (negative? 1/7))
@@ -790,6 +792,7 @@
 (test* "negative?" #t (negative? -3.1416))
 (test* "negative?" #f (negative? 134539485343498539458394))
 (test* "negative?" #t (negative? -134539485343498539458394))
+(test* "negative?" #f (negative? +nan.0))
 
 (let1 tester
     (lambda (name proc result)


### PR DESCRIPTION
With Gauche 0.9.4:
> $ gosh -V
> Gauche scheme shell, version 0.9.4 [utf-8,pthreads], x86_64-unknown-linux-gnu
> $ gosh
> gosh> (negative? +nan.0) 
> #t
> gosh>

However R6RS requires it to be #f, which seems also what is expected in R7RS.
Actually, both Guile 2.0 and Racket v6.1 evaluate it as #f.
