### PR TITLE
Fix the order of #if conditions.

### DIFF
--- a/lib/gauche/cgen/literal.scm
+++ b/lib/gauche/cgen/literal.scm
@@ -159,14 +159,14 @@
               (if (eq? category 'constant) "SCM_CGEN_CONST " "")
               name)
       (dolist [dl dls]
-        (for-each (cut print "#if "<>) (~ dl'cpp-conditions))
+        (for-each (cut print "#if "<>) (reverse (~ dl'cpp-conditions)))
         (format #t "  ~a ~a[~a];\n" (~ dl'c-type) (~ dl'c-member-name)
                 (~ dl'count))
         (for-each (cut print "#endif /*"<>"*/") (~ dl'cpp-conditions)))
       (format #t "} ~a = " name)))
 
   (define (emit-initializers dl)
-    (for-each (cut print "#if "<>) (~ dl'cpp-conditions))
+    (for-each (cut print "#if "<>) (reverse (~ dl'cpp-conditions)))
     (print "  {   /* "(~ dl'c-type)" "(~ dl'c-member-name)" */")
     (dolist [thunk (reverse (~ dl'init-thunks))]
       (if (string? thunk)

--- a/lib/gauche/cgen/unit.scm
+++ b/lib/gauche/cgen/unit.scm
@@ -222,10 +222,10 @@
   (define (with-cpp-condition gf)
     (cond [(~ node'cpp-conditions)
            => (^[cppc] (cond [(method-overridden? gf)
-                              (for-each (cut print "#if " <>) cppc)
+                              (for-each (cut print "#if " <>) (reverse cppc))
                               (gf node)
                               (for-each (cut print "#endif /* "<>" */")
-                                        (reverse cppc))]
+                                        cppc)]
                              [else (gf node)]))]
           [else (gf node)]))
   (case part


### PR DESCRIPTION
Currently, the nested cpp conditions in stub are converted like below. But I think it isn't expected. This patch fixes the order of the conditions.

    (when "defined(FOO)"
      (when "defined(BAR)"
        ...))


Expected:

    #if defined(FOO)
    #if defined(BAR)
    ...
    #endif /* defined(BAR) */
    #endif /* defined(FOO) */


Actual (Current behavior):

    #if defined(BAR)
    #if defined(FOO)
    ...
    #endif /* defined(FOO) */
    #endif /* defined(BAR) */