### PR TITLE
ssltest fix on Windows

### DIFF
--- a/ext/tls/ssltest-mod.scm
+++ b/ext/tls/ssltest-mod.scm
@@ -31,10 +31,19 @@
     [_ (usage)]))
 
 (define (do-translate srcdir builddir)
+(cond-expand
+ [gauche.os.windows
+  (define srcpath (regexp-replace-all #/\\/ (build-path srcdir "axTLS/ssl") "/"))
+  (define kicker  (regexp-replace-all #/\\/ (build-path builddir "kick_openssl.sh") "/"))
+  (define srcpath-replace #"~|srcpath|/")
+  (define kicker-replace #"sh ~kicker ")
+  ]
+ [else
   (define srcpath (build-path srcdir "axTLS/ssl"))
   (define kicker  (build-path builddir "kick_openssl.sh"))
   (define srcpath-replace #"~|srcpath|/")
   (define kicker-replace #"~kicker ")
+  ])
   
   (p "/* This is generated file. Don't edit! */"
      "static int safe_system(const char *);")


### PR DESCRIPTION
1. "build-path" returns a path including backslash characters on Windows,
   and "regexp-replace-all*" deletes these characters.
   So I replaced the backslash characters to slash characters.
   - tls/ssltest-mod.scm

2. I changed #"~kicker " to #"sh ~kicker " for executing a shell script file on Windows.
   - tls/ssltest-mod.scm


OS : Windows 8.1 (64bit)
DEVTOOL : MinGW32 (GCC v4.8.1, Runtime v3.21)
Total: 15856 tests, 15856 passed,     0 failed,     0 aborted.
