### PR TITLE
(char-general-category #\x20000) should be Lo

### DIFF
--- a/src/gauche/char_utf_8.h
+++ b/src/gauche/char_utf_8.h
@@ -294,7 +294,7 @@ static inline unsigned char Scm__LookupCharCategory(ScmChar ch)
 {
     if (ch == SCM_CHAR_INVALID || ch >= 0x10ffff) {
         return SCM_CHAR_CATEGORY_Cn;
-    } else if (ch <= 0x20000) {
+    } else if (ch < 0x20000) {
         return ucs_general_category_00000[ch];
     } else {
         return ucs_general_category_20000(ch);


### PR DESCRIPTION
`(char-general-category #\x20000)` returns `Lu` on my machine, but it should return `Lo`. 
See: http://www.fileformat.info/info/unicode/char/20000/index.htm

```
gosh> (gauche-version)
"0.9.5"
gosh> (gauche-architecture)
"x86_64-apple-darwin16.0.0"
gosh> (gauche-character-encoding)
utf-8
gosh> (char-general-category #\x20000)
Lu
```
