### PR TITLE
Fix new REPL on windows console

### DIFF
--- a/lib/gauche/interactive/editable-reader.scm
+++ b/lib/gauche/interactive/editable-reader.scm
@@ -69,8 +69,9 @@
                     (try))))
               x))))
       (values (read-1 read)
-              (read-1 read-line)))
-    (values #f #f)))                    ;no default console
+              (read-1 read-line)
+              buffer))
+    (values #f #f #f)))                     ; no default console
 
 ;; We have to handle both toplevel command (begins with comma, ends with
 ;; newline) and the complete sexp.


### PR DESCRIPTION
Windows コンソールで、環境変数 GAUCHE_READ_EDIT を設定して、REPL を起動すると、
Enter キーを 2回押さないと入力ができない件を修正しました。

原因は interactive.scm の %skip-trailing-ws が、open-input-string のポートではなくて、
標準入力のポートを チェックしていたためです。
(そこでブロッキングしてしまうのは、Windows では標準入力に select が使えないためだと思う)

とりあえず %skip-trailing-ws では、open-input-string のポートをチェックするように変更しました。

- interactive.scm
- editable-reader.scm
