### PR TITLE
Fix #275.  To send a packet to localhost, we should not send it to 0.0.0.0 but 127.0.0.1.

### DIFF
--- a/ext/net/test.scm
+++ b/ext/net/test.scm
@@ -555,7 +555,7 @@
            [rbuf   (make-u8vector 1024 0)])
 
        (define (xtest sbuf)
-         (socket-sendmsg s-sock (socket-buildmsg r-addr data '() 0 sbuf))
+         (socket-sendmsg s-sock (socket-buildmsg s-addr data '() 0 sbuf))
          (receive (size f-addr) (socket-recvfrom! r-sock rbuf (list from))
            (list (eq? f-addr from)
                  (equal? (uvector-alias <u8vector> rbuf 0 size)


### PR DESCRIPTION
On OpenBSD, we cannot send a packet to 0.0.0.0 to receive it on the host itself.  I know that 0.0.0.0 used to mean "the host itself" but I'm sure that sending to 127.0.0.1 works better on modern systems (possibly Windows/Cygwin).

Tested on OpenBSD 6.0.