### PR TITLE
Change buffer overwrite process in text.line-edit

### DIFF
--- a/lib/text/line-edit.scm
+++ b/lib/text/line-edit.scm
@@ -82,11 +82,7 @@
    ;; every command except yank and yank-pop.
    (kill-ring :init-form (make-ring-buffer
                           (make-vector *kill-ring-size*)
-                          ;:overflow-handler 'overwrite))
-                          :overflow-handler
-                          (^[rb v]
-                            (ring-buffer-add-front! rb (ring-buffer-remove-back! rb))
-                            'overwrite)))
+                          :overflow-handler 'overwrite))
    (last-yank :init-value -1) ; index into the kill-ring buffer.  -1 means
                               ; last op wasn't yank.
    (last-yank-pos :init-value 0) ; index into buffer where last yank is put.
@@ -107,11 +103,7 @@
    ;; the line and undo-stack; see below.
    (history :init-form (make-ring-buffer
                         (make-vector *history-size*)
-                        ;:overflow-handler 'overwrite))
-                        :overflow-handler
-                        (^[rb v]
-                          (ring-buffer-add-front! rb (ring-buffer-remove-back! rb))
-                          'overwrite)))
+                        :overflow-handler 'overwrite))
    (history-pos :init-value -1)
    (history-transient :init-value #f)
    ))


### PR DESCRIPTION
- text.line-edit の処理を一部変更しました。

- lib/text/line-edit.scm
  - ヒストリとキルリングのバッファについて、
    あふれたときに古いものから消えるようにしました。
    ただ、ちょっと正しい変更方法が分かりませんでした。

  - ささいな変更(3箇所)
