### PR TITLE
Re-do Cygwin64 patch

### DIFF
--- a/gc/include/gc.h
+++ b/gc/include/gc.h
@@ -1595,11 +1595,19 @@ GC_API int GC_CALL GC_get_force_unmap_on_gcollect(void);
 #if defined(__CYGWIN32__) || defined(__CYGWIN__)
   /* Similarly gnu-win32 DLLs need explicit initialization from the     */
   /* main program, as does AIX.                                         */
+# ifdef __x86_64__
+  extern int __data_start__[], __data_end__[], __bss_start__[], __bss_end__[];
+#  define GC_DATASTART (__data_start__ < __bss_start__ ? \
+                        (void *)__data_start__ : (void *)__bss_start__)
+#  define GC_DATAEND (__data_end__ > __bss_end__ ? \
+                      (void *)__data_end__ : (void *)__bss_end__)
+# else
   extern int _data_start__[], _data_end__[], _bss_start__[], _bss_end__[];
-# define GC_DATASTART ((GC_word)_data_start__ < (GC_word)_bss_start__ ? \
-                       (void *)_data_start__ : (void *)_bss_start__)
-# define GC_DATAEND ((GC_word)_data_end__ > (GC_word)_bss_end__ ? \
-                     (void *)_data_end__ : (void *)_bss_end__)
+#  define GC_DATASTART ((GC_word)_data_start__ < (GC_word)_bss_start__ ? \
+                        (void *)_data_start__ : (void *)_bss_start__)
+#  define GC_DATAEND ((GC_word)_data_end__ > (GC_word)_bss_end__ ? \
+                      (void *)_data_end__ : (void *)_bss_end__)
+# endif
 # define GC_INIT_CONF_ROOTS GC_add_roots(GC_DATASTART, GC_DATAEND); \
                                  GC_gcollect() /* For blacklisting. */
         /* Required at least if GC is in a DLL.  And doesn't hurt. */


### PR DESCRIPTION
From: https://github.com/okuoku/yunibase/issues/5

It seems released `0.9.4` and `master` branch dropped ability building on Cygwin64 at some point. This patch redo the change. Patched `0.9.4` and `master` successfully bootstrapped https://github.com/shirok/Gauche/commit/116a788f8c0046440609506e344d9ab1b99a321c

Two (f)stat related tests fails on Cygwin64. I'm still digg'in down the issue and trying find out why..

```
CYGWIN_NT-6.3 spring 2.4.1(0.293/5/3) 2016-01-24 11:26 x86_64 Cygwin
```