### PR TITLE
Update mingw-dist.sh for the architecture name change of MSYS2/MinGW-w64

### DIFF
--- a/src/mingw-dist.sh
+++ b/src/mingw-dist.sh
@@ -29,12 +29,15 @@ esac
 # the gcc path embedded in gauche-config should be Windows path.
 PATH=$mingwdir/bin:$PATH
 
-# We assume we run this script on 64bit platform.  For 32bit distribution,
-# though, we want the resulting gosh to run as if it's built on 32bit platform.
-case "$MSYSTEM" in
-  MINGW32)
-    buildopt=--build=i686-pc-mingw32
-esac
+## architecture name setting
+#case "$MSYSTEM" in
+#  MINGW64)
+#    buildopt=--build=x86_64-w64-mingw32;;
+#  MINGW32)
+#    buildopt=--build=i686-w64-mingw32;;
+#  *)
+#    buildopt=--build=i686-pc-mingw32;;
+#esac
 
 # Process Options:
 while [ "$#" -gt 0 ]; do
@@ -111,7 +114,7 @@ esac
 if [ "$WITH_GL" = "yes" ]; then
   PATH=$distdir/bin:$PATH
   (cd ../Gauche-gl; ./DIST gen; \
-   ./configure --prefix=$distdir --with-glut=mingw-static; \
+   ./configure --prefix=$distdir --with-glut=mingw-static $buildopt; \
    make clean; make; make install; make install-examples)
 fi
 


### PR DESCRIPTION
- 最近、MSYS2/MinGW-w64 の開発環境を更新したところ、デフォルトのアーキテクチャ名が以下のように変わっていました。(ずっと前から変わっていたのかも。。。)
  ```
  MinGW-w64 64bit 開発環境のとき : x86_64-pc-mingw64 → x86_64-w64-mingw32
  MinGW-w64 32bit 開発環境のとき : x86_64-pc-mingw32 → i686-w64-mingw32
  ```


- これは、config.guess が変わったわけではなくて、以下の config.site というファイルによって設定されていました。(config.guess は本家が対応してくれない?)
  ```
  /mingw64/etc/config.site
  /mingw32/etc/config.site
  ```
  (参考URL : https://github.com/Alexpux/MSYS2-packages/blob/master/filesystem/mingw64-config.site )


- それで、src/mingw-dist.sh に `buildopt=--build=i686-pc-mingw32` という記述があったので、
  削除して、代わりに (古い開発環境の人も設定できるように) 最新の設定をコメントに書いておきました。

- また、Gauche-gl 用の ./configure の呼び出しにも $buildopt を追加しました。


＜テスト＞
設定をコメントアウトした場合と、コメントアウトしなかった場合の両方について、以下を実行しました。
```
./DIST gen
src/mingw-dist.sh --with-gl
make check
```

OS : Windows 8.1 (64bit)
Gauche : コミット ed1f29c + 本変更

開発環境1 : MSYS2/MinGW-w64 (64bit) (gcc version 6.3.0 (Rev2, Built by MSYS2 project))
Total: 17487 tests, 17487 passed,     0 failed,     0 aborted.

開発環境2 : MSYS2/MinGW-w64 (32bit) (gcc version 6.3.0 (Rev2, Built by MSYS2 project))
Total: 17487 tests, 17487 passed,     0 failed,     0 aborted.

開発環境3 : MinGW.org (32bitのみ) (gcc v4.8.1)
Total: 17490 tests, 17490 passed,     0 failed,     0 aborted.


別件ですが、開発環境2について、ビルドやテストが失敗することが複数回あったので、またあとで調べてみます。(開発環境の更新前には問題なかったと思う。。。)
