### PR TITLE
Look into closures in toplevel closures' env frames for gref check.

### DIFF
--- a/lib/gauche/test.scm
+++ b/lib/gauche/test.scm
@@ -318,7 +318,8 @@
                            [(memq (slot-ref gref 'name) bypass-arity-check)]
                            [(arity-invalid? gref numargs (or src-code (slot-ref closure 'info)))
                             => (lambda (bad) (push! bad-arity bad))])))
-                 (closure-grefs closure)))
+                 (append-map closure-grefs
+                   (cons closure (filter closure? (closure-env->list closure))))))
      (toplevel-closures mod))
     ;; report discrepancies
     (unless (null? bad-autoload)

--- a/src/libproc.scm
+++ b/src/libproc.scm
@@ -238,6 +238,16 @@
     (return SCM_FALSE)
     (return (SCM_OBJ (-> m data)))))
 
+(define-cproc closure-env->list (clo::<closure>)
+  (let* ((env::ScmEnvFrame* (SCM_CLOSURE_ENV clo))
+         (h SCM_NIL)
+         (t SCM_NIL))
+    (when (== env NULL)
+      (return SCM_NIL))
+    (dotimes [i (-> env size)]
+      (SCM_APPEND1 h t (ENV_DATA env i)))
+    (return h)))
+
 (define-cproc procedure-info (proc::<procedure>)
   (return (SCM_PROCEDURE_INFO proc)))
 


### PR DESCRIPTION
The env frame can contain closures. So we should check them in test-module-common.
