### PR TITLE
Refine shell command syntax for our Autoconf macro

### DIFF
--- a/m4/gauche.m4
+++ b/m4/gauche.m4
@@ -150,7 +150,7 @@ dnl   Creates a Gauche package description file.
 dnl
 AC_DEFUN([AC_GAUCHE_MAKE_GPD],
 	 [
-GAUCHE_PACKAGE_CONFIGURE_ARGS="`echo ""$ac_configure_args"" | sed 's/[\\""\`\$]/\\\&/g'`"
+GAUCHE_PACKAGE_CONFIGURE_ARGS=`echo "$ac_configure_args" | sed 's/@<:@\\"\`\$@:>@/\\\\&/g'`
 AC_MSG_NOTICE([creating ${PACKAGE_NAME}.gpd])
 $GAUCHE_PACKAGE make-gpd "$PACKAGE_NAME" \
   -version "$PACKAGE_VERSION" \


### PR DESCRIPTION
This fix is also known as 0c36c0e88e1ff2633cae6b56929afad96607834e
