### PR TITLE
Make magnitude the same as abs

### DIFF
--- a/src/libnum.scm
+++ b/src/libnum.scm
@@ -805,5 +805,5 @@
         [(SCM_REALP z)  (return (Scm_VMReturnFlonum 0.0))]
         [else (return (Scm_VMReturnFlonum (SCM_COMPNUM_IMAG z)))]))
 
-(define-cproc magnitude (z) ::<double> :fast-flonum :constant Scm_Magnitude)
+(define-cproc magnitude (z) :fast-flonum :constant Scm_VMAbs)
 (define-cproc angle (z)     ::<double> :fast-flonum :constant Scm_Angle)

--- a/test/number.scm
+++ b/test/number.scm
@@ -1638,6 +1638,8 @@
 (test* "abs (minimum negative of 30-bit wide fixnum)" (expt 2 29) (abs (- (expt 2 29))))
 (test* "abs (minimum negative of 62-bit wide fixnum)" (expt 2 61) (abs (- (expt 2 61))))
 
+(test* "magnitude (exact real)" 1 (magnitude 1))
+
 
 ;;------------------------------------------------------------------
 (test-section "rounding")


### PR DESCRIPTION
With Gauche 0.9.4:
> $ gosh -V
> Gauche scheme shell, version 0.9.4 [utf-8,pthreads], x86_64-unknown-linux-gnu
> $ gosh
> gosh> (magnitude 1)
> 1.0
> gosh> 

while it returns the exact 1 in both Guile 2.0 and Racket v6.1.
In fact R7RS mentions that magnitude is the same as abs for real numbers.
Moreover Gauche's abs fully supports complex numbers, so let's share the implementation.
