### PR TITLE
Make iform->sexpr ignore identifiers

### DIFF
--- a/src/compile.scm
+++ b/src/compile.scm
@@ -1387,12 +1387,14 @@
 ;; it's not generally possible to convert it back to S-expr.  You can only
 ;; pass the IForm immediately after pass1.
 (define (iform->sexpr iform)
-  (define lvar-dict (make-hash-table 'eq?)) ;; lvar -> symbol
+  (define lvar-dict (make-hash-table 'eq?)) ;; lvar -> variable
   (define (get-lvar lvar)
     (or (hash-table-get lvar-dict lvar #f)
-        (rlet1 s ($ string->symbol $ format "~a.~d" (lvar-name lvar)
-                    $ hash-table-num-entries lvar-dict)
-          (hash-table-put! lvar-dict lvar s))))
+        (let1 name (lvar-name lvar)
+          (rlet1 s (if (identifier? name) name
+                       ($ string->symbol $ format "~a.~d" name
+                          $ hash-table-num-entries lvar-dict))
+            (hash-table-put! lvar-dict lvar s)))))
   (define (rec iform)
     (case/unquote
      (iform-tag iform)

--- a/src/compile.scm
+++ b/src/compile.scm
@@ -1392,7 +1392,7 @@
     (or (hash-table-get lvar-dict lvar #f)
         (let* ([name (lvar-name lvar)]
                [name (if (identifier? name) (identifier-name name) name)])
-          (rlet1 s ($ string->symbol $ format "~a.~d" (lvar-name lvar)
+          (rlet1 s ($ string->symbol $ format "~a.~d" name
                       $ hash-table-num-entries lvar-dict)
             (hash-table-put! lvar-dict lvar s)))))
   (define (rec iform)

--- a/src/compile.scm
+++ b/src/compile.scm
@@ -1387,13 +1387,13 @@
 ;; it's not generally possible to convert it back to S-expr.  You can only
 ;; pass the IForm immediately after pass1.
 (define (iform->sexpr iform)
-  (define lvar-dict (make-hash-table 'eq?)) ;; lvar -> variable
+  (define lvar-dict (make-hash-table 'eq?)) ;; lvar -> symbol
   (define (get-lvar lvar)
     (or (hash-table-get lvar-dict lvar #f)
-        (let1 name (lvar-name lvar)
-          (rlet1 s (if (identifier? name) name
-                       ($ string->symbol $ format "~a.~d" name
-                          $ hash-table-num-entries lvar-dict))
+        (let* ([name (lvar-name lvar)]
+               [name (if (identifier? name) (identifier-name name) name)])
+          (rlet1 s ($ string->symbol $ format "~a.~d" (lvar-name lvar)
+                      $ hash-table-num-entries lvar-dict)
             (hash-table-put! lvar-dict lvar s)))))
   (define (rec iform)
     (case/unquote


### PR DESCRIPTION
## Before
```scm
gosh> (macroexpand-all '(cut print <>))
(lambda (|#<identifier srfi-26#x.e82d20>.0|) (print |#<identifier srfi-26#x.e82d20>.0|))
gosh> (macroexpand-all '((cut print <>) 1))
(letrec ((|#<identifier srfi-26#x.e821c0>.0| '1)) (print |#<identifier srfi-26#x.e821c0>.0|))
```

## After
```scm
gosh> (macroexpand-all '(cut print <>))
(lambda (x) (print x))
gosh> (macroexpand-all '((cut print <>) 1))
(letrec ((x '1)) (print x))
```