### PR TITLE
doc example code fixes

### DIFF
--- a/doc/corelib.texi
+++ b/doc/corelib.texi
@@ -4977,7 +4977,7 @@ is the same (@code{eq?}) to which.
 @c COMMON
 
 @example
-(let1 s '#:foo) (list s s))
+(let1 s '#:foo (list s s))
   @result{} @r{prints} (#0=#:foo #0#)
 
 (let ((s '#:foo) (t '#:foo)) (list s t s t))

--- a/doc/modgauche.texi
+++ b/doc/modgauche.texi
@@ -1817,6 +1817,7 @@ After running this code you'll get @code{my-cfile.c} and
 @code{my-cfile.h} in the current directory.
 
 @example
+(use gauche.parameter)
 (use gauche.cgen)
 
 (define *unit* (make <cgen-unit> :name "my-cfile"))


### PR DESCRIPTION
As for cgen example, text says it will create both .c and .h but it actually only creates .c file.
I am not sure whether we should fix text or (cgen-unit-h-file).

By the way, how about putting parameterize into core library?
