### PR TITLE
Enable profiler function on Windows

### DIFF
--- a/src/gauche/prof.h
+++ b/src/gauche/prof.h
@@ -112,7 +112,12 @@ struct ScmVMProfilerRec {
     ScmHashTable* statHash;     /* hashtable for collected data.
                                    value is a pair of integers,
                                    (<call-count> . <sample-hits>) */
-
+#if defined(GAUCHE_WINDOWS)
+    HANDLE hTargetThread;       /* target thread */
+    HANDLE hObserverThread;     /* observer thread */
+    HANDLE hTimerEvent;         /* sampling timer event */
+    char *samplerFileName;      /* temporary file name to remove the file */
+#endif
     ScmProfSample samples[SCM_PROF_SAMPLES_IN_BUFFER];
     ScmProfCount  counts[SCM_PROF_COUNTER_IN_BUFFER];
 };

--- a/src/gauche/vm.h
+++ b/src/gauche/vm.h
@@ -45,10 +45,10 @@
 
 #define SCM_PCTYPE ScmWord*
 
-#if defined(ITIMER_PROF) && defined(SIGPROF)
+#if (defined(ITIMER_PROF) && defined(SIGPROF)) || defined(GAUCHE_WINDOWS)
 /* define if you want to use profiler */
 #define GAUCHE_PROFILE
-#endif /* defined(ITIMER_PROF) && defined(SIGPROF) */
+#endif /* (defined(ITIMER_PROF) && defined(SIGPROF)) || defined(GAUCHE_WINDOWS) */
 
 
 #ifdef __GNUC__

--- a/src/prof.c
+++ b/src/prof.c
@@ -53,6 +53,65 @@
 
 #define SAMPLING_PERIOD 10000
 
+#if defined(GAUCHE_WINDOWS)
+
+static void sampler_sample(ScmVM*);
+
+static unsigned __stdcall observer_thread(void *arg)
+{
+    ScmVM *vm = (ScmVM*)arg;
+    CONTEXT ctx;
+    DWORD sleep_time;
+    DWORD resume_result = 0;
+
+    /* NB: We can't use Scm_SysError in this thread. */
+    /* NB: GetThreadContext might be required to make the target thread
+           certainly suspended. */
+    sleep_time = SAMPLING_PERIOD / 1000;
+    if (sleep_time <= 0) sleep_time = 1;
+    do {
+        if (resume_result != -1) {
+            if (SuspendThread(vm->prof->hTargetThread) != -1) {
+                if (GetThreadContext(vm->prof->hTargetThread, &ctx)) {
+                    sampler_sample(vm);
+                }
+            }
+        }
+        resume_result = ResumeThread(vm->prof->hTargetThread);
+    } while (WAIT_OBJECT_0 != WaitForSingleObject(vm->prof->hTimerEvent,
+                                                  sleep_time));
+    return 0;
+}
+
+static void ITIMER_START(void)
+{
+    ScmVM *vm = Scm_VM();
+
+    vm->prof->hTimerEvent = CreateEvent(NULL, FALSE, FALSE, NULL);
+    if (vm->prof->hTimerEvent == NULL) {
+        Scm_SysError("CreateEvent failed");
+    }
+    vm->prof->hObserverThread = (HANDLE)_beginthreadex(NULL, 0, observer_thread,
+                                                       (void*)vm, 0, NULL);
+    if (vm->prof->hObserverThread == NULL) {
+        Scm_SysError("_beginthreadex failed");
+    }
+}
+
+static void ITIMER_STOP(void)
+{
+    ScmVM *vm = Scm_VM();
+
+    SetEvent(vm->prof->hTimerEvent);
+    WaitForSingleObject(vm->prof->hObserverThread, INFINITE);
+    CloseHandle(vm->prof->hObserverThread);
+    vm->prof->hObserverThread = NULL;
+    CloseHandle(vm->prof->hTimerEvent);
+    vm->prof->hTimerEvent = NULL;
+}
+
+#else  /* !GAUCHE_WINDOWS */
+
 #define ITIMER_START()                                  \
     do {                                                \
         struct itimerval tval, oval;                    \
@@ -72,6 +131,8 @@
         tval.it_value.tv_usec = 0;              \
         setitimer(ITIMER_PROF, &tval, &oval);   \
     } while (0)
