### PR TITLE
Add sys-mkdtemp function

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -515,7 +515,7 @@ AC_SUBST(ALTERNATIVE_GOSH)
 
 AC_FUNC_ALLOCA
 AC_CHECK_FUNCS(isnan isinf trunc rint tgamma lgamma)
-AC_CHECK_FUNCS(symlink readlink lchown mkstemp realpath nanosleep usleep)
+AC_CHECK_FUNCS(symlink readlink lchown mkdtemp mkstemp realpath nanosleep usleep)
 AC_CHECK_FUNCS(random srandom lrand48 srand48)
 AC_CHECK_FUNCS(putenv setenv unsetenv clearenv getpgid setgroups)
 AC_CHECK_FUNCS(gethostname sethostname getdomainname setdomainname)

--- a/doc/corelib.texi
+++ b/doc/corelib.texi
@@ -20037,6 +20037,20 @@ The file is opened for writing, and its permission is set to 600.
 @c COMMON
 @end defun
 
+@defun sys-mkdtemp template
+@c EN
+Creates a directory that has unique name, and returns the name.
+@var{template} is used as the prefix of the directory.  Unlike Unix's
+mkdtemp, you don't need padding characters.  The directory's
+permission is set to 700.
+@c JP
+ユニークな名前を持つディレクトリを作成し、その名前を返します。
+@var{template}はディレクトリ名のプレフィックスに使われます。
+Unixのmkdtempと違って、パディングキャラクタをつける必要はありません。
+ディレクトリのパーミッションは700にセットされます。
+@c COMMON
+@end defun
+
 @defun sys-link existing new
 [POSIX]
 @c EN

--- a/src/gauche/config.h.in
+++ b/src/gauche/config.h.in
@@ -246,6 +246,9 @@
 /* Define to 1 if you have the `mkstemp' function. */
 #undef HAVE_MKSTEMP
 
+/* Define to 1 if you have the `mkdtemp' function. */
+#undef HAVE_MKDTEMP
+
 /* Define to 1 if you have the `nanosleep' function. */
 #undef HAVE_NANOSLEEP
 

--- a/src/gauche/system.h
+++ b/src/gauche/system.h
@@ -278,6 +278,7 @@ typedef struct ScmHeaderRec ScmSysFdset;
 
 SCM_EXTERN int    Scm_Mkstemp(char *tmpl);
 SCM_EXTERN ScmObj Scm_SysMkstemp(ScmString *tmpl);
+SCM_EXTERN ScmObj Scm_SysMkdtemp(ScmString *tmpl);
 SCM_EXTERN ScmObj Scm_Environ(void);
 SCM_EXTERN const char *Scm_GetEnv(const char *name);
 SCM_EXTERN void Scm_SetEnv(const char *name, const char *value, int overwrite);

--- a/src/libsys.scm
+++ b/src/libsys.scm
@@ -407,6 +407,7 @@
          (return (SCM_MAKE_STR_COPYING s)))))
 
 (define-cproc sys-mkstemp (template::<string>) Scm_SysMkstemp)
+(define-cproc sys-mkdtemp (template::<string>) Scm_SysMkdtemp)
 
 ;; ctermid
 (define-cproc sys-ctermid () ::<const-cstring>

--- a/src/system.c
+++ b/src/system.c
@@ -681,8 +681,8 @@ ScmObj Scm_DirName(ScmString *filename)
  * success and non-zero otherwize.  NAME is a name of operation
  * performed by FUNC.  ARG is caller supplied data passed to FUNC.
  */
-static void Scm_EmulateMkxtemp(char *name, char *templat,
-                               int (*func)(char *, void *), void *arg)
+static void emulate_mkxtemp(char *name, char *templat,
+                            int (*func)(char *, void *), void *arg)
 {
     /* Emulate mkxtemp. */
     int siz = (int)strlen(templat);
@@ -706,10 +706,10 @@ static void Scm_EmulateMkxtemp(char *name, char *templat,
         }
     }
 }
