### PR TITLE
Fix expt for zero raised to a complex power

### DIFF
--- a/src/libnum.scm
+++ b/src/libnum.scm
@@ -487,8 +487,11 @@
         [(real? x)
          (cond [(real? y) (%expt x y)]
                [(number? y)
-                (* (%expt x (real-part y))
-                   (exp (* +i (imag-part y) (%log x))))]
+                (let1 ry (real-part y)
+                  (if (and (zero? x) (positive? ry))
+                      (if (exact? x) 0 0.0)
+                      (* (%expt x ry)
+                         (exp (* +i (imag-part y) (%log x))))))]
                [else (error "number required, but got" y)])]
         [(number? x) (exp (* y (log x)))]
         [else (error "number required, but got" x)]))

--- a/test/number.scm
+++ b/test/number.scm
@@ -503,6 +503,9 @@
 (test* "exact expt (ratinoal)" 5559060566555523/8589934592
        (expt 2/3 -33))
 
+(test* "expt (0 raised to a complex power)" 0 (expt 0 5+.0000312i))
+(test* "expt (0.0 raised to a complex power)" 0.0 (expt 0.0 5+.0000312i))
+
 (test* "expt (coercion to inexact)" 1.4142135623730951
        (expt 2 1/2)
        (lambda (x y) (nearly=? 10e7 x y))) ;; NB: pa$ will be tested later


### PR DESCRIPTION
With Gauche 0.9.4:
> $ gosh -V
> Gauche scheme shell, version 0.9.4 [utf-8,pthreads], x86_64-unknown-linux-gnu
> $ gosh
> gosh> (expt 0 1+2i)
> +nan.0+nan.0i
> gosh> (expt 0.0 1+2i)
> +nan.0+nan.0i
> gosh>

But R7RS specifies that both of the aboves are zero.
