### PR TITLE
Emit declarations of static define-cfn.

### DIFF
--- a/lib/gauche/cgen/cise.scm
+++ b/lib/gauche/cgen/cise.scm
@@ -464,11 +464,15 @@
   (define (type-symbol-type s)
     (string->symbol (string-drop (keyword->string s) 1)))
 
+  (define (gen-ret-type ret-type)
+    (match ret-type
+      [(x ...) (intersperse " " (map x->string x))]
+      [x (x->string x)]))
   (define (record-static name quals args ret-type)
     (cise-push-static-decl!
      `(,(source-info form env)
        ,@(gen-qualifiers quals) " "
-       ,ret-type" ",(cise-render-identifier name)
+       ,(gen-ret-type ret-type)" ",(cise-render-identifier name)
        "(",(gen-args args env)");")))
 
   (define (check-quals name quals args ret-type body)

--- a/lib/gauche/cgen/stub.scm
+++ b/lib/gauche/cgen/stub.scm
@@ -327,7 +327,9 @@
   (eval `(define-cise-expr ,@args) (current-module)))
 
 (define-form-parser define-cfn args
-  (cgen-body (cise-render-to-string `(define-cfn ,@args) 'toplevel)))
+  (parameterize ([cise-ambient (cise-ambient-copy (cise-ambient) '())])
+    (cgen-body (cise-render-to-string `(define-cfn ,@args) 'toplevel))
+    (cgen-decl (cise-ambient-decl-strings (cise-ambient)))))
 
 ;; extra check of valid clauses
 (define (check-clauses directive name clauses valid-keys)


### PR DESCRIPTION
This is a patch to emit function declarations which are generated by define-cfn with static qualifier.