### PR TITLE
Fix assume-type error in gauche.hashutil

### DIFF
--- a/lib/gauche/hashutil.scm
+++ b/lib/gauche/hashutil.scm
@@ -42,11 +42,11 @@
 
 ;; TRANSIENT: Precompiling with 0.9.5 doesn't load assume-type yet.
 ;; Remove this after 0.9.6 release.
-(cond-expand
- [gauche-0.9.5 (define-syntax assume-type
-                 (syntax-rules ()
-                   [(_ x type) (check-arg (cut is-a? <> type) x)]))]
- [else])
+(unless (global-variable-bound? 'gauche 'assume-type)
+  (eval '(define-syntax assume-type
+          (syntax-rules ()
+            [(_ x type) (check-arg (cut is-a? <> type) x)]))
+        (current-module)))
 
 (define (hash-table cmpr . kvs)
   (rlet1 h (make-hash-table cmpr)


### PR DESCRIPTION
- 2017-7-5 のコミット 03ece6d で v0.9.5 用の対策が入っていますが、
  v0.9.6_pre2 の古いものでビルドしてはまってしまったので、
  こうしてはどうでしょうか。。。
  - lib/gauche/hashutil.scm


＜テスト＞
OS : Windows 8.1 (64bit)
Gauche : コミット 7168d43 + 変更

開発環境1 : MSYS2/MinGW-w64 (64bit) (gcc version 7.1.0 (Rev2, Built by MSYS2 project))
Total: 18238 tests, 18238 passed,     0 failed,     0 aborted.
