### PR TITLE
Fix configure option --enable-tls=none

### DIFF
--- a/ext/tls/gauche-tls.h
+++ b/ext/tls/gauche-tls.h
@@ -43,7 +43,16 @@
 
 #if defined(GAUCHE_USE_AXTLS)
 #include "axTLS/ssl/ssl.h"
-#endif /*GAUCHE_USE_AXTLS*/
+#else /*!GAUCHE_USE_AXTLS*/
+#define SSL_CLIENT_AUTHENTICATION               0x00010000
+#define SSL_SERVER_VERIFY_LATER                 0x00020000
+#define SSL_NO_DEFAULT_KEY                      0x00040000
+#define SSL_DISPLAY_STATES                      0x00080000
+#define SSL_DISPLAY_BYTES                       0x00100000
+#define SSL_DISPLAY_CERTS                       0x00200000
+#define SSL_DISPLAY_RSA                         0x00400000
+#define SSL_CONNECT_IN_PARTS                    0x00800000
+#endif /*!GAUCHE_USE_AXTLS*/
 
 SCM_DECL_BEGIN
 

--- a/lib/rfc/http.scm
+++ b/lib/rfc/http.scm
@@ -83,7 +83,7 @@
           mime-compose-parameters
           mime-parse-content-type)
 (autoload rfc.tls
-          make-tls tls-connect tls-input-port tls-output-port tls-close)
+          make-tls tls-destroy tls-connect tls-input-port tls-output-port tls-close)
 
 (autoload file.util file-size find-file-in-paths null-device)
 


### PR DESCRIPTION
If configure option '--enable-tls=none' is specified, a compilation error occurs.
This patch fixes the error.
