### PR TITLE
rfc.tls server side support

### DIFF
--- a/ext/tls/gauche-tls.h
+++ b/ext/tls/gauche-tls.h
@@ -52,6 +52,11 @@
 #define SSL_DISPLAY_CERTS                       0x00200000
 #define SSL_DISPLAY_RSA                         0x00400000
 #define SSL_CONNECT_IN_PARTS                    0x00800000
+#define SSL_OBJ_X509_CERT                       1
+#define SSL_OBJ_X509_CACERT                     2
+#define SSL_OBJ_RSA_KEY                         3
+#define SSL_OBJ_PKCS8                           4
+#define SSL_OBJ_PKCS12                          5
 #endif /*!GAUCHE_USE_AXTLS*/
 
 SCM_DECL_BEGIN
@@ -73,6 +78,9 @@ SCM_CLASS_DECL(Scm_TLSClass);
 
 extern ScmObj Scm_MakeTLS(uint32_t options, int num_sessions);
 extern ScmObj Scm_TLSDestroy(ScmTLS* t);
+extern ScmObj Scm_TLSLoadObject(ScmTLS* t, ScmObj obj_type,
+                                const char *filename,
+                                const char *password);
 extern ScmObj Scm_TLSConnect(ScmTLS* t, int fd);
 extern ScmObj Scm_TLSAccept(ScmTLS* t, int fd);
 extern ScmObj Scm_TLSClose(ScmTLS* t);

--- a/ext/tls/gauche-tls.h
+++ b/ext/tls/gauche-tls.h
@@ -74,6 +74,7 @@ SCM_CLASS_DECL(Scm_TLSClass);
 extern ScmObj Scm_MakeTLS(uint32_t options, int num_sessions);
 extern ScmObj Scm_TLSDestroy(ScmTLS* t);
 extern ScmObj Scm_TLSConnect(ScmTLS* t, int fd);
+extern ScmObj Scm_TLSAccept(ScmTLS* t, int fd);
 extern ScmObj Scm_TLSClose(ScmTLS* t);
 
 /*

--- a/ext/tls/tls.c
+++ b/ext/tls/tls.c
@@ -122,6 +122,16 @@ ScmObj Scm_TLSConnect(ScmTLS* t, int fd)
     return SCM_OBJ(t);
 }
 
+ScmObj Scm_TLSAccept(ScmTLS* t, int fd)
+{
+#if defined(GAUCHE_USE_AXTLS)
+    context_check(t, "accept");
+    if (t->conn) Scm_SysError("attempt to connect already-connected TLS %S", t);
+    t->conn = ssl_server_new(t->ctx, fd);
+#endif /*GAUCHE_USE_AXTLS*/
+    return SCM_OBJ(t);
+}
+
 ScmObj Scm_TLSRead(ScmTLS* t)
 {
 #if defined(GAUCHE_USE_AXTLS)

--- a/ext/tls/tls.c
+++ b/ext/tls/tls.c
@@ -108,6 +108,17 @@ ScmObj Scm_TLSClose(ScmTLS* t)
     return SCM_TRUE;
 }
 
+ScmObj Scm_TLSLoadObject(ScmTLS* t, ScmObj obj_type,
+                         const char *filename, const char *password)
+{
+#if defined(GAUCHE_USE_AXTLS)
+    uint32_t type = Scm_GetIntegerU32Clamp(obj_type, SCM_CLAMP_ERROR, NULL);
+    if (ssl_obj_load(t->ctx, type, filename, password) == SSL_OK)
+        return SCM_TRUE;
+#endif /*GAUCHE_USE_AXTLS*/
+    return SCM_FALSE;
+}
+
 ScmObj Scm_TLSConnect(ScmTLS* t, int fd)
 {
 #if defined(GAUCHE_USE_AXTLS)

--- a/ext/tls/tls.scm
+++ b/ext/tls/tls.scm
@@ -36,12 +36,14 @@
 (define-module rfc.tls
   (use gauche.vport)
   (export <tls> make-tls tls-destroy tls-connect tls-accept tls-close
-          tls-read tls-write
+          tls-load-object tls-read tls-write
           tls-input-port tls-output-port
 
           SSL_SERVER_VERIFY_LATER SSL_CLIENT_AUTHENTICATION
           SSL_DISPLAY_BYTES SSL_DISPLAY_STATES SSL_DISPLAY_CERTS
-          SSL_DISPLAY_RSA SSL_CONNECT_IN_PARTS)
+          SSL_DISPLAY_RSA SSL_CONNECT_IN_PARTS SSL_NO_DEFAULT_KEY
+          SSL_OBJ_X509_CERT SSL_OBJ_X509_CACERT SSL_OBJ_RSA_KEY
+          SSL_OBJ_PKCS8 SSL_OBJ_PKCS12)
   )
 (select-module rfc.tls)
 
