### PR TITLE
Fix info-search node print order

### DIFF
--- a/lib/gauche/interactive/info.scm
+++ b/lib/gauche/interactive/info.scm
@@ -230,6 +230,7 @@
     (dolist [l node&lines]
       (format #t "~va~a:~d\n" *search-entry-indent* " " (car l) (cadr l))))
   (match-let1 (key node&lines ...) entry
+    (set! node&lines (reverse node&lines))
     (if (> (string-length key) (- *search-entry-indent* 1))
       (begin (print key) (subsequent-lines node&lines))
       (begin (format #t "~va ~a:~d\n" (- *search-entry-indent* 1) key


### PR DESCRIPTION
info-search で、ひとつの entry に複数の node が見つかった場合 (例えば `,i #/^let$/` )、
表示順が info (例えば `,i let` ) と逆になっていたので、合わせるようにしました。
