### PR TITLE
Fix running commands for MSYS (mintty)

### DIFF
--- a/ext/tls/axtls-diff.scm
+++ b/ext/tls/axtls-diff.scm
@@ -32,8 +32,13 @@
                   (^[p s] (if (#/(\.[ch]$)|(\.sh$)|(^Makefile$)/ p) (cons p s) s)) xs))
 
 (define (do-diff file dir)
-  (let* ([orig (build-path dir (regexp-replace #/^axTLS\// file ""))]
-         [p (run-process `(diff -u -N ,orig ,file) :wait #f :output :pipe)]
+  (let* ([orig (build-path dir (regexp-replace #/^axTLS[\/\\]/ file ""))]
+         [p (run-process
+             (cond-expand
+              ;; for MSYS (mintty)
+              [gauche.os.windows `("cmd.exe" "/c" diff -u -N ,orig ,file)]
+              [else              `(diff -u -N ,orig ,file)])
+             :wait #f :output :pipe)]
          ;; We replace pathnames in the diff header to be friendly for patch.
          ;; Especially, newer version of GNU patch rejects patchfile that has
          ;; absolute pathname, or pathname includes '..'.

--- a/lib/gauche/interactive/toplevel.scm
+++ b/lib/gauche/interactive/toplevel.scm
@@ -257,6 +257,7 @@
   (^[line]
     (cond-expand
      [gauche.os.windows
+      ;; for MSYS (mintty)
       (if-let1 sh (sys-getenv "SHELL")
         (run-process `("cmd.exe" "/c" ,sh "-c" ,line) :wait #t)
         (run-process `("cmd.exe" "/c" ,line) :wait #t))]

--- a/lib/gauche/process.scm
+++ b/lib/gauche/process.scm
@@ -770,8 +770,8 @@
 (define (%apply-run-process command stdin stdout stderr host)
   (apply run-process
          (cond [(string? command)
-                (cond-expand [gauche.os.windows `("cmd" "/c" ,command)]
-                             [else        `("/bin/sh" "-c" ,command)])]
+                (cond-expand [gauche.os.windows `("cmd.exe" "/c" ,command)]
+                             [else              `("/bin/sh" "-c" ,command)])]
                [(list? command) command]
                [else (error "Bad command spec" command)])
          :input stdin :output stdout :host host


### PR DESCRIPTION
MSYS (mintty) 上で、コマンドの実行エラーになるものを洗い出して対応しました。

基本的には cmd.exe をかませると動作するようでした。パイプもいけるようです。
(ただし、termios.scm の msys-get-stty だけは、あいかわらず無理でした)

注意する点として、シェルの内部コマンドや、先頭行に `#!` を書いたスクリプト等については、
`` `("cmd.exe" "/c" ,sh "-c" ,cmd-str)`` のように、シェルもかませる必要がありました。

また、別案として、run-process に :wincmd のような キーワード引数を追加することも考えたのですが、
影響範囲が大きそうなこと (%apply-run-process 等もある) と、
MSYS (mintty) 以外では、cmd.exe をかませなくても問題なく実行できることから、やめておきました。
(MSYS (mintty) 上でも、gosh.exe や calc.exe のように、cmd.exe をかませなくても問題なく実行できる
ものもあります)


- doc/makedoc.scm
  makeinfo と gzip コマンドの実行に対応。
  makeinfo は perl のスクリプトだったので、`` `("cmd.exe" "/c" ,sh "-c" ,cmd-str)`` のように、
  シェルもかませるようにした。
  (古い MinGW.org では、makeinfo は exe でしたが。。。)

- ext/tls/axtls-diff.scm
  diff コマンドの実行に対応。

- ext/tls/test.scm
  `openssl version` コマンドの実行に対応。

- lib/gauche/process.scm
  "cmd" → "cmd.exe"
  と変更した (他に合わせた。動作に問題があったわけではない)。

- lib/gauche/interactive/toplevel.scm
  コメントを他に合わせた。


＜テスト結果＞
OS : Windows 8.1 (64bit)
Gauche : コミット 2ed9837 + 本変更

開発環境1 : MSYS2/MinGW-w64 (64bit) (gcc version 6.2.0 (Rev2, Built by MSYS2 project))
Total: 16509 tests, 16509 passed,     0 failed,     0 aborted.

開発環境2 : MSYS2/MinGW-w64 (32bit) (gcc version 6.2.0 (Rev2, Built by MSYS2 project))
Total: 16509 tests, 16509 passed,     0 failed,     0 aborted.

開発環境3 : MinGW.org (32bitのみ) (gcc v4.8.1)
Total: 16512 tests, 16512 passed,     0 failed,     0 aborted.
