### PR TITLE
Fix unicode support (encoding=sjis, eucjp)

### DIFF
--- a/ext/text/unicode.scm
+++ b/ext/text/unicode.scm
@@ -479,7 +479,8 @@
      (^[str]
        (with-input-from-string str
          (cut generator->list
-              (cluster-reader-maker (generator-map char->ucs read-char)
+              (cluster-reader-maker (^[] (let1 ch (read-char)
+                                           (if (char? ch) (char->ucs ch) ch)))
                                     (^[cs] (map-to <string> ucs->char cs))))))]
     ))
 
@@ -976,7 +977,8 @@
                     (^[] (doer read-char (^[cs alt] (map display cs)) #t))))]
     [else
      (^[str doer] (with-string-io str
-                    (^[] (doer (generator-map char->ucs read-char)
+                    (^[] (doer (^[] (let1 ch (read-char)
+                                      (if (char? ch) (char->ucs ch) ch)))
                                (^[cs alt]
                                  (let1 cs_ (map ucs->char cs)
                                    (if (every char? cs_)

--- a/src/string.c
+++ b/src/string.c
@@ -1360,7 +1360,11 @@ static inline void string_putc(ScmChar ch, ScmPort *port, int bytemode)
         if (ch < ' ' || ch == 0x7f || (bytemode && ch >= 0x80)) {
             /* TODO: Should we provide 'legacy-compatible writer mode,
                which does not use ';' terminator? */
+#if defined(GAUCHE_CHAR_ENCODING_EUC_JP) || defined(GAUCHE_CHAR_ENCODING_SJIS)
+            snprintf(buf, 6, "\\x%02x", (unsigned char)ch);
+#else
             snprintf(buf, 6, "\\x%02x;", (unsigned char)ch);
+#endif
             SCM_PUTZ(buf, -1, port);
         } else {
             SCM_PUTC(ch, port);

--- a/test/include/r7rs-tests.scm
+++ b/test/include/r7rs-tests.scm
@@ -996,7 +996,7 @@
 (test #f (char-lower-case? #\3))
 
 (cond-expand
- [gauche.ces.utf-8
+ [gauche.ces.utf8
 (test #t (char-alphabetic? #\Λ))
 (test #f (char-alphabetic? #\x0E50))
 (test #t (char-upper-case? #\Λ))
@@ -1012,7 +1012,7 @@
 (test 3 (digit-value #\3))
 (test 9 (digit-value #\9))
 (cond-expand
- [gauche.ces.utf-8
+ [gauche.ces.utf8
 (test 4 (digit-value #\x0664))
 (test 0 (digit-value #\x0AE6))
 ][else])
@@ -1137,7 +1137,7 @@
 
 ;; cyrillic
 (cond-expand
- [gauche.ces.utf-8
+ [gauche.ces.utf8
 (test "ΑΒΓ" (string-upcase "αβγ"))
 (test "ΑΒΓ" (string-upcase "ΑΒΓ"))
 (test "αβγ" (string-downcase "αβγ"))
@@ -1148,7 +1148,7 @@
 
 ;; special cases
 (cond-expand
- [gauche.ces.utf-8
+ [gauche.ces.utf8
 (test "SSA" (string-upcase "ßa"))
 (test "ßa" (string-downcase "ßa"))
 (test "ssa" (string-downcase "SSA"))
@@ -1160,7 +1160,7 @@
 
 ;; context-sensitive (final sigma)
 (cond-expand
- [gauche.ces.utf-8
+ [gauche.ces.utf8
 (test "ΓΛΏΣΣΑ" (string-upcase "γλώσσα"))
 (test "γλώσσα" (string-downcase "ΓΛΏΣΣΑ"))
 (test "γλώσσα" (string-foldcase "ΓΛΏΣΣΑ"))
@@ -1810,7 +1810,7 @@
 (test #x7F (char->integer (read (open-input-string "#\\delete"))))
 (test #x1B (char->integer (read (open-input-string "#\\escape"))))
 (cond-expand
- [gauche.ces.utf-8
+ [gauche.ces.utf8
 (test #x03BB (char->integer (read (open-input-string "#\\λ"))))
 (test #x03BB (char->integer (read (open-input-string "#\\x03BB"))))
 ][else])
@@ -1833,7 +1833,7 @@
 (test "line 1continued\n" (read (open-input-string "\"line 1\\ \t \n \t continued\n\"")))
 (test "line 1\n\nline 3\n" (read (open-input-string "\"line 1\\ \t \n \t \n\nline 3\n\"")))
 (cond-expand
- [gauche.ces.utf-8
+ [gauche.ces.utf8
 (test #x03BB (char->integer (string-ref (read (open-input-string "\"\\x03BB;\"")) 0)))
 ][else])
 

--- a/test/srfi.scm
+++ b/test/srfi.scm
@@ -461,7 +461,7 @@
 (cond-expand
  ;; Only test in utf-8, for the literal notation is interpreted differently
  ;; in other encodings.
- [gauche.ces-utf-8
+ [gauche.ces.utf8
   (test* "char-set-delete!" #[\x81\x83\x84\x86]
          (char-set-delete! (->char-set '(#\x81 #\x82 #\x83 #\x84 #\x85 #\x86 #\x87))
                            #\x82 #\x87 #\x85)
@@ -485,7 +485,7 @@
 (cond-expand
  ;; Only test in utf-8, for the literal notation is interpreted differently
  ;; in other encodings.
- [gauche.ces.utf-8
+ [gauche.ces.utf8
   (test* "char-set-union!" #[\x81-\x89]
          (char-set-union! (->char-set '(#\x81 #\x83 #\x84 #\x86 #\x87))
                           (->char-set '(#\x82 #\x85 #\x86 #\x88 #\x89)))


### PR DESCRIPTION
1. gauche.ces.utf8 typo (gauche.ces-utf-8, gauche.ces.utf-8)
   - test/srfi.scm
   - test/include/r7rs-tests.scm


2. Gauche の内部エンコーディングが sjis か eucjp のときに、
   src/string.c の string_putc で、\xNN の表示にセミコロンを付けないように修正。
   (ユニコードの値ではないため)
   - src/string.c


3. Gauche の内部エンコーディングが sjis か eucjp のときに、
   ext/text/unicode.scm の make-string-splitter と string-xcase で、
   ジェネレータを渡すべきところで、リストを渡していたのを修正。
   - ext/text/unicode.scm
