### PR TITLE
Fix Scm_Peekc and GETC_SCRATCH (encoding=sjis, eucjp)

### DIFF
--- a/test/io2.scm
+++ b/test/io2.scm
@@ -594,14 +594,25 @@
     (define (t ces)
       (test* #"peek-char - read-char (~ces)"
              (fetch "\u3042" read1 ces) (fetch "\u3042" peek1 ces))
-      (test* #"peek-char - read-char^2 (~ces)"
+      (test* #"peek-char - read-char^2 (~ces) A"
              (fetch "\u3042" read2 ces) (fetch "\u3042" peek2 ces))
-      (test* #"peek-char - read-char^2 (~ces)"
+      (test* #"peek-char - read-char^2 (~ces) B"
              (fetch "\u3042\u3044" read2 ces)
              (fetch "\u3042\u3044" peek2 ces)))
 
-    (t 'sjis)
-    (t 'utf8)
-    (t 'eucjp))])
+    (cond-expand
+     [gauche.ces.utf8
+      (t 'sjis)
+      (t 'utf8)
+      (t 'eucjp)]
+     [gauche.ces.sjis
+      (t 'sjis)
+      ;(t 'utf8) ; *** IO-READ-ERROR: encountered EOF in middle of a multibyte character
+      (t 'eucjp)]
+     [gauche.ces.eucjp
+      (t 'sjis)
+      ;(t 'utf8) ; *** IO-READ-ERROR: encountered EOF in middle of a multibyte character
+      (t 'eucjp)]
+     [else]))])
 
 (test-end)


### PR DESCRIPTION
1. 文字列として不正なバイト列を入力したときに、peek が後の read に影響を与えないように
   src/portapi.c の Scm_Peekc と GETC_SCRATCH を修正。
   (プルリクエスト #177 と コミット 4a18aa1 dc5cc82 216440c にも関連あり)
   Scm_Peekc では、p->ungotten に SCM_CHAR_INVALID を入れても、
   空と判定されて情報が消えてしまうため対策。
   また、GETC_SCRATCH では、後続バイトありのケースの SCM_CHAR_INVALID は、
   バッファに残すと逆に Scm_Getc の結果が変わってしまったため対策。
   - src/portapi.c


2. Gauche の内部エンコーディングが sjis か eucjp のときに、
   test/io2.scm でエラーで aborted になるため対策。
   - test/io2.scm


＜確認＞
OS : Windows 8.1 (64bit)
開発環境 : MSYS2/MinGW-w64 (64bit) (gcc version 5.3.0 (Rev1, Built by MSYS2 project))

内部エンコーディング : utf-8
Total: 15986 tests, 15986 passed,     0 failed,     0 aborted.

内部エンコーディング : sjis
Total: 15921 tests, 15915 passed,     6 failed,     0 aborted.
Testing gettext ... failed
discrepancies found.  Errors are:
test get-en: "Menu|File|Quit": expects "Quit" => got "Menu|File|Quit"
test gettext-en: "Menu|File|Quit": expects "Quit" => got "Menu|File|Quit"
test dcgettext-en: "Menu|File|Quit": expects "Quit" => got "Menu|File|Quit"
test get-en: "Menu|File|Quit": expects "Quit" => got "Menu|File|Quit"
test gettext-en: "Menu|File|Quit": expects "Quit" => got "Menu|File|Quit"
test dcgettext-en: "Menu|File|Quit": expects "Quit" => got "Menu|File|Quit"
(上記6個のエラーは、iconv (ISO-8859-15→SJIS) が円記号(0x5C)を変換しようとして、
 エラーになるため、仕方ない)

内部エンコーディング : eucjp
Total: 15916 tests, 15916 passed,     0 failed,     0 aborted.

内部エンコーディング : none
Total: 15617 tests, 15617 passed,     0 failed,     0 aborted.
