### PR TITLE
Change for MinGW32 socket

### DIFF
--- a/examples/echo-server.scm
+++ b/examples/echo-server.scm
@@ -9,15 +9,12 @@
         (servers  (make-server-sockets #f port :reuse-addr? #t)))
 
     (define (echo client input output)
-      (print "  port-name = " (port-name input))
       (let ((str (read-uvector <u8vector> 4096 input)))
-        (print "  read-data = " str)
         (if (eof-object? str)
             (begin (selector-delete! selector (socket-fd client) #f #f)
                    (socket-close client))
             (begin (write-uvector str output)
-                   (flush output)))
-        (print "  socket-status = " (socket-status client))))
+                   (flush output)))))
 
     (for-each
      (lambda (server)
@@ -26,7 +23,6 @@
          (let* ((client (socket-accept server))
                 (input  (socket-input-port client :buffering :none))
                 (output (socket-output-port client)))
-           (print "client-socket-fd = " (socket-fd client))
            (selector-add! selector
                           (socket-fd client)
                           (lambda (sock flag)
@@ -38,7 +34,7 @@
                       accept-handler
                       '(r)))
      servers)
-    (do () (#f) (print "select-return-value = " (selector-select selector)))))
+    (do () (#f) (selector-select selector))))
 
 (define (main args)
   (print "echo server starting on port 3131")

--- a/examples/scheme-server.scm
+++ b/examples/scheme-server.scm
@@ -23,7 +23,7 @@
                 (input  (socket-input-port client :buffering :none))
                 (output (socket-output-port client))
                 (finalize (lambda ()
-                            (selector-delete! selector input #f #f)
+                            (selector-delete! selector (socket-fd client) #f #f)
                             (socket-close client)
                             (format #t "client #~a disconnected\n" id)))
                 (listener (make <listener>
@@ -37,7 +37,7 @@
            (format #t "client #~a from ~a\n" cid (socket-address client))
            (inc! cid)
            (listener-show-prompt listener)
-           (selector-add! selector input (lambda _ (handler)) '(r))))
+           (selector-add! selector (socket-fd client) (lambda _ (handler)) '(r))))
 
        (selector-add! selector
                       (socket-fd server)

--- a/ext/net/gauche-net.h
+++ b/ext/net/gauche-net.h
@@ -204,11 +204,9 @@ typedef struct ScmSocketRec {
     ScmPort *outPort;
     ScmString *name;
 #if defined(GAUCHE_WINDOWS)
-    /* Save them so that we can close them when the socket is closed.
-       We can't let these closed by inPort/outPort cleanup routine, since
-       even after one port is closed, another port may be still in use. */
-    int infd;
-    int outfd;
+    /* Save a C run-time file descriptor so that we can close it
+       when the socket is closed. */
+    int cfd;
 #endif /*GAUCHE_WINDOWS*/
 } ScmSocket;
 

--- a/test/system.scm
+++ b/test/system.scm
@@ -484,27 +484,20 @@
                (close-input-port in) (close-output-port out)
                (list f1 f2 f3))))))
 
-;; Kludge: MinGW32 seems not to support :none, :line buffering,
-;; so we flush and close the output pipe before reading from it.
-
 (test* "pipe and read-block(none)" 2
        (receive (in out) (sys-pipe :buffering :none)
          (display "ab" out)
-         (cond-expand (gauche.os.windows (close-output-port out)) (else))
          (let1 r (string-size (read-block 1000 in))
            (close-input-port in)
-           (cond-expand ((not gauche.os.windows) (close-output-port out))
-                        (else))
+           (close-output-port out)
            r)))
 
 (test* "pipe and read-block(line)" 2
        (receive (in out) (sys-pipe :buffering :line)
          (display "a\n" out)
-         (cond-expand (gauche.os.windows (close-output-port out)) (else))
          (let1 r (string-size (read-block 1000 in))
            (close-input-port in)
-           (cond-expand ((not gauche.os.windows) (close-output-port out))
-                        (else))
+           (close-output-port out)
            r)))
 
 ;;-------------------------------------------------------------------


### PR DESCRIPTION
1. To close osfhandle twice causes an error. (unknown target exception)
   - ext/net/gauche-net.h
   - ext/net/net.c

2. To read from socket causes a deadlock, since Scm_FdReady returns SCM_FD_UNKNOWN for socket.
   - src/port.c  (Scm_FdReady)

3. On windows, selector supports only socket-fd. (Though, on other os, selector supports socket-fd and port.)
   - examples/echo-server.scm
   - examples/scheme-server.scm

4. Now, some pipe tests don't require conditions. (ex. cond-expand (gauche.os.windows))
   - test/system.scm

5. Socket errors are not displayed, since「ScmVM *vm = Scm_VM();」clears Windows last error.
   - src/error.c

make check result is
Total: 15772 tests, 15772 passed,     0 failed,     0 aborted.
(Though, configure.ac and ext/tls/Makefile.in were modified.)

OS : Windows 8.1 (64bit)
DEVTOOL : MinGW32 (GCC v4.8.1, Runtime v3.21)
