### PR TITLE
Change header files for MinGW32 runtime v5.0

### DIFF
--- a/ext/net/gauche-net.h
+++ b/ext/net/gauche-net.h
@@ -90,6 +90,12 @@ const char *inet_ntop(int af, const void *src, char *dst, socklen_t size);
 #define AI_ALL        0x00000100
 #define AI_ADDRCONFIG 0x00000400
 #define AI_V4MAPPED   0x00000800
+/* for MinGW32 runtime v5.0 */
+#if defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR) && (__MINGW32_MAJOR_VERSION >= 5)
+void WSAAPI freeaddrinfo(struct addrinfo*);
+int  WSAAPI getaddrinfo(const char*, const char*, const struct addrinfo*, struct addrinfo**);
+int  WSAAPI getnameinfo(const struct sockaddr*, socklen_t, char*, DWORD, char*, DWORD, int);
+#endif /* defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR) && (__MINGW32_MAJOR_VERSION >= 5) */
 #endif /* HAVE_IPV6 */
 #endif /*GAUCHE_WINDOWS*/
 

--- a/src/gauche/win-compat.h
+++ b/src/gauche/win-compat.h
@@ -47,12 +47,6 @@ typedef unsigned long u_long;
 #define _BSDTYPES_DEFINED
 #endif /* _BSDTYPES_DEFINED */
 
-/* Mingw-w64 only defines sigset_t when _POSIX is defined. */
-#if defined(__MINGW64_VERSION_MAJOR) && !defined(_POSIX)
-typedef _sigset_t sigset_t;
-#endif  /*defined(__MINGW64_VERSION_MAJOR) && !defined(_POSIX)*/
-
-
 /*======================================================================
  * Time calculation
  * Win32API's FILETIME is 64bit time count since 1601/1/1 UTC, measured
@@ -120,8 +114,18 @@ typedef jmp_buf  sigjmp_buf;
 
 /* Windows doesn't support SIGKILL explicitly, but we want to emulate
    (sys-kill SIGKILL) by TerminateProcess.
-   The signal number 9 is unused in Windows at this moment.  Chekc signal.h.*/
+   The signal number 9 is unused in Windows at this moment.  Check signal.h.*/
 #define SIGKILL 9
+
+/* Mingw-w64 only defines sigset_t when _POSIX is defined. */
+#if defined(__MINGW64_VERSION_MAJOR) && !defined(_POSIX)
+typedef _sigset_t sigset_t;
+#endif  /*defined(__MINGW64_VERSION_MAJOR) && !defined(_POSIX)*/
+
+/* for MinGW32 runtime v5.0 */
+#if defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR) && (__MINGW32_MAJOR_VERSION >= 5)
+#define _SIGSET_T_
+#endif /* defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR) && (__MINGW32_MAJOR_VERSION >= 5) */
 
 #ifndef _SIGSET_T_
 #define _SIGSET_T_
@@ -201,8 +205,8 @@ extern __declspec(dllimport) const char *Scm_WCS2MBS(const WCHAR *s);
 #endif /* !UNICODE */
 #define fstat(fd, buf)     _fstat64(fd, buf)
 
-/* for MinGW32 */
-#if defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR)
+/* for MinGW32 runtime v3.X */
+#if defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR) && (__MINGW32_MAJOR_VERSION < 5)
 struct __stat64 {
     _dev_t st_dev;
     _ino_t st_ino;
@@ -219,7 +223,7 @@ struct __stat64 {
 _CRTIMP int __cdecl _stat64(const char*, struct __stat64*);
 _CRTIMP int __cdecl _wstat64(const wchar_t*, struct __stat64*);
 _CRTIMP int __cdecl _fstat64(int, struct __stat64*);
-#endif /* defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR) */
+#endif /* defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR) && (__MINGW32_MAJOR_VERSION < 5) */
 
 /*===================================================================
  * Miscellaneous POSIX stuff


### PR DESCRIPTION
- MinGW (32bitのみ) の方の更新があり、ランタイムが v3.X から v5.0 にバージョンアップしました。
  gcc も v4.X.X から v6.3.0 になりました。

- それで、Gauche のビルドでエラーが出ていたため、以下のファイルを一部変更しました。
  - src/gauche/win-compat.h  (シグナル,stat関連)
  - ext/net/gauche-net.h     (ipv6関連)

- もう MinGW (32bitのみ) でビルドする人もあまりいないかもしれませんが。
  (一応自分は古いPCで使っています。。。)


＜テスト＞
OS : Windows 8.1 (64bit)
Gauche : コミット 7168d43 + 変更

開発環境1 : MSYS2/MinGW-w64 (64bit) (gcc version 7.1.0 (Rev2, Built by MSYS2 project))
Total: 18238 tests, 18238 passed,     0 failed,     0 aborted.  (ipv6なし)
Total: 18294 tests, 18294 passed,     0 failed,     0 aborted.  (ipv6あり)

開発環境2 : MSYS2/MinGW-w64 (32bit) (gcc version 7.1.0 (Rev2, Built by MSYS2 project))
Total: 18238 tests, 18238 passed,     0 failed,     0 aborted.  (ipv6なし)
Total: 18294 tests, 18294 passed,     0 failed,     0 aborted.  (ipv6あり)

開発環境3 : MinGW (32bitのみ) (gcc version 6.3.0 (MinGW.org GCC-6.3.0-1))
Total: 18242 tests, 18242 passed,     0 failed,     0 aborted.  (ipv6なし)
Total: 18298 tests, 18298 passed,     0 failed,     0 aborted.  (ipv6あり)
