### PR TITLE
Fix bcrypt test (encoding=sjis, eucjp)

### DIFF
--- a/ext/bcrypt/test.scm
+++ b/ext/bcrypt/test.scm
@@ -1,5 +1,6 @@
 (use gauche.test)
 (use srfi-13)
+(use gauche.uvector)
 (test-start "bcrypt")
 
 (use crypt.bcrypt)
@@ -23,67 +24,74 @@
 	      ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789\
 	      chars after 72 are ignored")
 (test-hashpw "$2x$05$/OK.fbVrR/bpIqNJ5ianF.CE5elHaaO4EbggVDjb8P19RukzXSM3e"
-	     #*"\xa3;")
+	     (u8vector->string #u8(#xa3)))
 (test-hashpw "$2x$05$/OK.fbVrR/bpIqNJ5ianF.CE5elHaaO4EbggVDjb8P19RukzXSM3e"
-	     #*"\xff;\xff;\xa3;")
+	     (u8vector->string #u8(#xff #xff #xa3)))
 (test-hashpw "$2y$05$/OK.fbVrR/bpIqNJ5ianF.CE5elHaaO4EbggVDjb8P19RukzXSM3e"
-	     #*"\xff;\xff;\xa3;")
+	     (u8vector->string #u8(#xff #xff #xa3)))
 (test-hashpw "$2a$05$/OK.fbVrR/bpIqNJ5ianF.nqd1wy.pTMdcvrRWxyiGL2eMz.2a85."
-	     #*"\xff;\xff;\xa3;")
+	     (u8vector->string #u8(#xff #xff #xa3)))
 (test-hashpw "$2b$05$/OK.fbVrR/bpIqNJ5ianF.CE5elHaaO4EbggVDjb8P19RukzXSM3e"
-	     #*"\xff;\xff;\xa3;")
+	     (u8vector->string #u8(#xff #xff #xa3)))
 (test-hashpw "$2y$05$/OK.fbVrR/bpIqNJ5ianF.Sa7shbm4.OzKpvFnX1pQLmQW96oUlCq"
-	     #*"\xa3;")
+	     (u8vector->string #u8(#xa3)))
 (test-hashpw "$2a$05$/OK.fbVrR/bpIqNJ5ianF.Sa7shbm4.OzKpvFnX1pQLmQW96oUlCq"
-	     #*"\xa3;")
+	     (u8vector->string #u8(#xa3)))
 (test-hashpw "$2b$05$/OK.fbVrR/bpIqNJ5ianF.Sa7shbm4.OzKpvFnX1pQLmQW96oUlCq"
-	     #*"\xa3;")
+	     (u8vector->string #u8(#xa3)))
 (test-hashpw "$2x$05$/OK.fbVrR/bpIqNJ5ianF.o./n25XVfn6oAPaUvHe.Csk4zRfsYPi"
-	     #*"1\xa3;345")
+	     (string-append "1" (u8vector->string #u8(#xa3)) "345"))
 (test-hashpw "$2x$05$/OK.fbVrR/bpIqNJ5ianF.o./n25XVfn6oAPaUvHe.Csk4zRfsYPi"
-	     #*"\xff;\xa3;345")
+	     (string-append (u8vector->string #u8(#xff #xa3)) "345"))
 (test-hashpw "$2x$05$/OK.fbVrR/bpIqNJ5ianF.o./n25XVfn6oAPaUvHe.Csk4zRfsYPi"
-	     #*"\xff;\xa3;34\xff;\xff;\xff;\xa3;345")
+	     (string-append (u8vector->string #u8(#xff #xa3)) "34"
+	                    (u8vector->string #u8(#xff #xff #xff #xa3)) "345"))
 (test-hashpw "$2y$05$/OK.fbVrR/bpIqNJ5ianF.o./n25XVfn6oAPaUvHe.Csk4zRfsYPi"
-	     #*"\xff;\xa3;34\xff;\xff;\xff;\xa3;345")
+	     (string-append (u8vector->string #u8(#xff #xa3)) "34"
+			    (u8vector->string #u8(#xff #xff #xff #xa3)) "345"))
 (test-hashpw "$2a$05$/OK.fbVrR/bpIqNJ5ianF.ZC1JEJ8Z4gPfpe1JOr/oyPXTWl9EFd."
-	     #*"\xff;\xa3;34\xff;\xff;\xff;\xa3;345")
+	     (string-append (u8vector->string #u8(#xff #xa3)) "34"
+			    (u8vector->string #u8(#xff #xff #xff #xa3)) "345"))
 (test-hashpw "$2y$05$/OK.fbVrR/bpIqNJ5ianF.nRht2l/HRhr6zmCp9vYUvvsqynflf9e"
-	     #*"\xff;\xa3;345")
+	     (string-append (u8vector->string #u8(#xff #xa3)) "345"))
 (test-hashpw "$2a$05$/OK.fbVrR/bpIqNJ5ianF.nRht2l/HRhr6zmCp9vYUvvsqynflf9e"
-	     #*"\xff;\xa3;345")
+	     (string-append (u8vector->string #u8(#xff #xa3)) "345"))
 (test-hashpw "$2a$05$/OK.fbVrR/bpIqNJ5ianF.6IflQkJytoRVc1yuaNtHfiuq.FRlSIS"
-	     #*"\xa3;ab")
+	     (string-append (u8vector->string #u8(#xa3)) "ab"))
 (test-hashpw "$2x$05$/OK.fbVrR/bpIqNJ5ianF.6IflQkJytoRVc1yuaNtHfiuq.FRlSIS"
-	     #*"\xa3;ab")
+	     (string-append (u8vector->string #u8(#xa3)) "ab"))
 (test-hashpw "$2y$05$/OK.fbVrR/bpIqNJ5ianF.6IflQkJytoRVc1yuaNtHfiuq.FRlSIS"
-	     #*"\xa3;ab")
+	     (string-append (u8vector->string #u8(#xa3)) "ab"))
 (test-hashpw "$2x$05$6bNw2HLQYeqHYyBfLMsv/OiwqTymGIGzFsA4hOTWebfehXHNprcAS"
-	     #*"\xd1;\x91;")
+	     (u8vector->string #u8(#xd1 #x91)))
 (test-hashpw "$2x$05$6bNw2HLQYeqHYyBfLMsv/O9LIGgn8OMzuDoHfof8AQimSGfcSWxnS"
-	     #*"\xd0;\xc1;\xd2;\xcf;\xcc;\xd8;")
+	     (u8vector->string #u8(#xd0 #xc1 #xd2 #xcf #xcc #xd8)))
 (test-hashpw "$2a$05$/OK.fbVrR/bpIqNJ5ianF.swQOIzjOiJ9GHEPuhEkvqrUyvWhEMx6"
-	     #*"\xaa;\xaa;\xaa;\xaa;\xaa;\xaa;\xaa;\xaa;\xaa;\xaa;\xaa;\xaa;\
-	        \xaa;\xaa;\xaa;\xaa;\xaa;\xaa;\xaa;\xaa;\xaa;\xaa;\xaa;\xaa;\
-	        \xaa;\xaa;\xaa;\xaa;\xaa;\xaa;\xaa;\xaa;\xaa;\xaa;\xaa;\xaa;\
-	        \xaa;\xaa;\xaa;\xaa;\xaa;\xaa;\xaa;\xaa;\xaa;\xaa;\xaa;\xaa;\
-	        \xaa;\xaa;\xaa;\xaa;\xaa;\xaa;\xaa;\xaa;\xaa;\xaa;\xaa;\xaa;\
-	        \xaa;\xaa;\xaa;\xaa;\xaa;\xaa;\xaa;\xaa;\xaa;\xaa;\xaa;\xaa;\
-	        chars after 72 are ignored as usual")
+	     (string-append
+	      (u8vector->string
+	       #u8(#xaa #xaa #xaa #xaa #xaa #xaa #xaa #xaa #xaa #xaa #xaa #xaa
+		   #xaa #xaa #xaa #xaa #xaa #xaa #xaa #xaa #xaa #xaa #xaa #xaa
+		   #xaa #xaa #xaa #xaa #xaa #xaa #xaa #xaa #xaa #xaa #xaa #xaa
+		   #xaa #xaa #xaa #xaa #xaa #xaa #xaa #xaa #xaa #xaa #xaa #xaa
+		   #xaa #xaa #xaa #xaa #xaa #xaa #xaa #xaa #xaa #xaa #xaa #xaa
+		   #xaa #xaa #xaa #xaa #xaa #xaa #xaa #xaa #xaa #xaa #xaa #xaa))
+	      "chars after 72 are ignored as usual"))
 (test-hashpw "$2a$05$/OK.fbVrR/bpIqNJ5ianF.R9xrDjiycxMbQE2bp.vgqlYpW5wx2yy"
-	     #*"\xaa;\x55;\xaa;\x55;\xaa;\x55;\xaa;\x55;\xaa;\x55;\xaa;\x55;\
-	        \xaa;\x55;\xaa;\x55;\xaa;\x55;\xaa;\x55;\xaa;\x55;\xaa;\x55;\
-	        \xaa;\x55;\xaa;\x55;\xaa;\x55;\xaa;\x55;\xaa;\x55;\xaa;\x55;\
-	        \xaa;\x55;\xaa;\x55;\xaa;\x55;\xaa;\x55;\xaa;\x55;\xaa;\x55;\
-	        \xaa;\x55;\xaa;\x55;\xaa;\x55;\xaa;\x55;\xaa;\x55;\xaa;\x55;\
-	        \xaa;\x55;\xaa;\x55;\xaa;\x55;\xaa;\x55;\xaa;\x55;\xaa;\x55;")
+	     (u8vector->string
+	      #u8(#xaa #x55 #xaa #x55 #xaa #x55 #xaa #x55 #xaa #x55 #xaa #x55
+		  #xaa #x55 #xaa #x55 #xaa #x55 #xaa #x55 #xaa #x55 #xaa #x55
+		  #xaa #x55 #xaa #x55 #xaa #x55 #xaa #x55 #xaa #x55 #xaa #x55
+		  #xaa #x55 #xaa #x55 #xaa #x55 #xaa #x55 #xaa #x55 #xaa #x55
+		  #xaa #x55 #xaa #x55 #xaa #x55 #xaa #x55 #xaa #x55 #xaa #x55
+		  #xaa #x55 #xaa #x55 #xaa #x55 #xaa #x55 #xaa #x55 #xaa #x55)))
 (test-hashpw "$2a$05$/OK.fbVrR/bpIqNJ5ianF.9tQZzcJfm3uj2NvJ/n5xkhpqLrMpWCe"
-	     #*"\x55;\xaa;\xff;\x55;\xaa;\xff;\x55;\xaa;\xff;\x55;\xaa;\xff;\
-	        \x55;\xaa;\xff;\x55;\xaa;\xff;\x55;\xaa;\xff;\x55;\xaa;\xff;\
-	        \x55;\xaa;\xff;\x55;\xaa;\xff;\x55;\xaa;\xff;\x55;\xaa;\xff;\
-	        \x55;\xaa;\xff;\x55;\xaa;\xff;\x55;\xaa;\xff;\x55;\xaa;\xff;\
-	        \x55;\xaa;\xff;\x55;\xaa;\xff;\x55;\xaa;\xff;\x55;\xaa;\xff;\
-	        \x55;\xaa;\xff;\x55;\xaa;\xff;\x55;\xaa;\xff;\x55;\xaa;\xff;")
+	     (u8vector->string
+	      #u8(#x55 #xaa #xff #x55 #xaa #xff #x55 #xaa #xff #x55 #xaa #xff
+		  #x55 #xaa #xff #x55 #xaa #xff #x55 #xaa #xff #x55 #xaa #xff
+		  #x55 #xaa #xff #x55 #xaa #xff #x55 #xaa #xff #x55 #xaa #xff
+		  #x55 #xaa #xff #x55 #xaa #xff #x55 #xaa #xff #x55 #xaa #xff
+		  #x55 #xaa #xff #x55 #xaa #xff #x55 #xaa #xff #x55 #xaa #xff
+		  #x55 #xaa #xff #x55 #xaa #xff #x55 #xaa #xff #x55 #xaa #xff)))
 (test-hashpw "$2a$05$CCCCCCCCCCCCCCCCCCCCC.7uG0VCzI2bS7j6ymqJi9CdcdxiRTWNy"
 	     "")
 


### PR DESCRIPTION
1. 不完全文字列中の \xNN; が R7RS のユニコード文字指定であるため、
   Gauche の内部エンコーディングが utf-8 以外の場合に、テストがエラーとなっていたため、
   不完全文字列を u8vector->string で作成するように変更しました。

   不完全文字列では、\xNN; は、下位1バイトのみが出力される仕様のようです。
   例えば、Gauche の内部エンコーディングが sjis であった場合には、
   ` #*"\xa3;" ` → `sjis の 0x8192` → `下位1バイトの 0x92` → ` #*"\x92;" `
   のように変換されます。

   - ext/bcrypt/test.scm
