### PR TITLE
Fix run-process-pipeline on Windows

### DIFF
--- a/lib/gauche/process.scm
+++ b/lib/gauche/process.scm
@@ -363,7 +363,7 @@
                                            [else (write-block arg o)])
                                    (close-output-port o)))])
            (cond-expand
-            [gauche.sys.pthreads
+            [gauche.sys.threads
              (receive (in out) (sys-pipe)
                (push! iomap `(,fd . ,in))
                (thread-start! (make-thread (cut write-arg out))))]
@@ -490,8 +490,12 @@
          ;; the process that reads from the pipe would wait until all the
          ;; ends are closed.  We have to treat the last command separately,
          ;; for we might :wait #t for it.
-         [ps (map (cut apply run-process <>) (drop-right cmds 1))])
-    (dolist [p pipe-pairs] (close-output-port (cdr p)))
+         [ps (map (^[cmd out]
+                    (begin0
+                      (apply run-process cmd)
+                      (close-output-port out)))
+                  (drop-right cmds 1)
+                  (map cdr pipe-pairs))])
     (append ps (list (apply run-process (last cmds))))))
 
 ;;===================================================================

--- a/src/system.c
+++ b/src/system.c
@@ -1908,21 +1908,14 @@ static HANDLE *win_prepare_handles(int *fds)
     for (int i=0; i<count; i++) {
         int to = fds[i+1], from = fds[i+1+count];
         if (to >= 0 && to < 3) {
+            hs[to] = (HANDLE)_get_osfhandle(from);
             if (from >= 3) {
                 /* from_fd may be a pipe. */
-                HANDLE zh;
-                if (!DuplicateHandle(GetCurrentProcess(),
-                                     (HANDLE)_get_osfhandle(from),
-                                     GetCurrentProcess(),
-                                     &zh,
-                                     0, TRUE,
-                                     DUPLICATE_CLOSE_SOURCE
-                                     |DUPLICATE_SAME_ACCESS)) {
-                    Scm_SysError("DuplicateHandle failed");
+                if (!SetHandleInformation(hs[to],
+                                          HANDLE_FLAG_INHERIT,
+                                          HANDLE_FLAG_INHERIT)) {
+                    Scm_SysError("SetHandleInformation failed");
                 }
-                hs[to] = zh;
-            } else {
-                hs[to] = (HANDLE)_get_osfhandle(from);
             }
         }
     }


### PR DESCRIPTION
Windows 上で run-process-pipeline が正常に動作しない件を修正しました。

1. lib/gauche/process.scm
   run-process 実行後のパイプの出力ポートのクローズを、1個ずつ行うようにした。
   (あとからまとめてクローズすると、デッドロックするため)

2. src/system.c
   パイプのハンドルを、子プロセスに継承可能とする処理で、
   ハンドルの複製を行わないようにした。
   (複製すると、ファイルディスクリプタとの関連付けがなくなり、
    クローズできなくなるため)

3. test/process.scm
   pipeline のテストで、cat および grep のコマンドは gosh 版を使うように変更。
   (MSYS2 の cat や grep は、子プロセスとして起動したときに msvcrt のパイプを
    読み書きできないため)

4. lib/gauche/process.scm
   cond-expand の条件で gauche.sys.pthreads を gauche.sys.threads に1箇所修正
   (こうしないと、テストを実行するたびに C:\msys64\tmp にテンポラリファイルが
    増えていくため)


＜テスト結果＞
OS : Windows 8.1 (64bit)

開発環境1 : MSYS2/MinGW-w64 (64bit) (gcc version 5.3.0 (Rev1, Built by MSYS2 project))
Total: 16442 tests, 16442 passed,     0 failed,     0 aborted.
ただし以下の設定を行っている
・tools/gc-configure.gnu-gauche.in に --enable-gcj-support=no を追加

開発環境2 : MSYS2/MinGW-w64 (32bit) (gcc version 5.3.0 (Rev1, Built by MSYS2 project))
Total: 16442 tests, 16442 passed,     0 failed,     0 aborted.
ただし以下の設定を行っている
・tools/gc-configure.gnu-gauche.in に --enable-gcj-support=no を追加

開発環境3 : MinGW.org (32bitのみ) (gcc v4.8.1)
Total: 16445 tests, 16444 passed,     1 failed,     0 aborted.
Testing hash tables ...                                          failed.
discrepancies found.  Errors are:
test portable hash (new, legacy): expects
... 1981271040 ... => got ... 1981270711 ...
1個だけハッシュ値のエラー???
ただし以下の設定を行っている
・tools/gc-configure.gnu-gauche.in に --enable-gcj-support=no を追加
・DIST の find コマンドを set +e と set -e でくくってエラー回避
・pkg-config(exe, glib, intr.dll のバイナリ) および pkg.m4 を別途インストール
  ( http://www.gaia-gis.it/spatialite-3.0.0-BETA/mingw_how_to.html 
    http://blog.k-tai-douga.com/article/52368303.html )
