### PR TITLE
Fix exact for inexact integer around SCM_SMALL_INT_MAX or LONG_MAX

### DIFF
--- a/src/bignum.c
+++ b/src/bignum.c
@@ -186,9 +186,9 @@ ScmObj Scm_MakeBignumFromUIArray(int sign, const u_long *values, int size)
 
 ScmObj Scm_MakeBignumFromDouble(double val)
 {
-    if (val >= LONG_MIN && val <= LONG_MAX) {
+    if (LONG_MIN <= val
+        && val <= nextafter((double)LONG_MAX, 0.0))
         return Scm_MakeBignumFromSI((long)val);
-    }
 
     int exponent, sign;
     ScmObj mantissa = Scm_DecodeFlonum(val, &exponent, &sign);

--- a/src/number.c
+++ b/src/number.c
@@ -124,6 +124,11 @@ static double roundeven(double);
     ScmObj a(ScmObj obj1, ScmObj obj2) { return kernel(obj1, obj2, FALSE); } \
     ScmObj b(ScmObj obj1, ScmObj obj2) { return kernel(obj1, obj2, TRUE); }
 
+/* An analogue of SCM_SMALL_INT_FITS */
+#define DOUBLE_SMALL_INT_FITS(d)                            \
+    (SCM_SMALL_INT_MIN <= (d)                               \
+     && (d) <= nextafter((double)SCM_SMALL_INT_MAX, 0.0))
+
 /*================================================================
  * Classes of Numeric Tower
  */
@@ -311,10 +316,10 @@ ScmObj Scm_MakeFlonumToNumber(double d, int exact)
         double i, f;
         f = modf(d, &i);
         if (f == 0.0) {
-            if (i > SCM_SMALL_INT_MAX || i < SCM_SMALL_INT_MIN) {
-                return Scm_MakeBignumFromDouble(i);
-            } else {
+            if (DOUBLE_SMALL_INT_FITS(i)) {
                 return SCM_MAKE_INT((long)i);
+            } else {
+                return Scm_MakeBignumFromDouble(i);
             }
         }
     }
@@ -1620,10 +1625,10 @@ ScmObj Scm_Exact(ScmObj obj)
         }
         if ((f = modf(d, &i)) == 0.0) {
             /* integer */
-            if (d < SCM_SMALL_INT_MIN || d > SCM_SMALL_INT_MAX) {
-                obj = Scm_MakeBignumFromDouble(d);
-            } else {
+            if (DOUBLE_SMALL_INT_FITS(d)) {
                 obj = SCM_MAKE_INT((long)d);
+            } else {
+                obj = Scm_MakeBignumFromDouble(d);
             }
         } else {
             /* We'd find out the simplest rational numebr within the precision
@@ -3144,10 +3149,10 @@ ScmObj Scm_RoundToExact(ScmObj num, int mode)
         case SCM_ROUND_ROUND: r = roundeven(v); break;
         default: Scm_Panic("something screwed up");
         }
-        if (r < SCM_SMALL_INT_MIN || r > SCM_SMALL_INT_MAX) {
-            return Scm_MakeBignumFromDouble(r);
-        } else {
+        if (DOUBLE_SMALL_INT_FITS(r)) {
             return SCM_MAKE_INT((long)r);
+        } else {
+            return Scm_MakeBignumFromDouble(r);
         }
     }
     if (SCM_INTEGERP(num)) return num;

--- a/test/number.scm
+++ b/test/number.scm
@@ -561,6 +561,12 @@
    (1/3 . 0.3333333333333333)
    ))
 
+;; Boundary conditions for exact->inexact
+(test* "exact (greatest-fixnum)" (+ (greatest-fixnum) 1) (exact (inexact (greatest-fixnum))))
+(test* "exact (least-fixnum)" (least-fixnum) (exact (inexact (least-fixnum))))
+(test* "exact (64bit long max)" (expt 2 63) (exact (- (expt 2.0 63) 1)))
+(test* "exact (64bit long min)" (- (expt 2 63)) (exact (- (expt 2.0 63))))
+
 ;; Boundary conditions for inexact->exact
 ;; Since inexact->exact returns a simplest rational within the flonum precision,
 ;; the roundtrip of exact -> inexact -> exact isn't necessary kept, but
@@ -1673,12 +1679,28 @@
 
 (test* "round->exact" 3 (round->exact 3.4) =)
 (test* "round->exact" 4 (round->exact 3.5) =)
+(test* "round->exact" (+ (greatest-fixnum) 1) (round->exact (inexact (greatest-fixnum))))
+(test* "round->exact" (least-fixnum) (round->exact (inexact (least-fixnum))))
+(test* "round->exact" (expt 2 63) (round->exact (- (expt 2.0 63) 1)))
+(test* "round->exact" (- (expt 2 63)) (round->exact (- (expt 2.0 63))))
 (test* "floor->exact" 3 (floor->exact 3.4) =)
 (test* "floor->exact" -4 (floor->exact -3.5) =)
+(test* "floor->exact" (+ (greatest-fixnum) 1) (floor->exact (inexact (greatest-fixnum))))
+(test* "floor->exact" (least-fixnum) (floor->exact (inexact (least-fixnum))))
+(test* "floor->exact" (expt 2 63) (floor->exact (- (expt 2.0 63) 1)))
+(test* "floor->exact" (- (expt 2 63)) (floor->exact (- (expt 2.0 63))))
 (test* "ceiling->exact" 4 (ceiling->exact 3.4) =)
 (test* "ceiling->exact" -3 (ceiling->exact -3.5) =)
+(test* "ceiling->exact" (+ (greatest-fixnum) 1) (ceiling->exact (inexact (greatest-fixnum))))
+(test* "ceiling->exact" (least-fixnum) (ceiling->exact (inexact (least-fixnum))))
+(test* "ceiling->exact" (expt 2 63) (ceiling->exact (- (expt 2.0 63) 1)))
+(test* "ceiling->exact" (- (expt 2 63)) (ceiling->exact (- (expt 2.0 63))))
 (test* "truncate->exact" 3 (truncate->exact 3.4) =)
 (test* "truncate->exact" -3 (truncate->exact -3.5) =)
+(test* "truncate->exact" (+ (greatest-fixnum) 1) (truncate->exact (inexact (greatest-fixnum))))
+(test* "truncate->exact" (least-fixnum) (truncate->exact (inexact (least-fixnum))))
+(test* "truncate->exact" (expt 2 63) (truncate->exact (- (expt 2.0 63) 1)))
+(test* "truncate->exact" (- (expt 2 63)) (truncate->exact (- (expt 2.0 63))))
 
 ;;------------------------------------------------------------------
 (test-section "clamping")


### PR DESCRIPTION
With Gauche 0.9.4:
> $ gosh -V
> Gauche scheme shell, version 0.9.4 [utf-8,pthreads], x86_64-unknown-linux-gnu
> $ gosh
> gosh> (exact (- (expt 2.0 61) 1))
> -2305843009213693952
> gosh> (exact (- (expt 2.0 63) 1))
> -9223372036854775808
> gosh>
