### PR TITLE
a return statement was missing in make_trapper_port

### DIFF
--- a/src/port.c
+++ b/src/port.c
@@ -1981,6 +1981,7 @@ static ScmObj make_trapper_port(ScmObj name, int direction,
     bufrec.seeker = NULL;
     ScmObj p = Scm_MakeBufferedPort(SCM_CLASS_PORT, name, direction, TRUE,
                                     &bufrec);
+    return p;
 }
 
 /* This is supposed to be called from application main(), before any


### PR DESCRIPTION
port.c の make_trapper_port 関数に return 命令が抜けていました!!
本当にたまたま動いていたようです。申し訳ありません。

CFLAGS をいろいろ変えていたら gosh-noconsole.exe だけ動かなくなったので気が付きました。。。
