### PR TITLE
Change for MinGW-w64 (64bit/32bit) and MinGW.org (32bit)

### DIFF
--- a/ext/net/gauche-net.h
+++ b/ext/net/gauche-net.h
@@ -90,11 +90,11 @@ const char *inet_ntop(int af, const void *src, char *dst, socklen_t size);
 #define AI_ALL        0x00000100
 #define AI_ADDRCONFIG 0x00000400
 #define AI_V4MAPPED   0x00000800
-#if !defined(__MINGW64__)
+#if !defined(__MINGW64_VERSION_MAJOR)
 void WSAAPI freeaddrinfo(struct addrinfo*);
 int  WSAAPI getaddrinfo(const char*, const char*, const struct addrinfo*, struct addrinfo**);
-int  WSAAPI getnameinfo(const struct sockaddr*, socklen_t, char*,DWORD, char*,DWORD, int);
-#endif /*!defined(__MINGW64__)*/
+int  WSAAPI getnameinfo(const struct sockaddr*, socklen_t, char*, DWORD, char*, DWORD, int);
+#endif /*!defined(__MINGW64_VERSION_MAJOR)*/
 #endif /* HAVE_IPV6 */
 #endif /*GAUCHE_WINDOWS*/
 

--- a/src/gauche/system.h
+++ b/src/gauche/system.h
@@ -147,16 +147,16 @@ SCM_EXTERN ScmObj Scm_Int64SecondsToTime(ScmInt64 sec);
 SCM_EXTERN ScmObj Scm_RealSecondsToTime(double sec);
 SCM_EXTERN ScmObj Scm_TimeToSeconds(ScmTime *t);
 
-/* struct timespec compatibility handling.  Mingw 3.21, at least, has
+/* struct timespec compatibility handling.  MinGW32 runtime v3.21, at least, has
    incompatible struct timespec. */
-#if defined(HAVE_STRUCT_TIMESPEC) && !defined(GAUCHE_WINDOWS)
+#if defined(HAVE_STRUCT_TIMESPEC) && (!defined(GAUCHE_WINDOWS) || defined(__MINGW64_VERSION_MAJOR))
 typedef struct timespec ScmTimeSpec;
-#else
+#else  /*!(defined(HAVE_STRUCT_TIMESPEC) && (!defined(GAUCHE_WINDOWS) || defined(__MINGW64_VERSION_MAJOR)))*/
 typedef struct ScmTimeSpecRec {
     time_t tv_sec;
     long   tv_nsec;
 } ScmTimeSpec;
-#endif /*!HAVE_STRUCT_TIMESPEC && GAUCHE_WINDOWS*/
+#endif /*!(defined(HAVE_STRUCT_TIMESPEC) && (!defined(GAUCHE_WINDOWS) || defined(__MINGW64_VERSION_MAJOR)))*/
 
 SCM_EXTERN ScmTimeSpec *Scm_GetTimeSpec(ScmObj t, ScmTimeSpec *spec);
 

--- a/src/gauche/win-compat.h
+++ b/src/gauche/win-compat.h
@@ -44,9 +44,9 @@ typedef unsigned long u_long;
 #endif /* _BSDTYPES_DEFINED */
 
 /* Mingw-w64 only defines sigset_t when _POSIX is defined. */
-#if defined(__MINGW64__) && !defined(_POSIX)
+#if defined(__MINGW64_VERSION_MAJOR) && !defined(_POSIX)
 typedef _sigset_t sigset_t;
-#endif  /*defined(__MINGW64__) && !defined(_POSIX)*/
+#endif  /*defined(__MINGW64_VERSION_MAJOR) && !defined(_POSIX)*/
 
 
 /*======================================================================
@@ -203,7 +203,7 @@ int pipe(int fd[]);
 char *ttyname(int desc);
 unsigned int alarm(unsigned int seconds);
 
-#ifndef __MINGW64__
+#ifndef __MINGW64_VERSION_MAJOR
 int truncate(const char *path, off_t len);
 int ftruncate(int fd, off_t len);
 #endif

--- a/src/gauche/wthread.h
+++ b/src/gauche/wthread.h
@@ -127,7 +127,11 @@ typedef struct ScmInternalCondRec {
 #define SCM_INTERNAL_COND_INTR              2
 
 /* alternative timespec.  the definition is in system.h  */
+#if defined(__MINGW64_VERSION_MAJOR)
+#define ScmTimeSpecRec timespec
+#else  /*!defined(__MINGW64_VERSION_MAJOR)*/
 struct ScmTimeSpecRec;
+#endif /*!defined(__MINGW64_VERSION_MAJOR)*/
 
 SCM_EXTERN void Scm__InternalCondInit(ScmInternalCond *cond);
 SCM_EXTERN int  Scm__InternalCondSignal(ScmInternalCond *cond);