@@ -52,11 +54,17 @@
 
  (define-enum SSL_SERVER_VERIFY_LATER)
  (define-enum SSL_CLIENT_AUTHENTICATION)
+ (define-enum SSL_NO_DEFAULT_KEY)
  (define-enum SSL_DISPLAY_BYTES)
  (define-enum SSL_DISPLAY_STATES)
  (define-enum SSL_DISPLAY_CERTS)
  (define-enum SSL_DISPLAY_RSA)
  (define-enum SSL_CONNECT_IN_PARTS)
+ (define-enum SSL_OBJ_X509_CERT)
+ (define-enum SSL_OBJ_X509_CACERT)
+ (define-enum SSL_OBJ_RSA_KEY)
+ (define-enum SSL_OBJ_PKCS8)
+ (define-enum SSL_OBJ_PKCS12)
  
  (define-cproc make-tls (:optional flags (num-sessions::<int> 0))
    ;; NB: By default, we don't support certificate validation/trust.
@@ -66,6 +74,8 @@
      (when (SCM_INTEGERP flags)
        (set! f (Scm_GetIntegerU32Clamp flags SCM_CLAMP_ERROR NULL)))
      (return (Scm_MakeTLS f num-sessions))))
+ (define-cproc tls-load-object (tls::<tls> obj-type filename::<const-cstring>
+                                           :optional (password::<const-cstring>? #f)) Scm_TLSLoadObject)
  (define-cproc tls-destroy (tls::<tls>) Scm_TLSDestroy)
  (define-cproc %tls-connect (tls::<tls> fd::<long>) Scm_TLSConnect)
  (define-cproc %tls-accept (tls::<tls> fd::<long>) Scm_TLSAccept)

--- a/ext/tls/tls.scm
+++ b/ext/tls/tls.scm
@@ -35,7 +35,8 @@
 
 (define-module rfc.tls
   (use gauche.vport)
-  (export <tls> make-tls tls-destroy tls-connect tls-close tls-read tls-write
+  (export <tls> make-tls tls-destroy tls-connect tls-accept tls-close
+          tls-read tls-write
           tls-input-port tls-output-port
 
           SSL_SERVER_VERIFY_LATER SSL_CLIENT_AUTHENTICATION
@@ -67,6 +68,7 @@
      (return (Scm_MakeTLS f num-sessions))))
  (define-cproc tls-destroy (tls::<tls>) Scm_TLSDestroy)
  (define-cproc %tls-connect (tls::<tls> fd::<long>) Scm_TLSConnect)
+ (define-cproc %tls-accept (tls::<tls> fd::<long>) Scm_TLSAccept)
  (define-cproc %tls-close (tls::<tls>) Scm_TLSClose)
  (define-cproc tls-read (tls::<tls>) Scm_TLSRead)
  (define-cproc tls-write (tls::<tls> msg) Scm_TLSWrite)
@@ -83,6 +85,13 @@
 ;; API
 (define (tls-connect tls fd)
   (%tls-connect tls fd) ;; done before ports in case of connect failure.
+  (tls-input-port-set! tls (make-tls-input-port tls))
+  (tls-output-port-set! tls (make-tls-output-port tls))
+  tls)
+
+;; API
+(define (tls-accept tls fd)
+  (%tls-accept tls fd) ;; done before ports in case of connect failure.
   (tls-input-port-set! tls (make-tls-input-port tls))
   (tls-output-port-set! tls (make-tls-output-port tls))
   tls)


### PR DESCRIPTION
These two patches add bindings for ssl_server_new and ssl_obj_load. With this I can add https support to Gauche-makiki [1]. I only tested with self-signed certificate but it seemed to work ok.

[1] https://github.com/pclouds/Gauche-makiki/commits/master