### PR TITLE
Fix line continuation string

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -1080,6 +1080,7 @@ static ScmObj read_string(ScmPort *port, int incompletep,
         FETCH(c);
         switch (c) {
         case EOF: goto eof_exit;
+        doublequote:
         case '"': {
             int flags = ((incompletep? SCM_STRING_INCOMPLETE : 0)
                          | SCM_STRING_IMMUTABLE);
@@ -1116,7 +1117,7 @@ static ScmObj read_string(ScmPort *port, int incompletep,
             case '\t': {
                 for (;;) {
                     FETCH(c);
-                    if (c == EOF) goto eof_exit;
+                    if (c == EOF)  goto eof_exit;
                     if (c == '\r') goto cont_cr;
                     if (c == '\n') goto cont_lf;
                     if (!INTRALINE_WS(c)) goto cont_err;
@@ -1127,6 +1128,7 @@ static ScmObj read_string(ScmPort *port, int incompletep,
             case '\r': {
                 FETCH(c);
                 if (c == EOF)  goto eof_exit;
+                if (c == '"')  goto doublequote;
                 if (c == '\\') goto backslash;
                 if (c != '\n' && !INTRALINE_WS(c)) {
                     ACCUMULATE(c);
@@ -1138,7 +1140,8 @@ static ScmObj read_string(ScmPort *port, int incompletep,
             case '\n': {
                 for (;;) {
                     FETCH(c);
-                    if (c == EOF) goto eof_exit;
+                    if (c == EOF)  goto eof_exit;
+                    if (c == '"')  goto doublequote;
                     if (c == '\\') goto backslash;
                     if (!INTRALINE_WS(c)) {
                         ACCUMULATE(c);

--- a/test/string.scm
+++ b/test/string.scm
@@ -522,6 +522,12 @@
        (read (open-input-string "\"0123 \\   \n   4567\"")))
 (test* "line continuation" "0123-4567"
        (read (open-input-string "\"0123\\\n \\  \n -4567\"")))
+(test* "line continuation" "abcd"
+       (read (open-input-string "\"abcd\\\n\"")))
+(test* "line continuation" "abcd2"
+       (read (open-input-string "\"abcd2\\\r\n \"")))
+(test* "line continuation" "abcd3"
+       (read (open-input-string "\"abcd3\\\r\t\"")))
 (test* "line continuation (invalid)" (test-error)
        (read (open-input-string "\"1234\\ x\"")))
 


### PR DESCRIPTION
1. On line continuation string, if the next line begins with a doublequote character,
   it becomes a doublequote itself.
   
   ```
     "abcde\
     "
     →  "abcde\"  (This string is not complete.)
   ```
   It should be as follows. (R7RS 7.1.1.)
   
   ```
     "abcde\
     "
     →  "abcde"
   ```
   - src/read.c
   - test/string.scm


OS : Windows 8.1 (64bit)
DEVTOOL : MinGW32 (GCC v4.8.1, Runtime v3.21)
Total: 15862 tests, 15862 passed,     0 failed,     0 aborted.