+
+#endif /* !GAUCHE_WINDOWS */
 
 /*=============================================================
  * Statistic sampler
@@ -100,16 +161,26 @@ static void sampler_flush(ScmVM *vm)
 }
 
 /* signal handler */
+#if defined(GAUCHE_WINDOWS)
+static void sampler_sample(ScmVM *vm)
+#else  /* !GAUCHE_WINDOWS */
 static void sampler_sample(int sig)
+#endif /* !GAUCHE_WINDOWS */
 {
+#if !defined(GAUCHE_WINDOWS)
     ScmVM *vm = Scm_VM();
+#endif /* !GAUCHE_WINDOWS */
     if (vm == NULL || vm->prof == NULL) return;
     if (vm->prof->state != SCM_PROFILER_RUNNING) return;
 
     if (vm->prof->currentSample >= SCM_PROF_SAMPLES_IN_BUFFER) {
+#if !defined(GAUCHE_WINDOWS)
         ITIMER_STOP();
+#endif /* !GAUCHE_WINDOWS */
         sampler_flush(vm);
+#if !defined(GAUCHE_WINDOWS)
         ITIMER_START();
+#endif /* !GAUCHE_WINDOWS */
     }
 
     int i = vm->prof->currentSample++;
@@ -162,10 +233,12 @@ void Scm_ProfilerCountBufferFlush(ScmVM *vm)
     if (vm->prof->currentCount == 0) return;
 
     /* suspend itimer during hash table operation */
+#if !defined(GAUCHE_WINDOWS)
     sigset_t set;
     sigemptyset(&set);
     sigaddset(&set, SIGPROF);
     SIGPROCMASK(SIG_BLOCK, &set, NULL);
+#endif /* !GAUCHE_WINDOWS */
 
     int ncounts = vm->prof->currentCount;
     for (int i=0; i<ncounts; i++) {
@@ -198,7 +271,9 @@ void Scm_ProfilerCountBufferFlush(ScmVM *vm)
     vm->prof->currentCount = 0;
 
     /* resume itimer */
+#if !defined(GAUCHE_WINDOWS)
     SIGPROCMASK(SIG_UNBLOCK, &set, NULL);
+#endif /* !GAUCHE_WINDOWS */
 }
 
 /*=============================================================
@@ -221,10 +296,21 @@ void Scm_ProfilerStart(void)
         vm->prof->currentCount = 0;
         vm->prof->statHash =
             SCM_HASH_TABLE(Scm_MakeHashTableSimple(SCM_HASH_EQ, 0));
+#if defined(GAUCHE_WINDOWS)
+        vm->prof->hTargetThread = NULL;
+        vm->prof->hObserverThread = NULL;
+        vm->prof->hTimerEvent = NULL;
+        vm->prof->samplerFileName = templat_buf;
+#else  /* !GAUCHE_WINDOWS */
         unlink(templat_buf);       /* keep anonymous tmpfile */
+#endif /* !GAUCHE_WINDOWS */
     } else if (vm->prof->samplerFd < 0) {
         vm->prof->samplerFd = Scm_Mkstemp(templat_buf);
+#if defined(GAUCHE_WINDOWS)
+        vm->prof->samplerFileName = templat_buf;
+#else  /* !GAUCHE_WINDOWS */
         unlink(templat_buf);
+#endif /* !GAUCHE_WINDOWS */
     }
 
     if (vm->prof->state == SCM_PROFILER_RUNNING) return;
@@ -232,6 +318,16 @@ void Scm_ProfilerStart(void)
     vm->profilerRunning = TRUE;
 
     /* NB: this should be done globally!!! */
