### PR TITLE
Windows Installer ChangeFolder Button Fix

### DIFF
--- a/winnt/wix/genwxs.scm
+++ b/winnt/wix/genwxs.scm
@@ -254,7 +254,7 @@
                    (match-let1 (ctrl event value order content) param
                      `(Publish (@ (Dialog ,dlgname)
                                   (Control ,(x->string ctrl))
-                                  (Event ,(x->string event))
+                                  (,(if (eq? event '_BrowseProperty) 'Property 'Event) ,(x->string event))
                                   (Value ,(x->string value))
                                   ,@(cond-list
                                      [order `(Order ,(x->string order))]))


### PR DESCRIPTION
1. On Windows installer, the "ChangeFolder" button click raises a following error.
   
   "The installer has encountered an unexpected error installing this package.
   This may indicate a problem with this package. The error code is 2812.
   The arguments are: _BrowseProperty, , "
   
   I found that "_BrowseProperty" is a value of "Property" attribute,
   not a value of "Event" attribute.
   - winnt/wix/genwxs.scm
