### PR TITLE
Force static linking to iconv and zlib on MinGW

### DIFF
--- a/ext/charconv/charconv.ac
+++ b/ext/charconv/charconv.ac
@@ -86,6 +86,10 @@ AS_IF([test "$ac_cv_use_iconv" = yes], [
   ])
 ])
 
+dnl Force static linking on MinGW
+AS_CASE(["$target"],
+  [*mingw*], [ICONV_LIB="-Wl,-dn,$ICONV_LIB,-dy"])
+
 AS_IF([test "$ac_cv_use_iconv" = yes], [
   AC_DEFINE(USE_ICONV, [], [Define if uses iconv])
   EXT_LIBS="$EXT_LIBS $ICONV_LIB"

--- a/ext/zlib/Makefile.in
+++ b/ext/zlib/Makefile.in
@@ -6,7 +6,7 @@ include ../Makefile.ext
 
 XCPPFLAGS = @ZLIB_CPPFLAGS@
 XLDFLAGS  = @ZLIB_LDFLAGS@
-XLIBS     = -lz
+XLIBS     = @ZLIB_LIB@
 
 SCM_CATEGORY = rfc
 

--- a/ext/zlib/zlib.ac
+++ b/ext/zlib/zlib.ac
@@ -64,6 +64,10 @@ AS_IF([test "$ac_cv_use_zlib" = yes], [
   LIBS="$save_libs"
 ])
 
+dnl Force static linking on MinGW
+AS_CASE(["$target"],
+  [*mingw*], [ZLIB_LIB="-Wl,-dn,$ZLIB_LIB,-dy"])
+
 AS_IF([test "$ac_cv_use_zlib" = yes], [
   AC_DEFINE(USE_ZLIB, [], [Define if uses zlib])
   ZLIB_ARCHFILES=rfc--zlib.$SHLIB_SO_SUFFIX
@@ -76,7 +80,7 @@ AS_IF([test "$ac_cv_use_zlib" = yes], [
 ])
 AC_SUBST(ZLIB_CPPFLAGS)
 AC_SUBST(ZLIB_LDFLAGS)
-
+AC_SUBST(ZLIB_LIB)
 
 dnl Local variables:
 dnl mode: autoconf

--- a/src/mingw-dist.sh
+++ b/src/mingw-dist.sh
@@ -95,7 +95,7 @@ make install-examples
 rm -rf $distdir/lib/libgauche.dll*
 case "$MSYSTEM" in
   MINGW64|MINGW32)
-    for dll in libwinpthread-1.dll libcharset-1.dll libiconv-2.dll zlib1.dll libz-1.dll; do
+    for dll in libwinpthread-1.dll; do
       if [ -f $mingwdir/bin/$dll ]; then
         cp $mingwdir/bin/$dll $distdir/bin
       fi
@@ -103,11 +103,6 @@ case "$MSYSTEM" in
     ;;
   *)
     cp $mingwdir/bin/mingwm10.dll $distdir/bin
-    for dll in libcharset-1.dll libiconv-2.dll zlib1.dll libz-1.dll; do
-      if [ -f $mingwdir/bin/$dll ]; then
-        cp $mingwdir/bin/$dll $distdir/bin
-      fi
-    done
     ;;
 esac
 


### PR DESCRIPTION
MinGW の場合に、iconv と zlib をスタティックリンクにしてみました。
これによって、libcharset-1.dll, libiconv-2.dll, zlib1.dll, libgcc_s_dw2-1.dll
の配布が不要になります。


＜テスト結果＞
OS : Windows 8.1 (64bit)
Gauche : コミット b21d01b

開発環境1 : MSYS2/MinGW-w64 (64bit) (gcc version 5.3.0 (Rev1, Built by MSYS2 project))
Total: 16508 tests, 16508 passed,     0 failed,     0 aborted.

開発環境2 : MSYS2/MinGW-w64 (32bit) (gcc version 5.3.0 (Rev1, Built by MSYS2 project))
Total: 16508 tests, 16508 passed,     0 failed,     0 aborted.

開発環境3 : MinGW.org (32bitのみ) (gcc v4.8.1)
Total: 16511 tests, 16511 passed,     0 failed,     0 aborted.