+#if defined(GAUCHE_WINDOWS)
+    if (!DuplicateHandle(GetCurrentProcess(),
+                         GetCurrentThread(),
+                         GetCurrentProcess(),
+                         &vm->prof->hTargetThread,
+                         0, FALSE, DUPLICATE_SAME_ACCESS)) {
+        vm->prof->hTargetThread = NULL;
+        Scm_SysError("DuplicateHandle failed");
+    }
+#else  /* !GAUCHE_WINDOWS */
     struct sigaction act;
     act.sa_handler = sampler_sample;
     sigfillset(&act.sa_mask);
@@ -239,6 +335,7 @@ void Scm_ProfilerStart(void)
     if (sigaction(SIGPROF, &act, NULL) < 0) {
         Scm_SysError("sigaction failed");
     }
+#endif /* !GAUCHE_WINDOWS */
 
     ITIMER_START();
 }
@@ -249,6 +346,10 @@ int Scm_ProfilerStop(void)
     if (vm->prof == NULL) return 0;
     if (vm->prof->state != SCM_PROFILER_RUNNING) return 0;
     ITIMER_STOP();
+#if defined(GAUCHE_WINDOWS)
+    CloseHandle(vm->prof->hTargetThread);
+    vm->prof->hTargetThread = NULL;
+#endif /* GAUCHE_WINDOWS */
     vm->prof->state = SCM_PROFILER_PAUSING;
     vm->profilerRunning = FALSE;
     return vm->prof->totalSamples;
@@ -265,6 +366,9 @@ void Scm_ProfilerReset(void)
     if (vm->prof->samplerFd >= 0) {
         close(vm->prof->samplerFd);
         vm->prof->samplerFd = -1;
+#if defined(GAUCHE_WINDOWS)
+        unlink(vm->prof->samplerFileName);
+#endif /* GAUCHE_WINDOWS */
     }
     vm->prof->totalSamples = 0;
     vm->prof->currentSample = 0;
@@ -308,9 +412,17 @@ ScmObj Scm_ProfilerRawResult(void)
         collect_samples(vm->prof);
     }
     vm->prof->currentSample = 0;
+#if defined(GAUCHE_WINDOWS)
+    if (vm->prof->samplerFd >= 0) {
+        close(vm->prof->samplerFd);
+        vm->prof->samplerFd = -1;
+        unlink(vm->prof->samplerFileName);
+    }
+#else  /* !GAUCHE_WINDOWS */
     if (ftruncate(vm->prof->samplerFd, 0) < 0) {
         Scm_SysError("profiler: failed to truncate temporary file");
     }
+#endif /* !GAUCHE_WINDOWS */
 
     return SCM_OBJ(vm->prof->statHash);
 }


### PR DESCRIPTION
Windows で Gauche のプロファイラ機能を使用できないか調べたところ、
SaitoAtsushi さんの以下のパッチがありました。
https://gist.github.com/SaitoAtsushi/7555d9352084ecedc715
許可をいただいてプルリクエストにしました。

Windows ではシグナルが使えないため、別スレッドを起動してサンプリングを行っています。
また、スレッド間の競合を解消するため SuspendThread/ResumeThread を使用しています。

スレッドハンドルの vm->prof への追加等、一部改造を行い、動作確認しました。
また、テンポラリファイルが Windows では残ってしまうため、削除処理を追加しました。


＜テスト1＞
OS : Windows 8.1 (64bit)
Gauche : コミット 8ddad97 + 本変更

開発環境1 : MSYS2/MinGW-w64 (64bit) (gcc version 6.2.0 (Rev2, Built by MSYS2 project))
Total: 17218 tests, 17218 passed,     0 failed,     0 aborted.

開発環境2 : MSYS2/MinGW-w64 (32bit) (gcc version 6.2.0 (Rev2, Built by MSYS2 project))
Total: 17218 tests, 17218 passed,     0 failed,     0 aborted.

開発環境3 : MinGW.org (32bitのみ) (gcc v4.8.1)
Total: 17221 tests, 17221 passed,     0 failed,     0 aborted.

