### PR TITLE
rfc.tls - fix build on FreeBSD 10 (again)

### DIFF
--- a/ext/tls/axTLS/ssl/os_port.h
+++ b/ext/tls/axTLS/ssl/os_port.h
@@ -159,7 +159,9 @@ EXP_FUNC int STDCALL getdomainname(char *buf, int buf_size);
 #ifdef __APPLE__
 #include <libkern/OSByteOrder.h>
 #define be64toh(x) OSSwapBigToHostInt64(x)
-#else  /*!__APPLE__*/
+#elif defined(__NetBSD__) || defined(__FreeBSD__)
+#include <sys/endian.h>
+#else  /*!__APPLE__ && !__NetBSD__ */
 #include <asm/byteorder.h>
 #endif /*!__APPLE__*/
 


### PR DESCRIPTION
Do this again: https://github.com/shirok/Gauche/pull/193

Redo 7078147e5eec3de3689556ad2909d1b51afdccb3
which was clobbered with
bb924dddbcedfa0fe96693055ccfaad73cc1a1ee (Update axTLS to 1.5.4)