### PR TITLE
Change for gosh-noconsole stdio support improvement

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -371,13 +371,16 @@ static int init_console(void)
 {
 #  if defined(GAUCHE_WINDOWS_NOCONSOLE)
     char buf[100];
+    int in_fd, out_fd;
 #define ERR(msg) do {sprintf(buf, msg, strerror(errno));goto fail;} while(0)
-    if (freopen("NUL", "rb", stdin)  == NULL) ERR("couldn't open NUL: %s");
-    if (freopen("NUL", "wb", stdout) == NULL) ERR("couldn't open NUL: %s");
-    if (freopen("NUL", "wb", stderr) == NULL) ERR("couldn't open NUL: %s");
-    if (_dup2(_fileno(stdin),  0) < 0) ERR("dup2(0) failed (%s)");
-    if (_dup2(_fileno(stdout), 1) < 0) ERR("dup2(1) failed (%s)");
-    if (_dup2(_fileno(stderr), 2) < 0) ERR("dup2(2) failed (%s)");
+
+    if ((in_fd  = open("NUL", O_RDONLY | O_BINARY)) < 0) ERR("couldn't open NUL: %s");
+    if ((out_fd = open("NUL", O_WRONLY | O_BINARY)) < 0) ERR("couldn't open NUL: %s");
+    if (_dup2(in_fd,  0) < 0) ERR("dup2(0) failed (%s)");
+    if (_dup2(out_fd, 1) < 0) ERR("dup2(1) failed (%s)");
+    if (_dup2(out_fd, 2) < 0) ERR("dup2(2) failed (%s)");
+    close(in_fd);
+    close(out_fd);
     return FALSE;
 #undef ERR
  fail:

--- a/src/main.c
+++ b/src/main.c
@@ -371,16 +371,13 @@ static int init_console(void)
 {
 #  if defined(GAUCHE_WINDOWS_NOCONSOLE)
     char buf[100];
-    int in_fd, out_fd;
 #define ERR(msg) do {sprintf(buf, msg, strerror(errno));goto fail;} while(0)
-
-    if ((in_fd = open("NUL", O_RDONLY)) < 0) ERR("couldn't open NUL: %s");
-    if ((out_fd = open("NUL", O_WRONLY))< 0) ERR("couldn't open NUL: %s");
-    if (_dup2(in_fd, 0) < 0)  ERR("dup2(0) failed (%s)");
-    if (_dup2(out_fd, 1) < 0) ERR("dup2(1) failed (%s)");
-    if (_dup2(out_fd, 2) < 0) ERR("dup2(2) failed (%s)");
-    close(in_fd);
-    close(out_fd);
+    if (freopen("NUL", "rb", stdin)  == NULL) ERR("couldn't open NUL: %s");
+    if (freopen("NUL", "wb", stdout) == NULL) ERR("couldn't open NUL: %s");
+    if (freopen("NUL", "wb", stderr) == NULL) ERR("couldn't open NUL: %s");
+    if (_dup2(_fileno(stdin),  0) < 0) ERR("dup2(0) failed (%s)");
+    if (_dup2(_fileno(stdout), 1) < 0) ERR("dup2(1) failed (%s)");
+    if (_dup2(_fileno(stderr), 2) < 0) ERR("dup2(2) failed (%s)");
     return FALSE;
 #undef ERR
  fail:
@@ -647,7 +644,9 @@ int main(int ac, char **av)
 
     /* Following is the main dish. */
     if (scriptfile != NULL) exit_code = execute_script(scriptfile, args);
+#if !defined(GAUCHE_WINDOWS_NOCONSOLE)
     else                    enter_repl();
+#endif /*!defined(GAUCHE_WINDOWS_NOCONSOLE)*/
 
     /* All is done.  */
     Scm_Exit(exit_code);


### PR DESCRIPTION
1. trapperPort was deleted.
   trapper_flusher was changed to reopen stdio and duplicate file descriptors.
   Now, some .scm files can use stdio, even if they were started by double click.
   (e.g. (print "1+2+3=" (+ 1 2 3))(read-line) )
   - src/port.c

2. init_console was changed to use freopen and binary mode.
   - src/main.c

3. main was changed not to enter repl when GAUCHE_WINDOWS_NOCONSOLE is defined.
   (For compatibility with past)
   - src/main.c


make check result is
Total: 15828 tests, 15828 passed,     0 failed,     0 aborted.
(configure.ac and ext/tls/Makefile.in were modified.)


OS : Windows 8.1 (64bit)
DEVTOOL : MinGW32 (GCC v4.8.1, Runtime v3.21)
