### PR TITLE
Update to axTLS 2.0.1

### DIFF
--- a/ext/tls/axTLS/crypto/rc4.c
+++ b/ext/tls/axTLS/crypto/rc4.c
@@ -37,6 +37,9 @@
 #include "os_port.h"
 #include "crypto.h"
 
+/* only used for PKCS12 now */
+#ifdef CONFIG_SSL_USE_PKCS12
+
 /**
  * Get ready for an encrypt/decrypt operation
  */
@@ -90,3 +93,5 @@ void RC4_crypt(RC4_CTX *ctx, const uint8_t *msg, uint8_t *out, int length)
     ctx->x = x;
     ctx->y = y;
 }
+
+#endif

--- a/ext/tls/axTLS/ssl/tls1.c
+++ b/ext/tls/axTLS/ssl/tls1.c
@@ -647,7 +647,7 @@ static void add_hmac_digest(SSL *ssl, int mode, uint8_t *hmac_header,
         const uint8_t *buf, int buf_len, uint8_t *hmac_buf)
 {
     int hmac_len = buf_len + 8 + SSL_RECORD_SIZE;
-    uint8_t *t_buf = (uint8_t *)alloca(buf_len+100);
+    uint8_t *t_buf = (uint8_t *)alloca(hmac_len);
 
     memcpy(t_buf, (mode == SSL_SERVER_WRITE || mode == SSL_CLIENT_WRITE) ? 
                     ssl->write_sequence : ssl->read_sequence, 8);
@@ -847,8 +847,8 @@ static void prf(SSL *ssl, const uint8_t *sec, int sec_len,
     {
         int len, i;
         const uint8_t *S1, *S2;
-        uint8_t xbuf[256]; /* needs to be > the amount of key data */
-        uint8_t ybuf[256]; /* needs to be > the amount of key data */
+        uint8_t xbuf[2*(SHA256_SIZE+32+16) + MD5_SIZE]; /* max keyblock */
+        uint8_t ybuf[2*(SHA256_SIZE+32+16) + SHA1_SIZE]; /* max keyblock */
 
         len = sec_len/2;
         S1 = sec;

--- a/ext/tls/axTLS/ssl/version.h
+++ b/ext/tls/axTLS/ssl/version.h
@@ -1,1 +1,1 @@
-#define AXTLS_VERSION    "2.0.0"
+#define AXTLS_VERSION    "2.0.1"

--- a/ext/tls/axtls.diff
+++ b/ext/tls/axtls.diff
@@ -1,16 +1,16 @@
---- a/axTLS/ssl/tls1_clnt.c	Tue Aug 16 15:33:42 2016
-+++ b/axTLS/ssl/tls1_clnt.c	Mon Aug 22 02:48:44 2016
+--- a/axTLS/ssl/tls1_clnt.c	2016-08-30 19:20:07.000000000 +0900
++++ b/axTLS/ssl/tls1_clnt.c	2016-08-27 00:27:07.241885389 +0900
 @@ -311,7 +311,7 @@
      offset += 2; // ignore compression
      PARANOIA_CHECK(pkt_size, offset);
  
--    ssl->dc->bm_proc_index = offset+1; 
+-    ssl->dc->bm_proc_index = offset; 
 +    ssl->dc->bm_proc_index = offset;
      PARANOIA_CHECK(pkt_size, offset);
  
      // no extensions
---- a/axTLS/ssl/tls1.h	Wed Aug 17 18:54:52 2016
-+++ b/axTLS/ssl/tls1.h	Sat Aug 20 03:36:18 2016
+--- a/axTLS/ssl/tls1.h	2016-08-17 18:54:52.000000000 +0900
++++ b/axTLS/ssl/tls1.h	2016-09-03 00:06:40.056672130 +0900
 @@ -41,7 +41,7 @@
  #endif
  
@@ -20,8 +20,8 @@
  #include "os_int.h"
  #include "os_port.h"
  #include "crypto.h"
---- a/axTLS/ssl/test/ssltest.c	Wed Aug 17 18:56:58 2016
-+++ b/axTLS/ssl/test/ssltest.c	Sat Aug 20 03:36:18 2016
+--- a/axTLS/ssl/test/ssltest.c	2016-08-30 19:19:43.000000000 +0900
++++ b/axTLS/ssl/test/ssltest.c	2016-08-27 00:27:07.241885389 +0900
 @@ -922,19 +922,23 @@
  static int client_socket_init(uint16_t port)
  {
@@ -70,19 +70,7 @@
      ret = 0;
  
  cleanup:
-@@ -1540,7 +1546,11 @@
-     else
-     {
-         sprintf(openssl_buf, "openssl s_server " 
-+#ifdef WIN32
-+                "-accept %d -quiet %s", 
-+#else
-                 "-accept %d -quiet %s > /dev/null", 
-+#endif
-                 g_port, svr->openssl_option);
-     }
- //printf("SERVER %s\n", openssl_buf);
-@@ -1756,7 +1766,9 @@
+@@ -1760,7 +1766,9 @@
      if ((ret = SSL_client_test("Client renegotiation", 
                      &ssl_ctx, NULL, &sess_resume, 
                      DEFAULT_CLNT_OPTION, NULL, NULL, NULL)))
@@ -93,7 +81,7 @@
      sess_resume.do_reneg = 0;
  
      sess_resume.stop_server = 1;
-@@ -1876,6 +1888,7 @@
+@@ -1880,6 +1888,7 @@
  
      printf("SSL client test \"Invalid certificate type\" passed\n");
  
@@ -101,7 +89,7 @@
      if ((ret = SSL_client_test("GNUTLS client", 
                      &ssl_ctx,
                      "--x509certfile ../ssl/test/axTLS.x509_1024.pem "
-@@ -1892,7 +1905,7 @@
+@@ -1896,7 +1905,7 @@
                      DEFAULT_CLNT_OPTION|SSL_SERVER_VERIFY_LATER, 
                      NULL, NULL, NULL)))
          goto cleanup;
@@ -110,7 +98,7 @@
      ret = 0;
  
  cleanup:
-@@ -2380,6 +2393,10 @@
+@@ -2384,6 +2393,10 @@
      int ret = 1;
      BI_CTX *bi_ctx;
      int fd;
@@ -121,7 +109,7 @@
  
  #ifdef WIN32
      WSADATA wsaData;
-@@ -2393,6 +2410,12 @@
+@@ -2397,6 +2410,12 @@
      dup2(fd, 2);
  #endif
  
@@ -134,7 +122,7 @@
      /* can't do testing in this mode */
  #if defined CONFIG_SSL_GENERATE_X509_CERT
      printf("Error: Must compile with default key/certificates\n");
-@@ -2488,6 +2511,10 @@
+@@ -2492,6 +2511,10 @@
  
      SYSTEM("sh ../ssl/test/killopenssl.sh");
  
@@ -145,7 +133,7 @@
      if (SSL_client_tests())
          goto cleanup;
  
-@@ -2499,6 +2526,10 @@
+@@ -2503,6 +2526,10 @@
  
      SYSTEM("sh ../ssl/test/killopenssl.sh");
  
@@ -156,21 +144,21 @@
  //    if (header_issue())
  //    {
  //        printf("Header tests failed\n"); TTY_FLUSH();
---- a/axTLS/ssl/test/killopenssl.sh	Sun Jun 12 19:39:34 2016
-+++ b/axTLS/ssl/test/killopenssl.sh	Sat Aug 20 03:36:18 2016
+--- a/axTLS/ssl/test/killopenssl.sh	2016-06-12 19:39:35.000000000 +0900
++++ b/axTLS/ssl/test/killopenssl.sh	2016-08-11 20:27:20.085800717 +0900
 @@ -1,2 +1,3 @@
  #!/bin/sh
 -ps -ef|grep openssl | /usr/bin/awk '{print $2}' |xargs kill -9
 +awk '{print $1}' "../ssl/openssl.pid" | xargs kill -9
 +rm -f ../ssl/openssl.pid
---- a/axTLS/ssl/test/killgnutls.sh	Sun Jun 12 19:39:34 2016
-+++ b/axTLS/ssl/test/killgnutls.sh	Sat Aug 20 03:36:18 2016
+--- a/axTLS/ssl/test/killgnutls.sh	2016-06-12 19:39:35.000000000 +0900
++++ b/axTLS/ssl/test/killgnutls.sh	2016-08-11 20:27:20.085800717 +0900
 @@ -1,2 +1,2 @@
  #!/bin/sh
 -ps -ef|grep gnutls-serv | /usr/bin/awk '{print $2}' |xargs kill -9
 +#ps -ef|grep gnutls-serv | /usr/bin/awk '{print $2}' |xargs kill -9
---- a/axTLS/ssl/os_port.h	Tue Jul  5 16:33:36 2016
-+++ b/axTLS/ssl/os_port.h	Sat Aug 20 03:36:18 2016
+--- a/axTLS/ssl/os_port.h	2016-07-05 16:33:37.000000000 +0900
++++ b/axTLS/ssl/os_port.h	2016-08-14 21:41:27.759507681 +0900
 @@ -42,7 +42,7 @@
  #endif
  
@@ -244,8 +232,8 @@
  #ifndef be64toh
  #define be64toh(x) __be64_to_cpu(x)
  #endif
---- a/axTLS/ssl/os_port.c	Wed Jul  6 04:31:16 2016
-+++ b/axTLS/ssl/os_port.c	Sat Aug 20 03:36:18 2016
+--- a/axTLS/ssl/os_port.c	2016-07-06 04:31:16.000000000 +0900
++++ b/axTLS/ssl/os_port.c	2016-08-27 00:27:07.245885381 +0900
 @@ -40,6 +40,7 @@
  #include "os_port.h"
  
@@ -261,8 +249,8 @@
 +#endif /*__MINGW32__*/
  #endif
  
---- a/axTLS/crypto/os_int.h	Wed Jul  6 04:55:28 2016
-+++ b/axTLS/crypto/os_int.h	Sat Aug 20 03:36:18 2016
+--- a/axTLS/crypto/os_int.h	2016-07-06 04:55:29.000000000 +0900
++++ b/axTLS/crypto/os_int.h	2016-08-27 00:27:07.249885373 +0900
 @@ -41,7 +41,7 @@
  extern "C" {
  #endif
@@ -272,8 +260,8 @@
  typedef UINT8 uint8_t;
  typedef INT8 int8_t;
  typedef UINT16 uint16_t;
---- a/axTLS/crypto/crypto_misc.c	Wed Jul  6 04:49:46 2016
-+++ b/axTLS/crypto/crypto_misc.c	Sat Aug 20 03:36:18 2016
+--- a/axTLS/crypto/crypto_misc.c	2016-07-06 04:49:47.000000000 +0900
++++ b/axTLS/crypto/crypto_misc.c	2016-08-27 00:27:07.249885373 +0900
 @@ -48,7 +48,7 @@
  static HCRYPTPROV gCryptProv;
  #endif
@@ -283,8 +271,8 @@
  /* change to processor registers as appropriate */
  #define ENTROPY_POOL_SIZE 32
  #define ENTROPY_COUNTER1 ((((uint64_t)tv.tv_sec)<<32) | tv.tv_usec)
---- a/axTLS/crypto/crypto.h	Sun Jul 24 16:31:34 2016
-+++ b/axTLS/crypto/crypto.h	Sat Aug 20 03:36:18 2016
+--- a/axTLS/crypto/crypto.h	2016-07-24 16:31:34.000000000 +0900
++++ b/axTLS/crypto/crypto.h	2016-08-21 20:40:51.313381885 +0900
 @@ -39,6 +39,7 @@
  extern "C" {
  #endif
@@ -293,8 +281,8 @@
  #include "bigint_impl.h"
  #include "bigint.h"
  
---- a/axTLS/crypto/bigint_impl.h	Sun Jun 12 19:39:34 2016
-+++ b/axTLS/crypto/bigint_impl.h	Sat Aug 20 03:36:18 2016
+--- a/axTLS/crypto/bigint_impl.h	2016-06-12 19:39:34.000000000 +0900
++++ b/axTLS/crypto/bigint_impl.h	2016-08-11 20:27:20.077800719 +0900
 @@ -61,7 +61,7 @@
  typedef uint32_t long_comp;     /**< A double precision component. */
  typedef int32_t slong_comp;     /**< A signed double precision component. */
@@ -304,8 +292,8 @@
  #define COMP_RADIX          4294967296i64         
  #define COMP_MAX            0xFFFFFFFFFFFFFFFFui64
  #else
---- a/axTLS/config/config.h	Thu Jan  1 09:00:00 1970
-+++ b/axTLS/config/config.h	Sat Aug 20 03:36:18 2016
+--- a/axTLS/config/config.h	1970-01-01 09:00:00.000000000 +0900
++++ b/axTLS/config/config.h	2016-08-11 20:27:20.077800719 +0900
 @@ -0,0 +1,149 @@
 +/*
 + * In original axTLS, this file is automatically generated.


### PR DESCRIPTION
Update to axTLS 2.0.1 from upstream source code.

* RC4 only used if PKCS12 is used.
* Buffer sizes tightened up.