### PR TITLE
Change for gosh-noconsole sys-system support

### DIFF
--- a/src/gauche/win-compat.h
+++ b/src/gauche/win-compat.h
@@ -179,6 +179,7 @@ extern __declspec(dllimport) const char *Scm_WCS2MBS(const WCHAR *s);
 #define rename(o, n)       _wrename(Scm_MBS2WCS(o), Scm_MBS2WCS(n))
 #define rmdir(dir)         _wrmdir(Scm_MBS2WCS(dir))
 #define unlink(path)       _wunlink(Scm_MBS2WCS(path))
+#define system(path)       _wsystem(Scm_MBS2WCS(path))
 #endif /*UNICODE*/
 
 /*===================================================================

--- a/test/win-noconsole-stdio.scm
+++ b/test/win-noconsole-stdio.scm
@@ -1,0 +1,55 @@
+;;
+;; This manually test AllocConsole() opeartion of gosh-noconsole.exe
+;; on MinGW.  This can't be automated easily, so it's not run by
+;; make check.
+;;
+
+(cond-expand
+ [(not gauche.os.windows)
+  (exit 1 "This script needs to be run on MinGW version of gosh-noconsole.")]
+ [else])
+
+(use gauche.process)
+
+;; stdio test
+
+(print "1+2+3=" (+ 1 2 3))
+(print "HIT ENTER KEY!")
+(read-line)
+(display "4+5+6="  (current-error-port))
+(display (+ 4 5 6) (current-error-port))
+(newline (current-error-port))
+(display "HIT ENTER KEY!" (current-error-port))
+(read-line)
+
+;; run-process input test
+
+(let* ((p   (run-process "more.com" :input :pipe))
+       (out (process-input p)))
+  (display (iota 511) out)
+  (newline out)
+  (close-output-port out)
+  (process-wait p))
+(print "HIT ENTER KEY!")
+(read-line)
+
+;; run-process output test
+
+(let* ((p   (run-process '(echo "12345\nabcde") :output :pipe))
+       (in  (process-output p)))
+  (display (read-line in))
+  (newline)
+  (display (read-line in))
+  (newline)
+  (close-input-port in)
+  (process-wait p))
+(print "HIT ENTER KEY!")
+(read-line)
+
+;; sys-system test
+
+(sys-system "date /t")
+(sys-system "time /t")
+(print "HIT ENTER KEY!")
+(read-line)
+


### PR DESCRIPTION
1. After calling sys-system, newline characters don't work on gosh-noconsole.
   (e.g. (sys-system "dir") )
   - src/port.c

2. Windows has a unicode version of system().
   - src/win-compat.h

3. One test file was added.
   - test/win-noconsole-stdio.scm


reference:
https://social.msdn.microsoft.com/Forums/vstudio/en-US/286059e8-9163-4679-9663-efc63c5d9c53/allocconsole-backspace-and-newline-characters-incorrectly-printed-after-system-call?forum=vcgeneral


OS : Windows 8.1 (64bit)
DEVTOOL : MinGW32 (GCC v4.8.1, Runtime v3.21)
Total: 15845 tests, 15845 passed,     0 failed,     0 aborted.

OS : Windows XP SP3
DEVTOOL : MinGW32 (GCC v4.8.1, Runtime v4.0.3-1 (this is older than v3.21))
Total: 15792 tests, 15790 passed,     2 failed,     0 aborted.
Testing file.util ...                                            failed.
discrepancies found.  Errors are:
test touch-file :time :type: expects (60000 50001) => got (4294940896 50001)
test touch-file :time :type: expects (60000 70000) => got (4294940896 4294950896)
(I think these errors are no problem.)


＜内容について＞
gosh-noconsole について、例えば (sys-system "dir") を実行すると、
それ以後、改行が機能しなくなるという問題が見つかりました。
いろいろ調べると、open ではなく _open_osfhandle を使うと回避できる
とのことなので対応しました。

また、system() にユニコードバージョンの _wsystem() が存在したため、
win-compat.h に define を追加しました。

また、test フォルダに win-noconsole-threads.scm というテストがあったので、
同じ場所に win-noconsole-stdio.scm というテストを追加してみました。

今回は、Windows XP SP3 でもコンパイルして動作を確認しました。
