### PR TITLE
Fix error message of vector-copy! when `send' is out of range.

### DIFF
--- a/src/libvec.scm
+++ b/src/libvec.scm
@@ -97,7 +97,7 @@
     (unless (and (<= 0 sstart) (<= sstart (SCM_VECTOR_SIZE s)))
       (Scm_Error "sstart out of range: %ld" sstart))
     (unless (and (<= 0 send) (<= send (SCM_VECTOR_SIZE s)))
-      (Scm_Error "send out of range: %ld" sstart))
+      (Scm_Error "send out of range: %ld" send))
     (unless (<= (+ tstart (- send sstart)) tsize)
       (Scm_Error "source vector overruns the target vector: %20.0S [%ld,%ld]"
                  s sstart send))


### PR DESCRIPTION
Previously, the error message was like this:
```
gosh> (vector-copy! (vector 1 2) 0 '#(1 2 3) 2 4)
*** ERROR: send out of range: 2
```
The `send` is not 2 but 4.
