### PR TITLE
Refactoring conditional directives for if wrappers.

### DIFF
--- a/gc/misc.c
+++ b/gc/misc.c
@@ -1638,6 +1638,7 @@ GC_API GC_warn_proc GC_CALL GC_get_warn_proc(void)
   STATIC void GC_CALLBACK GC_default_on_abort(const char *msg)
   {
     GC_find_leak = FALSE; /* disable at-exit GC_gcollect()  */
+    int gc_write = 1;
 
     if (msg != NULL) {
 #     if defined(MSWIN32)
@@ -1660,14 +1661,15 @@ GC_API GC_warn_proc GC_CALL GC_get_warn_proc(void)
         /* Also duplicate msg to GC log file.   */
 #     endif
 
-#   ifndef GC_ANDROID_LOG
+#ifndef GC_ANDROID_LOG
       /* Avoid calling GC_err_printf() here, as GC_on_abort() could be  */
       /* called from it.  Note 1: this is not an atomic output.         */
       /* Note 2: possible write errors are ignored.                     */
-#     if defined(THREADS) && defined(GC_ASSERTIONS) \
+# if defined(THREADS) && defined(GC_ASSERTIONS) \
          && (defined(MSWIN32) || defined(MSWINCE))
-        if (!GC_write_disabled)
-#     endif
+        gc_write = (!GC_write_disabled);
+#endif
+      if (gc_write)
       {
         if (WRITE(GC_stderr, (void *)msg, strlen(msg)) >= 0)
           (void)WRITE(GC_stderr, (void *)("\n"), 1);

--- a/gc/os_dep.c
+++ b/gc/os_dep.c
@@ -2316,9 +2316,11 @@ void * os2_alloc(size_t bytes)
 
   GC_API void GC_CALL GC_win32_free_heap(void)
   {
+    int check_directive = 1;
 #   ifndef CYGWIN32
-      if (GLOBAL_ALLOC_TEST)
+      check_directive = (GLOBAL_ALLOC_TEST);
 #   endif
+    if (check_directive)
     {
       while (GC_n_heap_bases-- > 0) {
 #       ifdef CYGWIN32

--- a/gc/typd_mlc.c
+++ b/gc/typd_mlc.c
@@ -666,6 +666,7 @@ GC_API GC_ATTR_MALLOC void * GC_CALL GC_calloc_explicitly_typed(size_t n,
     register int descr_type;
     struct LeafDescriptor leaf;
     DCL_LOCK_STATE;
+    int gc_register = 1;
 
     descr_type = GC_make_array_descriptor((word)n, (word)lb, d,
                                           &simple_descr, &complex_descr, &leaf);
@@ -722,9 +723,10 @@ GC_API GC_ATTR_MALLOC void * GC_CALL GC_calloc_explicitly_typed(size_t n,
        ((word *)op)[lw - 1] = (word)complex_descr;
        /* Make sure the descriptor is cleared once there is any danger  */
        /* it may have been collected.                                   */
-       if (GC_general_register_disappearing_link((void * *)((word *)op+lw-1),
-                                                 op) == GC_NO_MEMORY)
+       gc_register = (GC_general_register_disappearing_link((void * *)((word *)op+lw-1),
+                                                 op) == GC_NO_MEMORY);
 #    endif
+       if (gc_register)
        {
            /* Couldn't register it due to lack of memory.  Punt.        */
            /* This will probably fail too, but gives the recovery code  */


### PR DESCRIPTION
A suggestion to compile entire statements and expressions, as suggested by code style guidelines from the Linux Kernel and practitioners.

* [Linux kernel coding style](https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/CodingStyle#n892)
* [Living in the #ifdef Hell](https://www.cqse.eu/en/blog/living-in-the-ifdef-hell/)

It might improve code understanding, maintainability and error-proneness.