-#endif /* !defined(HAVE_MKXTEMP) || defined(HAVE_MKDTEMP) */
+#endif /* !defined(HAVE_MKXTEMP) || !defined(HAVE_MKDTEMP) */
 
 #if !defined(HAVE_MKSTEMP)
-static int Scm_CreateTempFile(char *templat, void *arg)
+static int create_tmpfile(char *templat, void *arg)
 {
     int *fdp = (int *)arg;
     int flags;
@@ -733,7 +733,7 @@ int Scm_Mkstemp(char *templat)
     if (fd < 0) Scm_SysError("mkstemp failed");
     return fd;
 #else   /*!defined(HAVE_MKSTEMP)*/
-    Scm_EmulateMkxtemp("mkstemp", templat, Scm_CreateTempFile, &fd);
+    emulate_mkxtemp("mkstemp", templat, create_tmpfile, &fd);
     return fd;
 #endif /*!defined(HAVE_MKSTEMP)*/
 }
@@ -759,7 +759,7 @@ ScmObj Scm_SysMkstemp(ScmString *templat)
 }
 
 #if !defined(HAVE_MKDTEMP)
-static int Scm_CreateTempDir(char *templat, void *arg)
+static int create_tmpdir(char *templat, void *arg)
 {
     int r;
 
@@ -780,7 +780,7 @@ static void Scm_Mkdtemp(char *templat)
     SCM_SYSCALL(p, mkdtemp(templat));
     if (p == NULL) Scm_SysError("mkdtemp failed");
 #else   /*!defined(HAVE_MKDTEMP)*/
-    Scm_EmulateMkxtemp("mkdtemp", templat, Scm_CreateTempDir, NULL);
+    emulate_mkxtemp("mkdtemp", templat, create_tmpdir, NULL);
 #endif /*!defined(HAVE_MKDTEMP)*/
 }
 

--- a/src/system.c
+++ b/src/system.c
@@ -675,7 +675,7 @@ ScmObj Scm_DirName(ScmString *filename)
 #undef SEPARATOR
 
 
-#if !defined(HAVE_MKXTEMP) || defined(HAVE_MKDTEMP)
+#if !defined(HAVE_MKXTEMP) || !defined(HAVE_MKDTEMP)
 /*
  * Helper function to emulate mkstemp or mkdtemp.  FUNC returns 0 on
  * success and non-zero otherwize.  NAME is a name of operation

--- a/test/system.scm
+++ b/test/system.scm
@@ -375,13 +375,12 @@
  [else])
 
 ;; sys-mkdtemp
-(test* "sys-mkdtemp" '(#t #f #f #f)
+(test* "sys-mkdtemp" '(#t #t)
        (let1 dirs (map (^_ (sys-mkdtemp "test.dir")) (iota 3))
          (begin0 (list (every file-is-directory? dirs)
-                       (equal? (car dirs) (cadr dirs))
-                       (equal? (cadr dirs) (caddr dirs))
-                       (equal? (caddr dirs) (car dirs)))
-                 (for-each sys-rmdir dirs))))
+                       (let1 sorted (sort dirs)
+                         (every (complement equal?) sorted (cdr sorted))))
+           (for-each sys-rmdir dirs))))
 
 ;;-------------------------------------------------------------------
 (test-section "time")

--- a/test/system.scm
+++ b/test/system.scm
@@ -374,6 +374,15 @@
   ]
  [else])
 
+;; sys-mkdtemp
+(test* "sys-mkdtemp" '(#t #f #f #f)
+       (let1 dirs (map (^_ (sys-mkdtemp "test.dir")) (iota 3))
+         (begin0 (list (every file-is-directory? dirs)
+                       (equal? (car dirs) (cadr dirs))
+                       (equal? (cadr dirs) (caddr dirs))
+                       (equal? (caddr dirs) (car dirs)))
+                 (for-each sys-rmdir dirs))))
+
 ;;-------------------------------------------------------------------
 (test-section "time")
 


### PR DESCRIPTION
This PR add sys-mkdtemp function.  Sometimes, making temporary directory is preferred over
temporary files.  Not tested on windows.
