### PR TITLE
Richtext fix

### DIFF
--- a/winnt/wix/txt2rtf.scm
+++ b/winnt/wix/txt2rtf.scm
@@ -12,7 +12,7 @@
     [(_ in out) (file-filter doit :input in :output out)]
     [_ (exit 1 "Usage: ~a <input-file> <output-file>" (car args))])
   0)
-    
+
 (define (doit in out)
   (display "{\\rtf1\\ansi\\ansicpg1252\\deff0{\\fonttbl{\\f0\\fnil\\fcharset0 Arial Narrow;}}\r\n" out)
   (display "\\viewkind4\\uc1\\pard\\lang1033\\f0\\fs20 " out)
@@ -29,7 +29,3 @@
               [else
                (format out "~a\\par\r\n" prev-line)
                (loop line)])))))
-
-      
-             
-                             

--- a/winnt/wix/txt2rtf.scm
+++ b/winnt/wix/txt2rtf.scm
@@ -14,7 +14,7 @@
   0)
 
 (define (doit in out)
-  (display "{\\rtf1\\ansi\\ansicpg1252\\deff0{\\fonttbl{\\f0\\fnil\\fcharset0 Arial Narrow;}}\r\n" out)
+  (display "{\\rtf1\\ansi\\ansicpg1252\\deff0{\\fonttbl{\\f0\\fnil\\fcharset0 Tahoma;}}\r\n" out)
   (display "\\viewkind4\\uc1\\pard\\lang1033\\f0\\fs20 " out)
   (let loop ([prev-line (read-line in)])
     (unless (eof-object? prev-line)

--- a/winnt/wix/txt2rtf.scm
+++ b/winnt/wix/txt2rtf.scm
@@ -28,4 +28,5 @@
                (loop line)]
               [else
                (format out "~a\\par\r\n" prev-line)
-               (loop line)])))))
+               (loop line)]))))
+  (display "}" out))


### PR DESCRIPTION
`winnt/wix/txt2rtf.scm` makes broken RTF document.

Add "}" to last output line.