### PR TITLE
Fix axTLS module build on netbsd.

### DIFF
--- a/ext/tls/axTLS/crypto/os_int.h
+++ b/ext/tls/axTLS/crypto/os_int.h
@@ -60,6 +60,8 @@ typedef INT64 int64_t;
 #include <machine/endian.h>
 #elif defined(__MINGW32__)
 #define be64toh(x) __builtin_bswap64(x)
+#elif defined(__NetBSD__)
+#include <sys/endian.h>
 #else
 #include <endian.h>
 #endif

--- a/ext/tls/axTLS/ssl/os_port.h
+++ b/ext/tls/axTLS/ssl/os_port.h
@@ -156,7 +156,9 @@ EXP_FUNC int STDCALL getdomainname(char *buf, int buf_size);
 #ifdef __APPLE__
 #include <libkern/OSByteOrder.h>
 #define be64toh(x) OSSwapBigToHostInt64(x)
-#else  /*!__APPLE__*/
+#elif defined(__NetBSD__)
+#include <sys/endian.h>
+#else  /*!__APPLE__ && !__NetBSD__ */
 #include <asm/byteorder.h>
 #endif /*!__APPLE__*/
 


### PR DESCRIPTION
On NetBSD, there is no endian.h under /usr/include but sys/endian.h.  The macro be64toh() is defined
in sys/endian.h.
