### PR TITLE
gauche.cgen.cise - support more than 3 values in "result" form

### DIFF
--- a/lib/gauche/cgen/cise.scm
+++ b/lib/gauche/cgen/cise.scm
@@ -1118,10 +1118,18 @@
   [(_ stuff) (list (x->string stuff))])
 
 (define-cise-expr result
+  [(_) (error "cise: result form needs at least one value'")]
   [(_ e) `(set! SCM_RESULT ,e)]
   [(_ e0 e1) `(set! SCM_RESULT0 ,e0 SCM_RESULT1 ,e1)]
   [(_ e0 e1 e2) `(set! SCM_RESULT0 ,e0 SCM_RESULT1 ,e1 SCM_RESULT2 ,e2)]
-  )
+  [(_ x ...) `(set! ,@(reverse (cdr (fold
+                                     (lambda (elt counter/result)
+                                       (let* ([counter (car counter/result)]
+                                              [result (cdr counter/result)]
+                                              [sym (string->symbol #"SCM_RESULT~counter")])
+                                         `(,(+ counter 1) ,elt ,sym . ,result)))
+                                     '(0)
+                                     x))))])
 
 (define-cise-expr list
   [(_)           '("SCM_NIL")]

--- a/test/cgen.scm
+++ b/test/cgen.scm
@@ -359,6 +359,18 @@ some_trick();
        (test-error)
        (cise-render-to-string '(< a b) 'toplevel))
 
+;; result
+(parameterize ([cise-emit-source-line #f])
+  (define (c form exp)
+    (test* (format "cise transform: ~a" form) exp
+           (cise-render-to-string form 'stmt)))
+  (define err (test-error))
+  (c '(result) err)
+  (c '(result e) "SCM_RESULT=(e);")
+  (c '(result e0 e1) "SCM_RESULT0=(e0),SCM_RESULT1=(e1);")
+  (c '(result e0 e1 e2) "SCM_RESULT0=(e0),SCM_RESULT1=(e1),SCM_RESULT2=(e2);")
+  (c '(result e0 e1 e2 e3) "SCM_RESULT0=(e0),SCM_RESULT1=(e1),SCM_RESULT2=(e2),SCM_RESULT3=(e3);"))
+
 ;;====================================================================
 (test-section "gauche.cgen.stub")
 (use gauche.cgen.stub)


### PR DESCRIPTION
Gauche-Cairo needs to return 6 values at some point [1]. It extends cise for that, but I'm trying to clean it up and hopefully can get rid of that cise extension. Not sure if there's a better way than cdr/fold though. Also, "(result)" is technically ok if I read r7rs correctly, but it does not make much sense so I reject it.

[1] https://github.com/pclouds/Gauche-Cairo/blob/master/src/cairolib.stub#L1388