### PR TITLE
Change axTLS local patch file format

### DIFF
--- a/ext/tls/axtls-diff.scm
+++ b/ext/tls/axtls-diff.scm
@@ -33,27 +33,27 @@
 
 (define (do-diff file dir)
   (let* ([orig (build-path dir (regexp-replace #/^axTLS\// file ""))]
-         [p (run-process `(diff -c -N ,orig ,file) :wait #f :output :pipe)]
+         [p (run-process `(diff -u -N ,orig ,file) :wait #f :output :pipe)]
          ;; We replace pathnames in the diff header to be friendly for patch.
          ;; Especially, newer version of GNU patch rejects patchfile that has
          ;; absolute pathname, or pathname includes '..'.
          ;; The original diff header:
-         ;;   *** /path/to/original/axtls/subdir/foo.c    <timestamp>
-         ;;   --- axTLS/subdir/foo.c    <timestamp>
+         ;;   --- /path/to/original/axtls/subdir/foo.c    <timestamp>
+         ;;   +++ axTLS/subdir/foo.c    <timestamp>
          ;; Replaced diff header:
-         ;;   *** a/axTLS/subdir/foo.c    <timestamp>
-         ;;   --- b/axTLS/subdir/foo.c    <timestamp>
+         ;;   --- a/axTLS/subdir/foo.c    <timestamp>
+         ;;   +++ b/axTLS/subdir/foo.c    <timestamp>
          ;; By doing this, the result patch can be applied by
          ;;  patch -p1 < axtls.diff
          [line1 (read-line (process-output p))]
          [line2 (read-line (process-output p))])
     (unless (eof-object? line1)
-      (let ([m1 (#/^\*\*\* [^\s]+\s+(.*)/ line1)]
-            [m2 (#/^--- [^\s]+\s+(.*)/ line2)])
+      (let ([m1 (#/^--- [^\s]+\s+(.*)/ line1)]
+            [m2 (#/^\+\+\+ [^\s]+\s+(.*)/ line2)])
         (unless (and m1 m2)
           (exit 1 #"Diff output parse error.  Check the output of \
-                    `diff -c -N ~orig ~file'."))
-        (print #"*** a/~file\t~(m1 1)")
-        (print #"--- b/~file\t~(m2 1)")
+                    `diff -u -N ~orig ~file'."))
+        (print #"--- a/~file\t~(m1 1)")
+        (print #"+++ b/~file\t~(m2 1)")
         (copy-port (process-output p) (current-output-port))))
     (process-wait p)))

--- a/ext/tls/axtls-diff.scm
+++ b/ext/tls/axtls-diff.scm
@@ -57,11 +57,3 @@
         (print #"--- b/~file\t~(m2 1)")
         (copy-port (process-output p) (current-output-port))))
     (process-wait p)))
-            
-      
-
-                
-    
-
-
-

--- a/ext/tls/axtls.diff
+++ b/ext/tls/axtls.diff
@@ -1,585 +1,458 @@
-*** a/axTLS/ssl/tls1_clnt.c	Tue Aug 16 15:33:42 2016
---- b/axTLS/ssl/tls1_clnt.c	Mon Aug 22 02:48:44 2016
-***************
-*** 311,317 ****
-      offset += 2; // ignore compression
-      PARANOIA_CHECK(pkt_size, offset);
-  
-!     ssl->dc->bm_proc_index = offset+1; 
-      PARANOIA_CHECK(pkt_size, offset);
-  
-      // no extensions
---- 311,317 ----
-      offset += 2; // ignore compression
-      PARANOIA_CHECK(pkt_size, offset);
-  
-!     ssl->dc->bm_proc_index = offset;
-      PARANOIA_CHECK(pkt_size, offset);
-  
-      // no extensions
-*** a/axTLS/ssl/tls1.h	Wed Aug 17 18:54:52 2016
---- b/axTLS/ssl/tls1.h	Sat Aug 20 03:36:18 2016
-***************
-*** 41,47 ****
-  #endif
-  
-  #include "version.h"
-! #include "config.h"
-  #include "os_int.h"
-  #include "os_port.h"
-  #include "crypto.h"
---- 41,47 ----
-  #endif
-  
-  #include "version.h"
-! #include "../config/config.h"
-  #include "os_int.h"
-  #include "os_port.h"
-  #include "crypto.h"
-*** a/axTLS/ssl/test/ssltest.c	Wed Aug 17 18:56:58 2016
---- b/axTLS/ssl/test/ssltest.c	Sat Aug 20 03:36:18 2016
-***************
-*** 922,940 ****
-  static int client_socket_init(uint16_t port)
-  {
-      struct sockaddr_in address;
-!     int client_fd;
-  
-!     address.sin_family = AF_INET;
-!     address.sin_port = htons(port);
-!     address.sin_addr.s_addr =  inet_addr("127.0.0.1");
-!     client_fd = socket(AF_INET, SOCK_STREAM, 0);
-!     if (connect(client_fd, (struct sockaddr *)&address, sizeof(address)) < 0)
-!     {
-          perror("socket");
-          SOCKET_CLOSE(client_fd);
-          client_fd = -1;
-      }
-! 
-      return client_fd;
-  }
-  
---- 922,944 ----
-  static int client_socket_init(uint16_t port)
-  {
-      struct sockaddr_in address;
-!     int client_fd = -1;
-!     int i;
-  
-!     /* <SK> In case if the server process might not be ready, we retry
-!        connecting after some nap. */
-!     for (i=0; i<3; i++) {
-!         address.sin_family = AF_INET;
-!         address.sin_port = htons(port);
-!         address.sin_addr.s_addr =  inet_addr("127.0.0.1");
-!         client_fd = socket(AF_INET, SOCK_STREAM, 0);
-!         if (connect(client_fd, (struct sockaddr *)&address, sizeof(address)) == 0) break;
-          perror("socket");
-          SOCKET_CLOSE(client_fd);
-          client_fd = -1;
-+         sleep(2);
-      }
-!     /* </SK> */
-      return client_fd;
-  }
-  
-***************
-*** 1469,1474 ****
---- 1473,1479 ----
-                  NULL, "abcd", DEFAULT_SVR_OPTION)))
-          goto cleanup;
-  
-+ #if 0
-      /* 
-       * GNUTLS
-       */
-***************
-*** 1487,1492 ****
---- 1492,1498 ----
-                      "../ssl/test/axTLS.ca_x509.cer", NULL, 
-                      DEFAULT_SVR_OPTION|SSL_CLIENT_AUTHENTICATION)))
-          goto cleanup;
-+ #endif
-      ret = 0;
-  
-  cleanup:
-***************
-*** 1540,1546 ****
---- 1546,1556 ----
-      else
-      {
-          sprintf(openssl_buf, "openssl s_server " 
-+ #ifdef WIN32
-+                 "-accept %d -quiet %s", 
-+ #else
-                  "-accept %d -quiet %s > /dev/null", 
-+ #endif
-                  g_port, svr->openssl_option);
-      }
-  //printf("SERVER %s\n", openssl_buf);
-***************
-*** 1756,1762 ****
-      if ((ret = SSL_client_test("Client renegotiation", 
-                      &ssl_ctx, NULL, &sess_resume, 
-                      DEFAULT_CLNT_OPTION, NULL, NULL, NULL)))
-!         goto cleanup;
-      sess_resume.do_reneg = 0;
-  
-      sess_resume.stop_server = 1;
---- 1766,1774 ----
-      if ((ret = SSL_client_test("Client renegotiation", 
-                      &ssl_ctx, NULL, &sess_resume, 
-                      DEFAULT_CLNT_OPTION, NULL, NULL, NULL)))
-!         /*[SK] This test seems to fail depending on openssl version,
-!           so we make the test merely records the result and keep going. */
-!         printf("Client renegotiation: ret=%d\n", ret);
-      sess_resume.do_reneg = 0;
-  
-      sess_resume.stop_server = 1;
-***************
-*** 1876,1881 ****
---- 1888,1894 ----
-  
-      printf("SSL client test \"Invalid certificate type\" passed\n");
-  
-+ #if 0
-      if ((ret = SSL_client_test("GNUTLS client", 
-                      &ssl_ctx,
-                      "--x509certfile ../ssl/test/axTLS.x509_1024.pem "
-***************
-*** 1892,1898 ****
-                      DEFAULT_CLNT_OPTION|SSL_SERVER_VERIFY_LATER, 
-                      NULL, NULL, NULL)))
-          goto cleanup;
-! 
-      ret = 0;
-  
-  cleanup:
---- 1905,1911 ----
-                      DEFAULT_CLNT_OPTION|SSL_SERVER_VERIFY_LATER, 
-                      NULL, NULL, NULL)))
-          goto cleanup;
-! #endif
-      ret = 0;
-  
-  cleanup:
-***************
-*** 2380,2385 ****
---- 2393,2402 ----
-      int ret = 1;
-      BI_CTX *bi_ctx;
-      int fd;
-+     /*<SK> NB: String "openssl " will be replaced by the build script, so
-+       avoid ending the variable name with "openssl". */
-+     int have_openssl_p = 0;
-+     /*</SK>*/
-  
-  #ifdef WIN32
-      WSADATA wsaData;
-***************
-*** 2393,2398 ****
---- 2410,2421 ----
-      dup2(fd, 2);
-  #endif
-  
+--- a/axTLS/ssl/tls1_clnt.c	Tue Aug 16 15:33:42 2016
++++ b/axTLS/ssl/tls1_clnt.c	Mon Aug 22 02:48:44 2016
+@@ -311,7 +311,7 @@
+     offset += 2; // ignore compression
+     PARANOIA_CHECK(pkt_size, offset);
+ 
+-    ssl->dc->bm_proc_index = offset+1; 
++    ssl->dc->bm_proc_index = offset;
+     PARANOIA_CHECK(pkt_size, offset);
+ 
+     // no extensions
+--- a/axTLS/ssl/tls1.h	Wed Aug 17 18:54:52 2016
++++ b/axTLS/ssl/tls1.h	Sat Aug 20 03:36:18 2016
+@@ -41,7 +41,7 @@
+ #endif
+ 
+ #include "version.h"
+-#include "config.h"
++#include "../config/config.h"
+ #include "os_int.h"
+ #include "os_port.h"
+ #include "crypto.h"
+--- a/axTLS/ssl/test/ssltest.c	Wed Aug 17 18:56:58 2016
++++ b/axTLS/ssl/test/ssltest.c	Sat Aug 20 03:36:18 2016
+@@ -922,19 +922,23 @@
+ static int client_socket_init(uint16_t port)
+ {
+     struct sockaddr_in address;
+-    int client_fd;
++    int client_fd = -1;
++    int i;
+ 
+-    address.sin_family = AF_INET;
+-    address.sin_port = htons(port);
+-    address.sin_addr.s_addr =  inet_addr("127.0.0.1");
+-    client_fd = socket(AF_INET, SOCK_STREAM, 0);
+-    if (connect(client_fd, (struct sockaddr *)&address, sizeof(address)) < 0)
+-    {
++    /* <SK> In case if the server process might not be ready, we retry
++       connecting after some nap. */
++    for (i=0; i<3; i++) {
++        address.sin_family = AF_INET;
++        address.sin_port = htons(port);
++        address.sin_addr.s_addr =  inet_addr("127.0.0.1");
++        client_fd = socket(AF_INET, SOCK_STREAM, 0);
++        if (connect(client_fd, (struct sockaddr *)&address, sizeof(address)) == 0) break;
+         perror("socket");
+         SOCKET_CLOSE(client_fd);
+         client_fd = -1;
++        sleep(2);
+     }
+-
++    /* </SK> */
+     return client_fd;
+ }
+ 
+@@ -1469,6 +1473,7 @@
+                 NULL, "abcd", DEFAULT_SVR_OPTION)))
+         goto cleanup;
+ 
++#if 0
+     /* 
+      * GNUTLS
+      */
+@@ -1487,6 +1492,7 @@
+                     "../ssl/test/axTLS.ca_x509.cer", NULL, 
+                     DEFAULT_SVR_OPTION|SSL_CLIENT_AUTHENTICATION)))
+         goto cleanup;
++#endif
+     ret = 0;
+ 
+ cleanup:
+@@ -1540,7 +1546,11 @@
+     else
+     {
+         sprintf(openssl_buf, "openssl s_server " 
++#ifdef WIN32
++                "-accept %d -quiet %s", 
++#else
+                 "-accept %d -quiet %s > /dev/null", 
++#endif
+                 g_port, svr->openssl_option);
+     }
+ //printf("SERVER %s\n", openssl_buf);
+@@ -1756,7 +1766,9 @@
+     if ((ret = SSL_client_test("Client renegotiation", 
+                     &ssl_ctx, NULL, &sess_resume, 
+                     DEFAULT_CLNT_OPTION, NULL, NULL, NULL)))
+-        goto cleanup;
++        /*[SK] This test seems to fail depending on openssl version,
++          so we make the test merely records the result and keep going. */
++        printf("Client renegotiation: ret=%d\n", ret);
+     sess_resume.do_reneg = 0;
+ 
+     sess_resume.stop_server = 1;
+@@ -1876,6 +1888,7 @@
+ 
+     printf("SSL client test \"Invalid certificate type\" passed\n");
+ 
++#if 0
+     if ((ret = SSL_client_test("GNUTLS client", 
+                     &ssl_ctx,
+                     "--x509certfile ../ssl/test/axTLS.x509_1024.pem "
+@@ -1892,7 +1905,7 @@
+                     DEFAULT_CLNT_OPTION|SSL_SERVER_VERIFY_LATER, 
+                     NULL, NULL, NULL)))
+         goto cleanup;
+-
++#endif
+     ret = 0;
+ 
+ cleanup:
+@@ -2380,6 +2393,10 @@
+     int ret = 1;
+     BI_CTX *bi_ctx;
+     int fd;
++    /*<SK> NB: String "openssl " will be replaced by the build script, so
++      avoid ending the variable name with "openssl". */
++    int have_openssl_p = 0;
++    /*</SK>*/
+ 
+ #ifdef WIN32
+     WSADATA wsaData;
+@@ -2393,6 +2410,12 @@
+     dup2(fd, 2);
+ #endif
+ 
++    /*<SK>*/
++    if (argc == 2 && strcmp(argv[1], "--exttest") == 0) {
++        have_openssl_p = 1;
++    }
++    /*</SK>*/
++
+     /* can't do testing in this mode */
+ #if defined CONFIG_SSL_GENERATE_X509_CERT
+     printf("Error: Must compile with default key/certificates\n");
+@@ -2488,6 +2511,10 @@
+ 
+     SYSTEM("sh ../ssl/test/killopenssl.sh");
+ 
++    /*<SK>*/
++    if (have_openssl_p) {
++    /*</SK>*/
++
+     if (SSL_client_tests())
+         goto cleanup;
+ 
+@@ -2499,6 +2526,10 @@
+ 
+     SYSTEM("sh ../ssl/test/killopenssl.sh");
+ 
 +     /*<SK>*/
-+     if (argc == 2 && strcmp(argv[1], "--exttest") == 0) {
-+         have_openssl_p = 1;
-+     }
++     } /*have_openssl_p*/
 +     /*</SK>*/
 + 
-      /* can't do testing in this mode */
-  #if defined CONFIG_SSL_GENERATE_X509_CERT
-      printf("Error: Must compile with default key/certificates\n");
-***************
-*** 2488,2493 ****
---- 2511,2520 ----
-  
-      SYSTEM("sh ../ssl/test/killopenssl.sh");
-  
-+     /*<SK>*/
-+     if (have_openssl_p) {
-+     /*</SK>*/
-+ 
-      if (SSL_client_tests())
-          goto cleanup;
-  
-***************
-*** 2499,2504 ****
---- 2526,2535 ----
-  
-      SYSTEM("sh ../ssl/test/killopenssl.sh");
-  
-+      /*<SK>*/
-+      } /*have_openssl_p*/
-+      /*</SK>*/
-+  
-  //    if (header_issue())
-  //    {
-  //        printf("Header tests failed\n"); TTY_FLUSH();
-*** a/axTLS/ssl/test/killopenssl.sh	Sun Jun 12 19:39:34 2016
---- b/axTLS/ssl/test/killopenssl.sh	Sat Aug 20 03:36:18 2016
-***************
-*** 1,2 ****
-  #!/bin/sh
-! ps -ef|grep openssl | /usr/bin/awk '{print $2}' |xargs kill -9
---- 1,3 ----
-  #!/bin/sh
-! awk '{print $1}' "../ssl/openssl.pid" | xargs kill -9
-! rm -f ../ssl/openssl.pid
-*** a/axTLS/ssl/test/killgnutls.sh	Sun Jun 12 19:39:34 2016
---- b/axTLS/ssl/test/killgnutls.sh	Sat Aug 20 03:36:18 2016
-***************
-*** 1,2 ****
-  #!/bin/sh
-! ps -ef|grep gnutls-serv | /usr/bin/awk '{print $2}' |xargs kill -9
---- 1,2 ----
-  #!/bin/sh
-! #ps -ef|grep gnutls-serv | /usr/bin/awk '{print $2}' |xargs kill -9
-*** a/axTLS/ssl/os_port.h	Tue Jul  5 16:33:36 2016
---- b/axTLS/ssl/os_port.h	Sat Aug 20 03:36:18 2016
-***************
-*** 42,48 ****
-  #endif
-  
-  #include "os_int.h"
-! #include "config.h"
-  #include <stdio.h>
-  
-  #if defined(WIN32)
---- 42,48 ----
-  #endif
-  
-  #include "os_int.h"
-! #include "../config/config.h"
-  #include <stdio.h>
-  
-  #if defined(WIN32)
-***************
-*** 60,65 ****
---- 60,67 ----
-  
-  #ifdef WIN32
-  
-+ #include <windows.h>
-+ 
-  /* Windows CE stuff */
-  #if defined(_WIN32_WCE)
-  #include <basetsd.h>
-***************
-*** 98,105 ****
---- 100,111 ----
-  #define usleep(A)               Sleep(A/1000)
-  #define strdup(A)               _strdup(A)
-  #define chroot(A)               _chdir(A)
-+ #ifndef chdir
-  #define chdir(A)                _chdir(A)
-+ #endif
-+ #ifndef alloca
-  #define alloca(A)               _alloca(A)
-+ #endif
-  #ifndef lseek
-  #define lseek(A,B,C)            _lseek(A,B,C)
-  #endif
-***************
-*** 118,126 ****
---- 124,140 ----
-  
-  typedef int socklen_t;
-  
-+ #if !defined(__MINGW32__)
-  EXP_FUNC void STDCALL gettimeofday(struct timeval* t,void* timezone);
-  EXP_FUNC int STDCALL strcasecmp(const char *s1, const char *s2);
-  EXP_FUNC int STDCALL getdomainname(char *buf, int buf_size);
-+ #endif /*!defined(__MINGW32__)*/
-+ 
-+ #if defined(__MINGW32__)
-+ #include <malloc.h>
-+ #include <sys/time.h>
-+ #define be64toh(x) __builtin_bswap64(x)
-+ #endif /*defined(__MINGW32__)*/
-  
-  #else   /* Not Win32 */
-  
-***************
-*** 136,148 ****
-  #include <sys/wait.h>
-  #include <netinet/in.h>
-  #include <arpa/inet.h>
-- #include <asm/byteorder.h>
-  
-  #define SOCKET_READ(A,B,C)      read(A,B,C)
-  #define SOCKET_WRITE(A,B,C)     write(A,B,C)
-  #define SOCKET_CLOSE(A)         if (A >= 0) close(A)
-  #define TTY_FLUSH()
-  
-  #ifndef be64toh
-  #define be64toh(x) __be64_to_cpu(x)
-  #endif
---- 150,171 ----
-  #include <sys/wait.h>
-  #include <netinet/in.h>
-  #include <arpa/inet.h>
-  
-  #define SOCKET_READ(A,B,C)      read(A,B,C)
-  #define SOCKET_WRITE(A,B,C)     write(A,B,C)
-  #define SOCKET_CLOSE(A)         if (A >= 0) close(A)
-  #define TTY_FLUSH()
-  
-+ /* get be64toh */
-+ #if    defined(__APPLE__)
-+ #include <libkern/OSByteOrder.h>
-+ #define be64toh(x) OSSwapBigToHostInt64(x)
-+ #elif  defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
-+ #include <sys/endian.h>
-+ #else
-+ #include <asm/byteorder.h>
-+ #endif
-+ 
-  #ifndef be64toh
-  #define be64toh(x) __be64_to_cpu(x)
-  #endif
-*** a/axTLS/ssl/os_port.c	Wed Jul  6 04:31:16 2016
---- b/axTLS/ssl/os_port.c	Sat Aug 20 03:36:18 2016
-***************
-*** 40,45 ****
---- 40,46 ----
-  #include "os_port.h"
-  
-  #ifdef WIN32
-+ #ifndef __MINGW32__
-  /**
-   * gettimeofday() not in Win32 
-   */
-***************
-*** 88,92 ****
---- 89,94 ----
-      RegCloseKey(hKey);
-      return 0; 
-  }
-+ #endif /*__MINGW32__*/
-  #endif
-  
-*** a/axTLS/crypto/os_int.h	Wed Jul  6 04:55:28 2016
---- b/axTLS/crypto/os_int.h	Sat Aug 20 03:36:18 2016
-***************
-*** 41,47 ****
-  extern "C" {
-  #endif
-  
-! #if defined(WIN32)
-  typedef UINT8 uint8_t;
-  typedef INT8 int8_t;
-  typedef UINT16 uint16_t;
---- 41,47 ----
-  extern "C" {
-  #endif
-  
-! #if defined(WIN32) && !defined(__MINGW32__)
-  typedef UINT8 uint8_t;
-  typedef INT8 int8_t;
-  typedef UINT16 uint16_t;
-*** a/axTLS/crypto/crypto_misc.c	Wed Jul  6 04:49:46 2016
---- b/axTLS/crypto/crypto_misc.c	Sat Aug 20 03:36:18 2016
-***************
-*** 48,54 ****
-  static HCRYPTPROV gCryptProv;
-  #endif
-  
-! #if (!defined(CONFIG_USE_DEV_URANDOM) && !defined(CONFIG_WIN32_USE_CRYPTO_LIB))
-  /* change to processor registers as appropriate */
-  #define ENTROPY_POOL_SIZE 32
-  #define ENTROPY_COUNTER1 ((((uint64_t)tv.tv_sec)<<32) | tv.tv_usec)
---- 48,54 ----
-  static HCRYPTPROV gCryptProv;
-  #endif
-  
-! #if (!defined(CONFIG_USE_DEV_URANDOM) && !defined(CONFIG_WIN32_USE_CRYPTO_LIB)) || !defined(ENTROPY_POOL_SIZE) /* The last condition added to compile on MinGW */
-  /* change to processor registers as appropriate */
-  #define ENTROPY_POOL_SIZE 32
-  #define ENTROPY_COUNTER1 ((((uint64_t)tv.tv_sec)<<32) | tv.tv_usec)
-*** a/axTLS/crypto/crypto.h	Sun Jul 24 16:31:34 2016
---- b/axTLS/crypto/crypto.h	Sat Aug 20 03:36:18 2016
-***************
-*** 39,44 ****
---- 39,45 ----
-  extern "C" {
-  #endif
-  
-+ #include "../config/config.h"
-  #include "bigint_impl.h"
-  #include "bigint.h"
-  
-*** a/axTLS/crypto/bigint_impl.h	Sun Jun 12 19:39:34 2016
---- b/axTLS/crypto/bigint_impl.h	Sat Aug 20 03:36:18 2016
-***************
-*** 61,67 ****
-  typedef uint32_t long_comp;     /**< A double precision component. */
-  typedef int32_t slong_comp;     /**< A signed double precision component. */
-  #else /* regular 32 bit */
-! #ifdef WIN32
-  #define COMP_RADIX          4294967296i64         
-  #define COMP_MAX            0xFFFFFFFFFFFFFFFFui64
-  #else
---- 61,67 ----
-  typedef uint32_t long_comp;     /**< A double precision component. */
-  typedef int32_t slong_comp;     /**< A signed double precision component. */
-  #else /* regular 32 bit */
-! #if defined(WIN32) && !defined(__MINGW32__)
-  #define COMP_RADIX          4294967296i64         
-  #define COMP_MAX            0xFFFFFFFFFFFFFFFFui64
-  #else
-*** a/axTLS/config/config.h	Thu Jan  1 09:00:00 1970
---- b/axTLS/config/config.h	Sat Aug 20 03:36:18 2016
-***************
-*** 0 ****
---- 1,149 ----
-+ /*
-+  * In original axTLS, this file is automatically generated.
-+  * To include in Gauche, we hand-edited this file, so be careful
-+  * not to clobber this file.
-+  */
-+ 
-+ /*
-+  * General Configuration
-+  */
-+ #define CONFIG_DEBUG 1
-+ 
-+ /*
-+  * SSL Library
-+  */
-+ #undef CONFIG_SSL_SERVER_ONLY
-+ #undef CONFIG_SSL_CERT_VERIFICATION
-+ #undef CONFIG_SSL_ENABLE_CLIENT
-+ #define CONFIG_SSL_FULL_MODE 1
-+ #undef CONFIG_SSL_SKELETON_MODE
-+ #undef CONFIG_SSL_PROT_LOW
-+ #define CONFIG_SSL_PROT_MEDIUM 1
-+ #undef CONFIG_SSL_PROT_HIGH
-+ #define CONFIG_SSL_USE_DEFAULT_KEY 1
-+ #define CONFIG_SSL_PRIVATE_KEY_LOCATION ""
-+ #define CONFIG_SSL_PRIVATE_KEY_PASSWORD ""
-+ #define CONFIG_SSL_X509_CERT_LOCATION ""
-+ #undef CONFIG_SSL_GENERATE_X509_CERT
-+ #define CONFIG_SSL_X509_COMMON_NAME ""
-+ #define CONFIG_SSL_X509_ORGANIZATION_NAME ""
-+ #define CONFIG_SSL_X509_ORGANIZATION_UNIT_NAME ""
-+ #undef CONFIG_SSL_ENABLE_V23_HANDSHAKE
-+ #define CONFIG_SSL_HAS_PEM 1
-+ #define CONFIG_SSL_USE_PKCS12 1
-+ #define CONFIG_SSL_EXPIRY_TIME 24
-+ #define CONFIG_X509_MAX_CA_CERTS 150
-+ #define CONFIG_SSL_MAX_CERTS 3
-+ #undef CONFIG_SSL_CTX_MUTEXING
-+ #define CONFIG_USE_DEV_URANDOM 1
-+ #ifdef WIN32
-+ #define CONFIG_WIN32_USE_CRYPTO_LIB 1
-+ #endif /*WIN32*/
-+ #undef CONFIG_OPENSSL_COMPATIBLE
-+ #undef CONFIG_PERFORMANCE_TESTING
-+ #undef CONFIG_SSL_TEST
-+ #undef CONFIG_AXTLSWRAP
-+ #undef CONFIG_AXHTTPD
-+ #undef CONFIG_HTTP_STATIC_BUILD
-+ #define CONFIG_HTTP_PORT 
-+ #define CONFIG_HTTP_HTTPS_PORT 
-+ #define CONFIG_HTTP_SESSION_CACHE_SIZE 
-+ #define CONFIG_HTTP_WEBROOT ""
-+ #define CONFIG_HTTP_TIMEOUT 
-+ #undef CONFIG_HTTP_HAS_CGI
-+ #define CONFIG_HTTP_CGI_EXTENSIONS ""
-+ #undef CONFIG_HTTP_ENABLE_LUA
-+ #define CONFIG_HTTP_LUA_PREFIX ""
-+ #define CONFIG_HTTP_LUA_CGI_LAUNCHER ""
-+ #undef CONFIG_HTTP_BUILD_LUA
-+ #undef CONFIG_HTTP_DIRECTORIES
-+ #undef CONFIG_HTTP_HAS_AUTHORIZATION
-+ #undef CONFIG_HTTP_HAS_IPV6
-+ #undef CONFIG_HTTP_ENABLE_DIFFERENT_USER
-+ #define CONFIG_HTTP_USER ""
-+ #undef CONFIG_HTTP_VERBOSE
-+ #undef CONFIG_HTTP_IS_DAEMON
-+ 
-+ /*
-+  * Language Bindings
-+  */
-+ #undef CONFIG_BINDINGS
-+ #undef CONFIG_CSHARP_BINDINGS
-+ #undef CONFIG_VBNET_BINDINGS
-+ #define CONFIG_DOT_NET_FRAMEWORK_BASE ""
-+ #undef CONFIG_JAVA_BINDINGS
-+ #define CONFIG_JAVA_HOME ""
-+ #undef CONFIG_PERL_BINDINGS
-+ #define CONFIG_PERL_CORE ""
-+ #define CONFIG_PERL_LIB ""
-+ #undef CONFIG_LUA_BINDINGS
-+ #define CONFIG_LUA_CORE ""
-+ 
-+ /*
-+  * Samples
-+  */
-+ #define CONFIG_SAMPLES 1
-+ #define CONFIG_C_SAMPLES 1
-+ #undef CONFIG_CSHARP_SAMPLES
-+ #undef CONFIG_VBNET_SAMPLES
-+ #undef CONFIG_JAVA_SAMPLES
-+ #undef CONFIG_PERL_SAMPLES
-+ #undef CONFIG_LUA_SAMPLES
-+ 
-+ /*
-+  * BigInt Options
-+  */
-+ #undef CONFIG_BIGINT_CLASSICAL
-+ #undef CONFIG_BIGINT_MONTGOMERY
-+ #define CONFIG_BIGINT_BARRETT 1
-+ #define CONFIG_BIGINT_CRT 1
-+ #undef CONFIG_BIGINT_KARATSUBA
-+ #define MUL_KARATSUBA_THRESH 
-+ #define SQU_KARATSUBA_THRESH 
-+ #define CONFIG_BIGINT_SLIDING_WINDOW 1
-+ #define CONFIG_BIGINT_SQUARE 1
-+ #define CONFIG_BIGINT_CHECK_ON 1
-+ #define CONFIG_INTEGER_32BIT 1
-+ #undef CONFIG_INTEGER_16BIT
-+ #undef CONFIG_INTEGER_8BIT
-+ 
-+ /* The following macros rename APIs defined in the files under crypto
-+    directory. This is to avoid build-time problems when those names
-+    conflict with system-provided ones. */
-+ #define AES_set_key       AES_set_key__axtls
-+ #define AES_cbc_encrypt   AES_cbc_encrypt__axtls
-+ #define AES_cbc_decrypt   AES_cbc_decrypt__axtls
-+ #define AES_convert_key   AES_convert_key__axtls
-+ #define RC4_setup         RC4_setup__axtls
-+ #define RC4_crypt         RC4_crypt__axtls
-+ #define SHA1_Init         SHA1_Init__axtls
-+ #define SHA1_Update       SHA1_Update__axtls
-+ #define SHA1_Final        SHA1_Final__axtls
-+ #define SHA256_Init       SHA256_Init__axtls
-+ #define SHA256_Update     SHA256_Update__axtls
-+ #define SHA256_Final      SHA256_Final__axtls
-+ #define SHA384_Init       SHA384_Init__axtls
-+ #define SHA384_Update     SHA384_Update__axtls
-+ #define SHA384_Final      SHA384_Final__axtls
-+ #define SHA512_Init       SHA512_Init__axtls
-+ #define SHA512_Update     SHA512_Update__axtls
-+ #define SHA512_Final      SHA512_Final__axtls
-+ #define MD5_Init          MD5_Init__axtls
-+ #define MD5_Update        MD5_Update__axtls
-+ #define MD5_Final         MD5_Final__axtls
-+ #define hmac_md5          hmac_md5__axtls
-+ #define hmac_sha1         hmac_sha1__axtls
-+ #define RSA_priv_key_new  RSA_priv_key_new__axtls
-+ #define RSA_pub_key_new   RSA_pub_key_new__axtls
-+ #define RSA_free          RSA_free__axtls
-+ #define RSA_decrypt       RSA_decrypt__axtls
-+ #define RSA_private       RSA_private__axtls
-+ #define RSA_sign_verify   RSA_sign_verify__axtls
-+ #define RSA_public        RSA_public__axtls
-+ #define RSA_encrypt       RSA_encrypt__axtls
-+ #define RSA_print         RSA_print__axtls
-+ #define RNG_initialize    RNG_initialize__axtls
-+ #define RNG_terminate     RNG_terminate__axtls
-+ #define get_random        get_random__axtls
-+ #define get_random_NZ     get_random_NZ__axtls
-+ 
+ //    if (header_issue())
+ //    {
+ //        printf("Header tests failed\n"); TTY_FLUSH();
+--- a/axTLS/ssl/test/killopenssl.sh	Sun Jun 12 19:39:34 2016
++++ b/axTLS/ssl/test/killopenssl.sh	Sat Aug 20 03:36:18 2016
+@@ -1,2 +1,3 @@
+ #!/bin/sh
+-ps -ef|grep openssl | /usr/bin/awk '{print $2}' |xargs kill -9
++awk '{print $1}' "../ssl/openssl.pid" | xargs kill -9
++rm -f ../ssl/openssl.pid
+--- a/axTLS/ssl/test/killgnutls.sh	Sun Jun 12 19:39:34 2016
++++ b/axTLS/ssl/test/killgnutls.sh	Sat Aug 20 03:36:18 2016
+@@ -1,2 +1,2 @@
+ #!/bin/sh
+-ps -ef|grep gnutls-serv | /usr/bin/awk '{print $2}' |xargs kill -9
++#ps -ef|grep gnutls-serv | /usr/bin/awk '{print $2}' |xargs kill -9
+--- a/axTLS/ssl/os_port.h	Tue Jul  5 16:33:36 2016
++++ b/axTLS/ssl/os_port.h	Sat Aug 20 03:36:18 2016
+@@ -42,7 +42,7 @@
+ #endif
+ 
+ #include "os_int.h"
+-#include "config.h"
++#include "../config/config.h"
+ #include <stdio.h>
+ 
+ #if defined(WIN32)
+@@ -60,6 +60,8 @@
+ 
+ #ifdef WIN32
+ 
++#include <windows.h>
++
+ /* Windows CE stuff */
+ #if defined(_WIN32_WCE)
+ #include <basetsd.h>
+@@ -98,8 +100,12 @@
+ #define usleep(A)               Sleep(A/1000)
+ #define strdup(A)               _strdup(A)
+ #define chroot(A)               _chdir(A)
++#ifndef chdir
+ #define chdir(A)                _chdir(A)
++#endif
++#ifndef alloca
+ #define alloca(A)               _alloca(A)
++#endif
+ #ifndef lseek
+ #define lseek(A,B,C)            _lseek(A,B,C)
+ #endif
+@@ -118,9 +124,17 @@
+ 
+ typedef int socklen_t;
+ 
++#if !defined(__MINGW32__)
+ EXP_FUNC void STDCALL gettimeofday(struct timeval* t,void* timezone);
+ EXP_FUNC int STDCALL strcasecmp(const char *s1, const char *s2);
+ EXP_FUNC int STDCALL getdomainname(char *buf, int buf_size);
++#endif /*!defined(__MINGW32__)*/
++
++#if defined(__MINGW32__)
++#include <malloc.h>
++#include <sys/time.h>
++#define be64toh(x) __builtin_bswap64(x)
++#endif /*defined(__MINGW32__)*/
+ 
+ #else   /* Not Win32 */
+ 
+@@ -136,13 +150,22 @@
+ #include <sys/wait.h>
+ #include <netinet/in.h>
+ #include <arpa/inet.h>
+-#include <asm/byteorder.h>
+ 
+ #define SOCKET_READ(A,B,C)      read(A,B,C)
+ #define SOCKET_WRITE(A,B,C)     write(A,B,C)
+ #define SOCKET_CLOSE(A)         if (A >= 0) close(A)
+ #define TTY_FLUSH()
+ 
++/* get be64toh */
++#if    defined(__APPLE__)
++#include <libkern/OSByteOrder.h>
++#define be64toh(x) OSSwapBigToHostInt64(x)
++#elif  defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
++#include <sys/endian.h>
++#else
++#include <asm/byteorder.h>
++#endif
++
+ #ifndef be64toh
+ #define be64toh(x) __be64_to_cpu(x)
+ #endif
+--- a/axTLS/ssl/os_port.c	Wed Jul  6 04:31:16 2016
++++ b/axTLS/ssl/os_port.c	Sat Aug 20 03:36:18 2016
+@@ -40,6 +40,7 @@
+ #include "os_port.h"
+ 
+ #ifdef WIN32
++#ifndef __MINGW32__
+ /**
+  * gettimeofday() not in Win32 
+  */
+@@ -88,5 +89,6 @@
+     RegCloseKey(hKey);
+     return 0; 
+ }
++#endif /*__MINGW32__*/
+ #endif
+ 
+--- a/axTLS/crypto/os_int.h	Wed Jul  6 04:55:28 2016
++++ b/axTLS/crypto/os_int.h	Sat Aug 20 03:36:18 2016
+@@ -41,7 +41,7 @@
+ extern "C" {
+ #endif
+ 
+-#if defined(WIN32)
++#if defined(WIN32) && !defined(__MINGW32__)
+ typedef UINT8 uint8_t;
+ typedef INT8 int8_t;
+ typedef UINT16 uint16_t;
+--- a/axTLS/crypto/crypto_misc.c	Wed Jul  6 04:49:46 2016
++++ b/axTLS/crypto/crypto_misc.c	Sat Aug 20 03:36:18 2016
+@@ -48,7 +48,7 @@
+ static HCRYPTPROV gCryptProv;
+ #endif
+ 
+-#if (!defined(CONFIG_USE_DEV_URANDOM) && !defined(CONFIG_WIN32_USE_CRYPTO_LIB))
++#if (!defined(CONFIG_USE_DEV_URANDOM) && !defined(CONFIG_WIN32_USE_CRYPTO_LIB)) || !defined(ENTROPY_POOL_SIZE) /* The last condition added to compile on MinGW */
+ /* change to processor registers as appropriate */
+ #define ENTROPY_POOL_SIZE 32
+ #define ENTROPY_COUNTER1 ((((uint64_t)tv.tv_sec)<<32) | tv.tv_usec)
+--- a/axTLS/crypto/crypto.h	Sun Jul 24 16:31:34 2016
++++ b/axTLS/crypto/crypto.h	Sat Aug 20 03:36:18 2016
+@@ -39,6 +39,7 @@
+ extern "C" {
+ #endif
+ 
++#include "../config/config.h"
+ #include "bigint_impl.h"
+ #include "bigint.h"
+ 
+--- a/axTLS/crypto/bigint_impl.h	Sun Jun 12 19:39:34 2016
++++ b/axTLS/crypto/bigint_impl.h	Sat Aug 20 03:36:18 2016
+@@ -61,7 +61,7 @@
+ typedef uint32_t long_comp;     /**< A double precision component. */
+ typedef int32_t slong_comp;     /**< A signed double precision component. */
+ #else /* regular 32 bit */
+-#ifdef WIN32
++#if defined(WIN32) && !defined(__MINGW32__)
+ #define COMP_RADIX          4294967296i64         
+ #define COMP_MAX            0xFFFFFFFFFFFFFFFFui64
+ #else
+--- a/axTLS/config/config.h	Thu Jan  1 09:00:00 1970
++++ b/axTLS/config/config.h	Sat Aug 20 03:36:18 2016
+@@ -0,0 +1,149 @@
++/*
++ * In original axTLS, this file is automatically generated.
++ * To include in Gauche, we hand-edited this file, so be careful
++ * not to clobber this file.
++ */
++
++/*
++ * General Configuration
++ */
++#define CONFIG_DEBUG 1
++
++/*
++ * SSL Library
++ */
++#undef CONFIG_SSL_SERVER_ONLY
++#undef CONFIG_SSL_CERT_VERIFICATION
++#undef CONFIG_SSL_ENABLE_CLIENT
++#define CONFIG_SSL_FULL_MODE 1
++#undef CONFIG_SSL_SKELETON_MODE
++#undef CONFIG_SSL_PROT_LOW
++#define CONFIG_SSL_PROT_MEDIUM 1
++#undef CONFIG_SSL_PROT_HIGH
++#define CONFIG_SSL_USE_DEFAULT_KEY 1
++#define CONFIG_SSL_PRIVATE_KEY_LOCATION ""
++#define CONFIG_SSL_PRIVATE_KEY_PASSWORD ""
++#define CONFIG_SSL_X509_CERT_LOCATION ""
++#undef CONFIG_SSL_GENERATE_X509_CERT
++#define CONFIG_SSL_X509_COMMON_NAME ""
++#define CONFIG_SSL_X509_ORGANIZATION_NAME ""
++#define CONFIG_SSL_X509_ORGANIZATION_UNIT_NAME ""
++#undef CONFIG_SSL_ENABLE_V23_HANDSHAKE
++#define CONFIG_SSL_HAS_PEM 1
++#define CONFIG_SSL_USE_PKCS12 1
++#define CONFIG_SSL_EXPIRY_TIME 24
++#define CONFIG_X509_MAX_CA_CERTS 150
++#define CONFIG_SSL_MAX_CERTS 3
++#undef CONFIG_SSL_CTX_MUTEXING
++#define CONFIG_USE_DEV_URANDOM 1
++#ifdef WIN32
++#define CONFIG_WIN32_USE_CRYPTO_LIB 1
++#endif /*WIN32*/
++#undef CONFIG_OPENSSL_COMPATIBLE
++#undef CONFIG_PERFORMANCE_TESTING
++#undef CONFIG_SSL_TEST
++#undef CONFIG_AXTLSWRAP
++#undef CONFIG_AXHTTPD
++#undef CONFIG_HTTP_STATIC_BUILD
++#define CONFIG_HTTP_PORT 
++#define CONFIG_HTTP_HTTPS_PORT 
++#define CONFIG_HTTP_SESSION_CACHE_SIZE 
++#define CONFIG_HTTP_WEBROOT ""
++#define CONFIG_HTTP_TIMEOUT 
++#undef CONFIG_HTTP_HAS_CGI
++#define CONFIG_HTTP_CGI_EXTENSIONS ""
++#undef CONFIG_HTTP_ENABLE_LUA
++#define CONFIG_HTTP_LUA_PREFIX ""
++#define CONFIG_HTTP_LUA_CGI_LAUNCHER ""
++#undef CONFIG_HTTP_BUILD_LUA
++#undef CONFIG_HTTP_DIRECTORIES
++#undef CONFIG_HTTP_HAS_AUTHORIZATION
++#undef CONFIG_HTTP_HAS_IPV6
++#undef CONFIG_HTTP_ENABLE_DIFFERENT_USER
++#define CONFIG_HTTP_USER ""
++#undef CONFIG_HTTP_VERBOSE
++#undef CONFIG_HTTP_IS_DAEMON
++
++/*
++ * Language Bindings
++ */
++#undef CONFIG_BINDINGS
++#undef CONFIG_CSHARP_BINDINGS
++#undef CONFIG_VBNET_BINDINGS
++#define CONFIG_DOT_NET_FRAMEWORK_BASE ""
++#undef CONFIG_JAVA_BINDINGS
++#define CONFIG_JAVA_HOME ""
++#undef CONFIG_PERL_BINDINGS
++#define CONFIG_PERL_CORE ""
++#define CONFIG_PERL_LIB ""
++#undef CONFIG_LUA_BINDINGS
++#define CONFIG_LUA_CORE ""
++
++/*
++ * Samples
++ */
++#define CONFIG_SAMPLES 1
++#define CONFIG_C_SAMPLES 1
++#undef CONFIG_CSHARP_SAMPLES
++#undef CONFIG_VBNET_SAMPLES
++#undef CONFIG_JAVA_SAMPLES
++#undef CONFIG_PERL_SAMPLES
++#undef CONFIG_LUA_SAMPLES
++
++/*
++ * BigInt Options
++ */
++#undef CONFIG_BIGINT_CLASSICAL
++#undef CONFIG_BIGINT_MONTGOMERY
++#define CONFIG_BIGINT_BARRETT 1
++#define CONFIG_BIGINT_CRT 1
++#undef CONFIG_BIGINT_KARATSUBA
++#define MUL_KARATSUBA_THRESH 
++#define SQU_KARATSUBA_THRESH 
++#define CONFIG_BIGINT_SLIDING_WINDOW 1
++#define CONFIG_BIGINT_SQUARE 1
++#define CONFIG_BIGINT_CHECK_ON 1
++#define CONFIG_INTEGER_32BIT 1
++#undef CONFIG_INTEGER_16BIT
++#undef CONFIG_INTEGER_8BIT
++
++/* The following macros rename APIs defined in the files under crypto
++   directory. This is to avoid build-time problems when those names
++   conflict with system-provided ones. */
++#define AES_set_key       AES_set_key__axtls
++#define AES_cbc_encrypt   AES_cbc_encrypt__axtls
++#define AES_cbc_decrypt   AES_cbc_decrypt__axtls
++#define AES_convert_key   AES_convert_key__axtls
++#define RC4_setup         RC4_setup__axtls
++#define RC4_crypt         RC4_crypt__axtls
++#define SHA1_Init         SHA1_Init__axtls
++#define SHA1_Update       SHA1_Update__axtls
++#define SHA1_Final        SHA1_Final__axtls
++#define SHA256_Init       SHA256_Init__axtls
++#define SHA256_Update     SHA256_Update__axtls
++#define SHA256_Final      SHA256_Final__axtls
++#define SHA384_Init       SHA384_Init__axtls
++#define SHA384_Update     SHA384_Update__axtls
++#define SHA384_Final      SHA384_Final__axtls
++#define SHA512_Init       SHA512_Init__axtls
++#define SHA512_Update     SHA512_Update__axtls
++#define SHA512_Final      SHA512_Final__axtls
++#define MD5_Init          MD5_Init__axtls
++#define MD5_Update        MD5_Update__axtls
++#define MD5_Final         MD5_Final__axtls
++#define hmac_md5          hmac_md5__axtls
++#define hmac_sha1         hmac_sha1__axtls
++#define RSA_priv_key_new  RSA_priv_key_new__axtls
++#define RSA_pub_key_new   RSA_pub_key_new__axtls
++#define RSA_free          RSA_free__axtls
++#define RSA_decrypt       RSA_decrypt__axtls
++#define RSA_private       RSA_private__axtls
++#define RSA_sign_verify   RSA_sign_verify__axtls
++#define RSA_public        RSA_public__axtls
++#define RSA_encrypt       RSA_encrypt__axtls
++#define RSA_print         RSA_print__axtls
++#define RNG_initialize    RNG_initialize__axtls
++#define RNG_terminate     RNG_terminate__axtls
++#define get_random        get_random__axtls
++#define get_random_NZ     get_random_NZ__axtls
++


### PR DESCRIPTION
Change axTLS local patch format into "unified diff" format.
Many modern tools including Git uses this format.