@@ -136,6 +140,10 @@ SCM_EXTERN int  Scm__InternalCondWait(ScmInternalCond *cond,
                                       ScmInternalMutex *mutex,
                                       struct ScmTimeSpecRec *pts);
 SCM_EXTERN void Scm__InternalCondDestroy(ScmInternalCond *cond);
+
+#if defined(__MINGW64_VERSION_MAJOR_)
+#undef ScmTimeSpecRec
+#endif /*defined(__MINGW64_VERSION_MAJOR)*/
 
 /* We don't provide fast lock */
 typedef HANDLE ScmInternalFastlock;

--- a/src/port.c
+++ b/src/port.c
@@ -367,7 +367,7 @@ int Scm_FdReady(int fd, int dir)
             int r;
             struct timeval tm;
             FD_ZERO(&fds);
-            FD_SET(h, &fds);
+            FD_SET((SOCKET)h, &fds);
             tm.tv_sec = tm.tv_usec = 0;
             /* NB: The first argument of select() is ignored on Windows */
             SCM_SYSCALL(r, select(0, &fds, NULL, NULL, &tm));

--- a/src/system.c
+++ b/src/system.c
@@ -1779,7 +1779,11 @@ ScmObj Scm_SysExec(ScmString *file, ScmObj args, ScmObj iomap,
         }
         /* TODO: We should probably use Windows API to handle various
            options consistently with fork-and-exec case above. */
+#if defined(__MINGW64_VERSION_MAJOR)
         execvp(program, (char *const*)argv);
+#else  /* !defined(__MINGW64_VERSION_MAJOR) */
+        execvp(program, (const char *const*)argv);
+#endif /* !defined(__MINGW64_VERSION_MAJOR) */
         Scm_Panic("exec failed: %s: %s", program, strerror(errno));
     }
     return SCM_FALSE; /* dummy */
@@ -2810,7 +2814,7 @@ static int win_truncate(HANDLE file, off_t len)
     return 0;
 }
 
-#ifndef __MINGW64__             /* MinGW64 has these */
+#ifndef __MINGW64_VERSION_MAJOR /* MinGW64 has these */
 
 int truncate(const char *path, off_t len)
 {
@@ -2842,7 +2846,7 @@ int ftruncate(int fd, off_t len)
     return 0;
 }
 
-#endif /* __MINGW64__ */
+#endif /* __MINGW64_VERSION_MAJOR */
 
 unsigned int alarm(unsigned int seconds)
 {


### PR DESCRIPTION
MSYS2/MinGW-w64 (64bit/32bit) と MinGW.org (32bitのみ) の各開発環境で、
コンパイルが通るようにしてみました。

各開発環境の検出方法は以下の通りです。

- シェルスクリプト (mingw-dist.sh) 内
  ```
  環境変数 MSYSTEM の内容で判別
    MINGW64  ==>  MSYS2/MinGW-w64 (64bit)
    MINGW32  ==>  MSYS2/MinGW-w64 (32bit)
    なし     ==>  MinGW.org (32bitのみ)
  ```

- C言語のソース内
  ```
  シンボルで判別
    __MINGW32__  ==>  MSYS2/MinGW-w64 (64bit/32bit), MinGW.org (32bitのみ)
    __MINGW64_VERSION_MAJOR
                 ==>  MSYS2/MinGW-w64 (64bit/32bit)
    __MINGW64__  ==>  MSYS2/MinGW-w64 (64bit)
  ```

＜環境＞
OS : Windows 8.1 (64bit)

開発環境1 : MSYS2/MinGW-w64 (64bit) (gcc version 5.3.0 (Rev1, Built by MSYS2 project))
Total: 15859 tests, 15859 passed,     0 failed,     0 aborted.

開発環境2 : MSYS2/MinGW-w64 (32bit) (gcc version 5.3.0 (Rev1, Built by MSYS2 project))
Total: 15859 tests, 15859 passed,     0 failed,     0 aborted.

開発環境3 : MinGW.org (32bitのみ) (gcc v4.8.1)
Total: 15862 tests, 15862 passed,     0 failed,     0 aborted.


＜その他、不具合等＞

1. MSYS2/MinGW-w64 (64bit/32bit) 環境で、tlsのテストが固まる。
   どうも openssl.exe の種類によって、OKのものとNGのものがあるようです(詳細原因不明)。
   ```
   c:\msys64\mingw64\bin\openssl.exe  ==> NG
   c:\msys64\mingw32\bin\openssl.exe  ==> NG
   c:\msys64\usr\bin\openssl.exe      ==> OK
   ```
   NGのものを消すかリネームすれば、テストが成功するようになります。

2. gdbm のテストが通らない。デフォルトでインストールされるものはどれもNGのようです。
   (多分、Windows用のパッチを当てないと、まともに動かない)
   とりあえず mingw-dist.sh の configure オプションで、
   --with-dbm=ndbm,odbm として、gdbm は外すようにしました。