＜テスト2＞
以下の test_prof.scm を作成して gosh -ptime test_prof.scm で実行。
```
(define (fib n) (if (<= n 1) n (+ (fib (- n 1)) (fib (- n 2)))))
(define (heavy-calc) (fib 35))
(define (tarai x y z) (if (<= x y) y (tarai (tarai (- x 1) y z)
                                            (tarai (- y 1) z x)
                                            (tarai (- z 1) x y))))
(define (medium-calc) (tarai 18 9 6))
(define (some-calc) (dotimes (n 3) (+ (heavy-calc) (medium-calc))))
(some-calc)
```
実行結果
```
Profiler statistics (total 509 samples, 5.09 seconds)
                                                    num    time/    total
Name                                                calls  call(ms) samples
---------------------------------------------------+------+-------+-----------
fib                                                89582109  0.0000   410( 81%)
tarai                                              21275559  0.0000    98( 19%)
(file-is-directory? path)                                1 10.0000     1(  0%)
variable?                                               95  0.0000     0(  0%)
pass2/rec                                               87  0.0000     0(  0%)
pass4/scan                                              85  0.0000     0(  0%)
pass3/rec                                               85  0.0000     0(  0%)
reset-lvars/rec                                         85  0.0000     0(  0%)
(id->bound-gloc id)                                     76  0.0000     0(  0%)
lvar-immutable?                                         74  0.0000     0(  0%)
pass5/rec                                               71  0.0000     0(  0%)
pass1                                                   62  0.0000     0(  0%)
$const?                                                 58  0.0000     0(  0%)
null-list?                                              55  0.0000     0(  0%)
(list? obj)                                             51  0.0000     0(  0%)
(cenv-lookup-syntax cenv name)                          43  0.0000     0(  0%)
pass1/lookup-head                                       43  0.0000     0(  0%)
pass2/lref-eliminate                                    42  0.0000     0(  0%)
(lvar-ref++! lvar)                                      42  0.0000     0(  0%)
(cenv-lookup-variable cenv name)                        40  0.0000     0(  0%)
$lref?                                                  37  0.0000     0(  0%)
(global-call-type id cenv)                              36  0.0000     0(  0%)
(%map1c proc lis c)                                     35  0.0000     0(  0%)
(%imax x y)                                             35  0.0000     0(  0%)
bottom-context?                                         33  0.0000     0(  0%)
global-identifier=?                                     33  0.0000     0(  0%)
lvar?                                                   26  0.0000     0(  0%)
(%map1cc proc lis c1 c2)                                25  0.0000     0(  0%)
every                                                   24  0.0000     0(  0%)
pass2/check-constant-asm                                24  0.0000     0(  0%)
(compiled-code-emit-PUSH! cc)                           24  0.0000     0(  0%)
$lref                                                   22  0.0000     0(  0%)
pass2/$LREF                                             22  0.0000     0(  0%)
(undefined? obj)                                        21  0.0000     0(  0%)
normal-context                                          21  0.0000     0(  0%)
global-eq?                                              21  0.0000     0(  0%)
(unwrap-syntax form)                                    21  0.0000     0(  0%)
make-label-dic                                          20  0.0000     0(  0%)
reset-lvars/rec/$LREF                                   20  0.0000     0(  0%)
(renv-lookup renv lvar)                                 20  0.0000     0(  0%)
pass3/$LREF                                             20  0.0000     0(  0%)
pass4/add-lvar                                          20  0.0000     0(  0%)
pass4/scan/$LREF                                        20  0.0000     0(  0%)
(pair-attribute-get pair key optional fallback)         20  0.0000     0(  0%)
(integer? obj)                                          18  0.0000     0(  0%)
(compiled-code-emit1i! cc code arg0 info)               18  0.0000     0(  0%)
pass5/$LREF                                             17  0.0000     0(  0%)
(compiled-code-emit2i! cc code arg0 arg1 info)          17  0.0000     0(  0%)
check-numeric-constant                                  17  0.0000     0(  0%)
(pair-attribute-set! pair key value)                    16  0.0000     0(  0%)
```
