### PR TITLE
Fix array size in char.c

### DIFF
--- a/src/char.c
+++ b/src/char.c
@@ -996,7 +996,7 @@ int read_charset_syntax(ScmPort *input, int bracket_syntax, ScmDString *buf,
 ScmObj read_predef_charset(const char **cp, int error_p)
 {
     int i;
-    char name[MAX_CHARSET_NAME_LEN];
+    char name[MAX_CHARSET_NAME_LEN+1];
     for (i=0; i<MAX_CHARSET_NAME_LEN; i++) {
         ScmChar ch;
         SCM_CHAR_GET(*cp, ch);


### PR DESCRIPTION
- Cのチェッカーで1件見つかったので修正しました。


＜テスト＞
OS : Windows 8.1 (64bit)
Gauche : コミット 7168d43 + 変更

開発環境1 : MSYS2/MinGW-w64 (64bit) (gcc version 7.1.0 (Rev2, Built by MSYS2 project))
Total: 18238 tests, 18238 passed,     0 failed,     0 aborted.
