### PR TITLE
Delete documentencoding of info files

### DIFF
--- a/doc/gauche-dev.texi
+++ b/doc/gauche-dev.texi
@@ -2,9 +2,8 @@
 \input texinfo    @c -*- mode: texinfo; coding: utf-8; -*-
 @c JP
 \input texinfo-ja @c -*- mode: texinfo; coding: utf-8; -*-
-@comment %**start of header
 @c COMMON
-@documentencoding UTF-8
+@comment %**start of header
 @c EN
 @documentlanguage en
 @setfilename gauche-deve.info
@@ -14,6 +13,7 @@
 * Gauche Developers' Reference: (gauche-deve.info).	Internals of Gauche
 @end direntry
 @c JP
+@documentencoding UTF-8
 @documentlanguage ja
 @setfilename gauche-devj.info
 @settitle Gauche Developers' Reference

--- a/doc/gauche-ref.texi
+++ b/doc/gauche-ref.texi
@@ -2,9 +2,8 @@
 \input texinfo    @c -*- mode: texinfo; coding: utf-8; -*-
 @c JP
 \input texinfo-ja @c -*- mode: texinfo; coding: utf-8; -*-
-@comment %**start of header
 @c COMMON
-@documentencoding UTF-8
+@comment %**start of header
 @c EN
 @documentlanguage en
 @setfilename gauche-refe.info
@@ -15,6 +14,7 @@
 * Gauche: (gauche-refe.info).	        An R7RS Scheme implementation.
 @end direntry
 @c JP
+@documentencoding UTF-8
 @documentlanguage ja
 @setfilename gauche-refj.info
 @settitle Gauche ユーザリファレンス


### PR DESCRIPTION
Windows 上で Gauche をショートカットから起動して、,i cond 等を実行すると、
文字化けが発生する件に対応。
@code や @result がUnicode文字に変換されて、コンソールがCP932なので化ける。
#231 の変更から、EN の @documentencoding UTF-8 のみ削除しました。
