### PR TITLE
Change REPL's skipping white space procedure

### DIFF
--- a/lib/gauche/interactive.scm
+++ b/lib/gauche/interactive.scm
@@ -252,13 +252,13 @@
         expr))))
 
 (define (%skip-trailing-ws)
-  (if (byte-ready?)
-    (let1 b (peek-byte)
-      (cond [(memv b '(9 32)) (read-byte) (%skip-trailing-ws)]
-            [(eqv? b 13)
-             (read-byte)
-             (when (and (byte-ready?) (eqv? (peek-byte) 10)) (read-byte))]
-            [(eqv? b 10) (read-byte)]
+  (if (char-ready?)
+    (let1 c (peek-char)
+      (cond [(memv c '(#\tab #\space)) (read-char) (%skip-trailing-ws)]
+            [(eqv? c #\return)
+             (read-char)
+             (when (and (char-ready?) (eqv? (peek-char) #\newline)) (read-char))]
+            [(eqv? c #\newline) (read-char)]
             [else #t]))
     #t))
 


### PR DESCRIPTION
gauche.interactive の %skip-trailing-ws で、peek-byte を peek-char に変更しました。

正常な文字列が入力されている場合は、動作に違いはありませんが、
不正なバイト列が入力された場合には、動作が変わってきます。

例えば、REPL 上で SJIS の「1 あ」 (1とあの間に半角スペースあり) が入力されると、
元の %skip-trailing-ws の処理だと、Gauche が終了します。

これは、read 内で peek-byte で先読みした1バイトによって、
SCM_CHAR_PUT (=Scm_CharUtf8Putc) でバイト列を UTF-8 に変換する前に
SCM_CHAR_GET (=Scm_CharUtf8Getc) でバイト列がチェックされ、
結果が SCM_CHAR_INVALID = -1 となるため、EOF と判定されて終了することになります。

特に不正な処理ではないと思いますが、read と同じ結果になった方が分かりやすいと思い、
変更しました。
