### PR TITLE
Windows installer 64bit support

### DIFF
--- a/winnt/wix/Makefile
+++ b/winnt/wix/Makefile
@@ -1,15 +1,31 @@
 MORE_CONTENT = Gauche/COPYING.rtf \
 	       Gauche/gauche-logo.ico
 
-all: stamp.0
+ifeq ($(MSYSTEM),MINGW64)
+  ARCH_SUFFIX=-64bit
+  GENWXS_OPTION=--arch=x64
+  CANDLE_OPTION=-arch x64
+else ifeq ($(MSYSTEM),MINGW32)
+  ARCH_SUFFIX=-32bit
+  GENWXS_OPTION=
+  CANDLE_OPTION=
+else
+  ARCH_SUFFIX=
+  GENWXS_OPTION=
+  CANDLE_OPTION=
+endif
 
-stamp.0 : genwxs.scm Gauche $(MORE_CONTENT)
-	rm -f gauche.wxs *.msi
-	../../src/gosh -ftest ./genwxs.scm gauche.wxs
-	candle gauche.wxs
-	light -ext WixUIExtension -sice:ICE61 gauche.wixobj
-	mv gauche.msi Gauche-mingw-`Gauche/bin/gauche-config -V`.msi
-	touch stamp.0
+INSTALLER_FILENAME=Gauche-mingw-`Gauche/bin/gauche-config -V`$(ARCH_SUFFIX).msi
+
+all: stamp$(ARCH_SUFFIX).0
+
+stamp$(ARCH_SUFFIX).0 : genwxs.scm Gauche $(MORE_CONTENT)
+	rm -f gauche$(ARCH_SUFFIX).wxs $(INSTALLER_FILENAME)
+	../../src/gosh -ftest ./genwxs.scm $(GENWXS_OPTION) gauche$(ARCH_SUFFIX).wxs
+	candle $(CANDLE_OPTION) gauche$(ARCH_SUFFIX).wxs
+	light -ext WixUIExtension -sice:ICE61 gauche$(ARCH_SUFFIX).wixobj
+	mv gauche$(ARCH_SUFFIX).msi $(INSTALLER_FILENAME)
+	touch stamp$(ARCH_SUFFIX).0
 
 Gauche/COPYING.rtf : txt2rtf.scm
 	../../src/gosh -ftest ./txt2rtf.scm ../../COPYING Gauche/COPYING.rtf
@@ -18,4 +34,4 @@ Gauche/gauche-logo.ico : gauche-logo.ico
 	cp gauche-logo.ico Gauche/
 
 clean:
-	rm -f stamp.0 *.wxs *.msi *.wixobj *.wixpdb *.log *~
+	rm -f stamp*.0 *.wxs *.msi *.wixobj *.wixpdb *.log *~


### PR DESCRIPTION
- 64bit版のインストーラを作成可能にしました。

- MSYS2/MinGW-w64 (64bit) 環境だった場合に、
  wxs ファイル内の ProgramFilesFolder を ProgramFiles64Folder に切り換えて、
  candle コマンドのオプションに -arch x64 を付けることで、
  64bit版のインストーラを作成します。

- また、heat コマンドで 64bit 版のファイルを検索するとエラーが出たため、
  `-sreg` オプションを追加しました。

- インストーラのファイル名は、以下のようにしました。
  ```
  Gauche-mingw-0.9.5_pre1-64bit.msi  :  MSYS2/MinGW-w64 (64bit) 環境のとき
  Gauche-mingw-0.9.5_pre1-32bit.msi  :  MSYS2/MinGW-w64 (32bit) 環境のとき
  Gauche-mingw-0.9.5_pre1.msi        :  MinGW.org (32bitのみ) 環境のとき
  ```
  (0.9.5_pre1の部分はGaucheのバージョンによって変わります)

- 64bit版のインストーラは、デフォルトで、
  c:\Program Files
  の下にインストールを行います( (x86) が付きません )。

- 32bit版のインストールとの共存はできないので、事前にアンインストールが必要です。
  (Gaucheのフォルダごと取っておいて使い分けることは可能です)


＜環境＞
OS : Windows 8.1 (64bit)
開発環境1 : MSYS2/MinGW-w64 (64bit) (gcc version 5.3.0 (Rev1, Built by MSYS2 project))
開発環境2 : MSYS2/MinGW-w64 (32bit) (gcc version 5.3.0 (Rev1, Built by MSYS2 project))
開発環境3 : MinGW.org (32bitのみ) (gcc v4.8.1)
インストーラ作成ツール : WiX v3.10.1 (Stable)
