### PR TITLE
rfc.tls - fix build on FreeBSD 10.2

### DIFF
--- a/ext/tls/axTLS/crypto/os_int.h
+++ b/ext/tls/axTLS/crypto/os_int.h
@@ -60,7 +60,7 @@ typedef INT64 int64_t;
 #include <machine/endian.h>
 #elif defined(__MINGW32__)
 #define be64toh(x) __builtin_bswap64(x)
-#elif defined(__NetBSD__)
+#elif defined(__NetBSD__) || defined(__FreeBSD__)
 #include <sys/endian.h>
 #else
 #include <endian.h>

--- a/ext/tls/axTLS/ssl/os_port.h
+++ b/ext/tls/axTLS/ssl/os_port.h
@@ -156,7 +156,7 @@ EXP_FUNC int STDCALL getdomainname(char *buf, int buf_size);
 #ifdef __APPLE__
 #include <libkern/OSByteOrder.h>
 #define be64toh(x) OSSwapBigToHostInt64(x)
-#elif defined(__NetBSD__)
+#elif defined(__NetBSD__) || defined(__FreeBSD__)
 #include <sys/endian.h>
 #else  /*!__APPLE__ && !__NetBSD__ */
 #include <asm/byteorder.h>


### PR DESCRIPTION
On an unrelated note, "make test" is ok with this build (on x86-64). threading is disabled though because configure says "FreeBSD does not yet fully support threads with Boehm GC."