### PR TITLE
Incompatible update for blowfish crypt module

### DIFF
--- a/doc/modutil.texi
+++ b/doc/modutil.texi
@@ -1632,6 +1632,7 @@ The @var{prefix} argument specifies the version/scheme of
 password hashing.  Currently @code{$2a$} and @code{$2b$} are supported,
 which means the blowfish algorithm compatible to bcrypt.
 But @code{$2a$} is vulnerable. Use @code{$2b$} for new code.
+If you omit @var{prefix}, use @code{$2b$} for default value.
 
 The @var{count} arugment specifies the amount of iterations;
 the larger the value is, the more time is required to calculate
@@ -1653,6 +1654,7 @@ a random bytes.  For bcrypt algorithm it must be at least 16 octet long.
 されています。
 ただし、@code{$2a$}には脆弱性が発見されていますので、
 新規のコードには@code{$2b$}を使用して下さい。
+@var{perfix}引数を省略した場合は@code{$2b$}が用いられます。
 
 @var{count}引数はハッシュの繰り返し回数に関係します。大きな値を指定すれば、
 ハッシュ値の計算により長い時間がかかります。パスワードハッシュにおいては、

--- a/ext/bcrypt/bcrypt.scm
+++ b/ext/bcrypt/bcrypt.scm
@@ -43,7 +43,7 @@
 (define (bcrypt-hashpw pass :optional (setting #f))
   (crypt-ra pass (or setting (bcrypt-gensalt))))
 
-(define (bcrypt-gensalt :key (prefix "$2a$") (count 10) (entropy-source #f))
+(define (bcrypt-gensalt :key (prefix "$2b$") (count 10) (entropy-source #f))
   (crypt-gensalt-ra prefix count (or entropy-source (get-entropy))))
 
 (define-constant +esize+ 16)

--- a/ext/bcrypt/test.scm
+++ b/ext/bcrypt/test.scm
@@ -105,7 +105,27 @@
 (test-wrong-hash "method is larger than 'z'"
 		 "$2{$05$CCCCCCCCCCCCCCCCCCCCC.")
 
-(test* "bcrypt-gensalt" "$2a$12$"
+(test* "bcrypt-gensalt" "$2b$10$"
+       (string-take (bcrypt-gensalt) 7))
+(test* "bcrypt-gensalt" "$2b$12$"
        (string-take (bcrypt-gensalt :count 12) 7))
+(test* "bcrypt-gensalt 'a'" "$2a$12$"
+       (string-take (bcrypt-gensalt :prefix "$2a$" :count 12) 7))
+(test* "bcrypt-gensalt 'b'" "$2b$12$"
+       (string-take (bcrypt-gensalt :prefix "$2b$" :count 12) 7))
+
+(test* "bcrypt-gensalt count smaller than 4" (test-error)
+       (bcrypt-gensalt :count 3))
+(test* "bcrypt-gensalt count larger than 31" (test-error)
+       (bcrypt-gensalt :count 32))
+
+(test* "bcrypt-gensalt not implemented prefix 'c'" (test-error)
+       (bcrypt-gensalt :prefix "$2c$"))
+(test* "bcrypt-gensalt not implemented prefix 'z'" (test-error)
+       (bcrypt-gensalt :prefix "$2z$"))
+(test* "bcrypt-gensalt prefix smaller than 'a' (`)" (test-error)
+       (bcrypt-gensalt :prefix "$2`$"))
+(test* "bcrypt-gensalt prefix larger than 'z' ({)" (test-error)
+       (bcrypt-gensalt :prefix "$2{$"))
 
 (test-end)


### PR DESCRIPTION
Change `bcrypt` default algorithm to `$2b$`

`$2a$` is vulnerable. Don't use for new code. It's incompatible update from previous version.
