### PR TITLE
libeval.scm: repair %vm-show-stack-trace

### DIFF
--- a/src/libeval.scm
+++ b/src/libeval.scm
@@ -556,10 +556,10 @@
   (return (Scm_VMGetStackLite vm)))
 
 (define (%vm-show-stack-trace trace :key
-                                    (port::<port> (current-output-port))
-                                    (maxdepth::<int> 0)
-                                    (skip::<int> 0)
-                                    (offset::<int> 0))
+                                    (port (current-output-port))
+                                    (maxdepth 0)
+                                    (skip 0)
+                                    (offset 0))
   ((with-module gauche.internal %show-stack-trace)
    trace port maxdepth skip offset))
 


### PR DESCRIPTION
Since 21c463c (Rewrite and improve stack trace dump in Scheme -
2015-10-01), %vm-show-stack-trace is redefined with "define" instead
of "define-cproc", the type annotations lose their meaning and
accidentally become part of the argument names. Calling this procedure
will result this error

    *** ERROR: unbound variable: port
        While loading "/tmp/test.scm" at line 9
    Stack Trace:
    _______________________________________

Remove type annotations to fix this.