### PR TITLE
Set WINVER and _WIN32_WINNT

### DIFF
--- a/ext/net/gauche-net.h
+++ b/ext/net/gauche-net.h
@@ -90,11 +90,6 @@ const char *inet_ntop(int af, const void *src, char *dst, socklen_t size);
 #define AI_ALL        0x00000100
 #define AI_ADDRCONFIG 0x00000400
 #define AI_V4MAPPED   0x00000800
-#if !defined(__MINGW64_VERSION_MAJOR)
-void WSAAPI freeaddrinfo(struct addrinfo*);
-int  WSAAPI getaddrinfo(const char*, const char*, const struct addrinfo*, struct addrinfo**);
-int  WSAAPI getnameinfo(const struct sockaddr*, socklen_t, char*, DWORD, char*, DWORD, int);
-#endif /*!defined(__MINGW64_VERSION_MAJOR)*/
 #endif /* HAVE_IPV6 */
 #endif /*GAUCHE_WINDOWS*/
 

--- a/src/gauche/win-compat.h
+++ b/src/gauche/win-compat.h
@@ -18,9 +18,13 @@ extern "C" {
 #define GAUCHE_WINDOWS 1
 
 /* Preparation. */
-#ifndef WINVER
-#define WINVER 0x0500           /* we support Windows 2000 or later */
-#endif /*WINVER*/
+#if !defined(WINVER)
+#define WINVER 0x0502           /* Windows XP SP2 or later */
+#endif /* !WINVER */
+
+#if !defined(_WIN32_WINNT)
+#define _WIN32_WINNT WINVER
+#endif /* !_WIN32_WINNT */
 
 #if defined(UNICODE) && !defined(_UNICODE)
 #define _UNICODE                /* Windows needs both UNICODE and _UNICODE */


### PR DESCRIPTION
src/gauche/win-compat.h で、WINVER と _WIN32_WINNT の値を両方設定するようにしました。
MinGW のヘッダファイル内では、両方が使われているようです。
現状は、MinGW-w64 のデフォルト値と同じ値(=0x0502)にしました。

また、これらを仮に大きい値(=0x0A00)に設定しても、ビルドできることを確認しました。
(使える Windows API が増えます。ただし、非対応のOSでそれらのAPIを使用すると、
「エントリポイントが見つかりません」という実行時エラーになります)

また、本設定によって、gauche-net.h で不要になった宣言があったので、削除しました。


＜テスト結果＞
OS : Windows 8.1 (64bit)
Gauche : コミット 4af9d85 + 本変更

開発環境1 : MSYS2/MinGW-w64 (64bit) (gcc version 6.2.0 (Rev2, Built by MSYS2 project))
Total: 17217 tests, 17217 passed,     0 failed,     0 aborted.

開発環境2 : MSYS2/MinGW-w64 (32bit) (gcc version 6.2.0 (Rev2, Built by MSYS2 project))
Total: 17217 tests, 17217 passed,     0 failed,     0 aborted.

開発環境3 : MinGW.org (32bitのみ) (gcc v4.8.1)
Total: 17220 tests, 17220 passed,     0 failed,     0 aborted.
