### PR TITLE
Fix legacy flonum hash on MinGW.org (32bit)

### DIFF
--- a/src/hash.c
+++ b/src/hash.c
@@ -1195,7 +1195,7 @@ static u_long legacy_flonum_hash(double f)
        to 1.0.  With 80 bit and integer truncation the result is 0 but
        with 64bit we get 1.
      */
-    double d = f * 2654435761UL;
+    volatile double d = f * 2654435761UL;
     static double two_pow_63 = 0.0;
     static double minus_two_pow_63 = 0.0;
     static double two_pow_32 = 0.0;


### PR DESCRIPTION
MinGW.org (32bitのみ) の開発環境でビルドした場合に、
(hash  3.474701543e9) が 1981271040 ではなくて 1981270711 になる件、
気になったのでもう少し調べてみました。

test/hash.scm のコメントをみると、
8087 系の 80bit 浮動小数点演算に関係があるようです。

とりあえず、src/hash.c の legacy_flonum_hash 関数内の変数 d に volatile を付加したところ、
正常値になることを確認しました。
また、コンパイルオプションで -O0 を指定した場合にも、正常値になることを確認しました。
このため、コンパイラによって、変数 d の処理が最適化された場合に発生するようです。

ただ、MinGW-w64 (32bit/64bit) の開発環境では、再現しないので、
この修正が必須なのかどうかはよく分かりません。。。
(コンパイルオプションに -mfpmath=387 を指定しても再現せず)

確認した gcc のバージョンは、MinGW.org が v4.8.1 で、MinGW-w64 が v5.3.0 です。
