### PR TITLE
Fix stat definition on Windows

### DIFF
--- a/src/gauche/system.h
+++ b/src/gauche/system.h
@@ -94,7 +94,7 @@ SCM_EXTERN ScmObj Scm_BaseName(ScmString *filename);
 
 /* struct stat */
 #ifdef GAUCHE_WINDOWS
-typedef struct _stat64 ScmStat;
+typedef struct __stat64 ScmStat;
 #else  /*!GAUCHE_WINDOWS*/
 typedef struct stat ScmStat;
 #endif /*!GAUCHE_WINDOWS*/


### PR DESCRIPTION
Windows 環境での stat の定義を、以下のように変更しました。

1. _stat64 構造体を、__stat64 構造体にした (MSDNより) 。

2. UNICODE が未定義のときは、_stat64 関数を使用するようにした。

3. fstat は、_fstat64 関数を使用するようにした (構造体がstatと共通のため) 。

4. MinGW32 用の定義を追加した。
   ( sys/stat.h を読み込む前に `__MSVCRT_VERSION__` を 0x0601 以上に設定すれば、
     これらの定義は不要なようだが、他にも影響がありそうなので今回この定数は設定せず )

＜環境＞
OS : Windows 8.1 (64bit)

開発環境1 : MSYS2/MinGW-w64 (64bit) (gcc version 5.3.0 (Rev1, Built by MSYS2 project))
Total: 16411 tests, 16411 passed,     0 failed,     0 aborted.

開発環境2 : MSYS2/MinGW-w64 (32bit) (gcc version 5.3.0 (Rev1, Built by MSYS2 project))
Total: 16411 tests, 16411 passed,     0 failed,     0 aborted.

開発環境3 : MinGW.org (32bitのみ) (gcc v4.8.1)
Total: 16414 tests, 16414 passed,     0 failed,     0 aborted.
