### PR TITLE
fix slib  path for windows x86_64

### DIFF
--- a/lib/slib.scm.in
+++ b/lib/slib.scm.in
@@ -21,7 +21,7 @@
 ;;; backward compatibility,
 
 (define software-type
-  (let ((t (if (#/-mingw32$/ (gauche-architecture))
+  (let ((t (if (#/-mingw/ (gauche-architecture))
              '(ms-dos . MS-DOS)
              '(unix . UNIX))))
     (lambda ()


### PR DESCRIPTION
This pull request fixes SLIB Path for Windows x86_64.

I found following error occurs when using Gauche-mingw-0.9.5-64bit.msi.
> *** ERROR: cannot find "/usr/local/slib/require" to load
>     While loading "c:\\Program Files\\Gauche\\share\\gauche-0.9\\0.9.5\\lib/slib.scm" at line 424
>     While compiling "D:\\home\\.gaucherc" at line 1: (use slib)
>     While loading "D:\\home\\.gaucherc" at line 1
>     While loading "c:\\Program Files\\Gauche\\share\\gauche-0.9\\0.9.5\\lib/gauche/interactive.scm" at line 321