### PR TITLE
Fix uint to u_int (flat numberical vector binary search)

### DIFF
--- a/src/gauche/priv/vectorP.h
+++ b/src/gauche/priv/vectorP.h
@@ -66,17 +66,17 @@
       :          :
  */
 
-size_t Scm_BinarySearchS8(int8_t vec[], size_t len, int8_t key, uint skip);
-size_t Scm_BinarySearchU8(uint8_t vec[], size_t len, uint8_t key, uint skip);
-size_t Scm_BinarySearchS16(int16_t vec[], size_t len, int16_t key, uint skip);
-size_t Scm_BinarySearchU16(uint16_t vec[], size_t len, uint16_t key, uint skip);
-size_t Scm_BinarySearchS32(int32_t vec[], size_t len, int32_t key, uint skip);
-size_t Scm_BinarySearchU32(uint32_t vec[], size_t len, uint32_t key, uint skip);
-size_t Scm_BinarySearchS64(ScmInt64 vec[], size_t len, int64_t key, uint skip);
-size_t Scm_BinarySearchU64(ScmUInt64 vec[], size_t len, uint64_t key, uint skip);
-size_t Scm_BinarySearchF16(ScmHalfFloat vec[], size_t len, ScmHalfFloat key, uint skip);
-size_t Scm_BinarySearchF32(float vec[], size_t len, float key, uint skip);
-size_t Scm_BinarySearchF64(double vec[], size_t len, double key, uint skip);
+size_t Scm_BinarySearchS8(int8_t vec[], size_t len, int8_t key, u_int skip);
+size_t Scm_BinarySearchU8(uint8_t vec[], size_t len, uint8_t key, u_int skip);
+size_t Scm_BinarySearchS16(int16_t vec[], size_t len, int16_t key, u_int skip);
+size_t Scm_BinarySearchU16(uint16_t vec[], size_t len, uint16_t key, u_int skip);
+size_t Scm_BinarySearchS32(int32_t vec[], size_t len, int32_t key, u_int skip);
+size_t Scm_BinarySearchU32(uint32_t vec[], size_t len, uint32_t key, u_int skip);
+size_t Scm_BinarySearchS64(ScmInt64 vec[], size_t len, int64_t key, u_int skip);
+size_t Scm_BinarySearchU64(ScmUInt64 vec[], size_t len, uint64_t key, u_int skip);
+size_t Scm_BinarySearchF16(ScmHalfFloat vec[], size_t len, ScmHalfFloat key, u_int skip);
+size_t Scm_BinarySearchF32(float vec[], size_t len, float key, u_int skip);
+size_t Scm_BinarySearchF64(double vec[], size_t len, double key, u_int skip);
 
 #endif /*GAUCHE_PRIV_VECTORP_H*/
 

--- a/src/libvec.scm
+++ b/src/libvec.scm
@@ -201,7 +201,7 @@
 (inline-stub
  (define-cise-stmt %binary-search
    [(_ elttype)
-    `(let* ([esize::uint (+ skip 1)]
+    `(let* ([esize::u_int  (+ skip 1)]
             [nume::size_t (/ len esize)]
             [k::size_t (/ nume 2)]
             [hi::size_t nume]
@@ -218,56 +218,56 @@
 
  (define-cfn Scm_BinarySearchS8 (vec::int8_t* len::size_t
                                               key::int8_t
-                                              skip::uint)
+                                              skip::u_int )
    ::size_t (%binary-search int8_t))
 
  (define-cfn Scm_BinarySearchU8 (vec::uint8_t* len::size_t
                                                key::uint8_t
-                                               skip::uint)
+                                               skip::u_int )
    ::size_t (%binary-search uint8_t))
 
  (define-cfn Scm_BinarySearchS16 (vec::int16_t* len::size_t
                                                 key::int16_t
-                                                skip::uint)
+                                                skip::u_int)
    ::size_t (%binary-search int16_t))
 
  (define-cfn Scm_BinarySearchU16 (vec::uint16_t* len::size_t
                                                  key::uint16_t
-                                                 skip::uint)
+                                                 skip::u_int)
    ::size_t (%binary-search uint16_t))
 
  (define-cfn Scm_BinarySearchS32 (vec::int32_t* len::size_t
                                                 key::int32_t
-                                                skip::uint)
+                                                skip::u_int)
    ::size_t (%binary-search int32_t))
 
  (define-cfn Scm_BinarySearchU32 (vec::uint32_t* len::size_t
                                                  key::uint32_t
-                                                 skip::uint)
+                                                 skip::u_int)
    ::size_t (%binary-search uint32_t))
 
  (define-cfn Scm_BinarySearchS64 (vec::ScmInt64* len::size_t
                                                  key::ScmInt64
-                                                 skip::uint)
+                                                 skip::u_int)
    ::size_t (%binary-search ScmInt64))
 
  (define-cfn Scm_BinarySearchU64 (vec::ScmUInt64* len::size_t
                                                   key::ScmUInt64
-                                                  skip::uint)
+                                                  skip::u_int)
    ::size_t (%binary-search ScmUInt64))
  
  (define-cfn Scm_BinarySearchF16 (vec::ScmHalfFloat* len::size_t
                                                      key::ScmHalfFloat
-                                                     skip::uint)
+                                                     skip::u_int)
    ::size_t (%binary-search ScmHalfFloat))
 
  (define-cfn Scm_BinarySearchF32 (vec::float* len::size_t
                                               key::float
-                                              skip::uint)
+                                              skip::u_int)
    ::size_t (%binary-search float))
 
  (define-cfn Scm_BinarySearchF64 (vec::double* len::size_t
                                                key::double
-                                               skip::uint)
+                                               skip::u_int)
    ::size_t (%binary-search double))
  )


### PR DESCRIPTION
uint が MinGW にないため、エラーになっていました。
他では u_int が使われているようなので、u_int に変更しました。
