### PR TITLE
Fix build on osx and fix ioctls to work

### DIFF
--- a/ext/net/net.ac
+++ b/ext/net/net.ac
@@ -74,7 +74,8 @@ dnl
 dnl Checks if sturct ifreq has ifr_ifindex and/or ifr_index field
 dnl
 AC_CHECK_MEMBERS([struct ifreq.ifr_ifindex,
-                  struct ifreq.ifr_index],,,[
+                  struct ifreq.ifr_index,
+                  struct ifreq.ifr_netmask],,,[
 @%:@ifdef HAVE_SYS_TYPES_H
 @%:@include <sys/types.h>
 @%:@endif

--- a/ext/net/net.c
+++ b/ext/net/net.c
@@ -636,7 +636,7 @@ ScmObj Scm_SocketGetOpt(ScmSocket *s, int level, int option, int rsize)
 
 #if HAVE_STRUCT_IFREQ
 static void ioctl_by_ifr_name(int fd, struct ifreq *ifr, ScmObj data,
-			      int req, const char *req_name)
+                              unsigned long req, const char *req_name)
 {
     if (!SCM_STRINGP(data)) {
         Scm_Error("string expected for %s ioctl argument, but got %s",
@@ -717,9 +717,15 @@ ScmObj Scm_SocketIoctl(ScmSocket *s, int request, ScmObj data)
     case SIOCGIFNETMASK:
         ioctl_by_ifr_name(s->fd, &ifreq_pkt, data,
                           SIOCGIFNETMASK, "SIOCGIFNETMASK");
+#if defined(HAVE_STRUCT_IFREQ_IFR_NETMASK)
         return Scm_MakeSockAddr(NULL,
                                 &ifreq_pkt.ifr_netmask,
                                 sizeof(ifreq_pkt.ifr_netmask));
+#else
+        return Scm_MakeSockAddr(NULL,
+                                &ifreq_pkt.ifr_addr,
+                                sizeof(ifreq_pkt.ifr_addr));
+#endif /*HAVE_STRUCT_IFREQ_IFR_NETMASK*/
 #endif  /*SIOCGIFNETMASK*/
 #if defined(SIOCGIFMTU)
     case SIOCGIFMTU:

--- a/ext/net/net.c
+++ b/ext/net/net.c
@@ -680,7 +680,7 @@ ScmObj Scm_SocketIoctl(ScmSocket *s, int request, ScmObj data)
 #if HAVE_STRUCT_IFREQ_IFR_IFINDEX
         return Scm_MakeInteger(ifreq_pkt.ifr_ifindex);
 #elif HAVE_STRUCT_IFREQ_IFR_INDEX
-       return Scm_MakeInteger(ifreq_pkt.ifr_index);
+        return Scm_MakeInteger(ifreq_pkt.ifr_index);
 #endif /*HAVE_STRUCT_IFREQ_IFR_INDEX*/
 #endif /*SIOCGIFINDEX*/
 #if defined(SIOCGIFFLAGS)

--- a/src/gauche/config.h.in
+++ b/src/gauche/config.h.in
@@ -342,6 +342,9 @@
 /* Define to 1 if `ifr_index' is a member of `struct ifreq'. */
 #undef HAVE_STRUCT_IFREQ_IFR_INDEX
 
+/* Define to 1 if `ifr_netmask' is a member of `struct ifreq'. */
+#undef HAVE_STRUCT_IFREQ_IFR_NETMASK
+
 /* Define to 1 if `pw_class' is a member of `struct passwd'. */
 #undef HAVE_STRUCT_PASSWD_PW_CLASS
 


### PR DESCRIPTION
This is minimum fix.  There is sitll some warnings like this:
```
gcc -DHAVE_CONFIG_H -I. -I. -I../../src -I../../src -I../../gc/include   -no-cpp-precomp  -g -O2 -no-cpp-precomp -fPIC -fno-common  -fomit-frame-pointer  -o net.o -c net.c
net.c:731:10: warning: overflow converting case value to switch condition type (3223349555 to 18446744072637933875) [-Wswitch]
    case SIOCGIFMTU:
         ^
/usr/include/sys/sockio.h:106:20: note: expanded from macro 'SIOCGIFMTU'
#define SIOCGIFMTU      _IOWR('i', 51, struct ifreq)    /* get IF mtu */
                        ^
/usr/include/sys/ioccom.h:97:22: note: expanded from macro '_IOWR'
#define _IOWR(g,n,t)    _IOC(IOC_INOUT, (g), (n), sizeof(t))
                        ^
/usr/include/sys/ioccom.h:92:2: note: expanded from macro '_IOC'
        (inout | ((len & IOCPARM_MASK) << 16) | ((group) << 8) | (num))
        ^
```