### PR TITLE
Windows console code page support

### DIFF
--- a/lib/Makefile.in
+++ b/lib/Makefile.in
@@ -68,7 +68,7 @@ SCMFILES = srfi-0.scm \
        gauche/serializer.scm gauche/serializer/aserializer.scm \
        gauche/parseopt.scm gauche/interactive.scm gauche/interactive/info.scm \
        gauche/interactive/ed.scm gauche/interactive/toplevel.scm \
-       gauche/interactive/editable-reader.scm \
+       gauche/interactive/editable-reader.scm gauche/interactive/windows.scm \
        gauche/selector.scm gauche/logger.scm \
        gauche/common-macros.scm gauche/singleton.scm gauche/validator.scm \
        gauche/version.scm gauche/partcont.scm gauche/lazy.scm gauche/base.scm \

--- a/lib/gauche/interactive.scm
+++ b/lib/gauche/interactive.scm
@@ -333,20 +333,20 @@
     ;; wide character settings for text.line-edit
     (if-let1 ctx %line-edit-ctx
       (case (sys-get-console-output-cp)
-        [(932)
-         (set! (~ ctx 'wide-char-disp-setting 'mode) 'Surrogate)
-         (set! (~ ctx 'wide-char-pos-setting  'mode) 'Surrogate)
-         (set! (~ ctx 'wide-char-disp-setting 'wide-char-width) 2)
-         (set! (~ ctx 'wide-char-pos-setting  'wide-char-width) 2)
-         (set! (~ ctx 'wide-char-disp-setting 'surrogate-char-width) 4)
-         (set! (~ ctx 'wide-char-pos-setting  'surrogate-char-width) 4)]
         [(65001)
          (set! (~ ctx 'wide-char-disp-setting 'mode) 'Surrogate)
          (set! (~ ctx 'wide-char-pos-setting  'mode) 'Surrogate)
          (set! (~ ctx 'wide-char-disp-setting 'wide-char-width) 2)
          (set! (~ ctx 'wide-char-pos-setting  'wide-char-width) 1)
          (set! (~ ctx 'wide-char-disp-setting 'surrogate-char-width) 2)
-         (set! (~ ctx 'wide-char-pos-setting  'surrogate-char-width) 2)])))]
+         (set! (~ ctx 'wide-char-pos-setting  'surrogate-char-width) 2)]
+        [else ; 932 etc.
+         (set! (~ ctx 'wide-char-disp-setting 'mode) 'Surrogate)
+         (set! (~ ctx 'wide-char-pos-setting  'mode) 'Surrogate)
+         (set! (~ ctx 'wide-char-disp-setting 'wide-char-width) 2)
+         (set! (~ ctx 'wide-char-pos-setting  'wide-char-width) 2)
+         (set! (~ ctx 'wide-char-disp-setting 'surrogate-char-width) 4)
+         (set! (~ ctx 'wide-char-pos-setting  'surrogate-char-width) 4)])))]
  [else])
 
 ;;;

--- a/lib/gauche/interactive/editable-reader.scm
+++ b/lib/gauche/interactive/editable-reader.scm
@@ -45,7 +45,8 @@
 
 ;; Internal API, to be used by gauche.interactive.
 ;; Because of toplevel commands, we can't just provide alternative 'read'
-;; procedure.  Instead, this returns three procedures, one for 'read',
+;; procedure.  Instead, this returns three procedures and
+;; one <line-edit-context> object. three procedures are one for 'read',
 ;; one for 'read-line', and another for skipping trailing whitespaces.
 ;  They are suitable to be passed to make-repl-reader.
 ;; NB: Currently we assume we use default console.  Might be useful
@@ -70,8 +71,9 @@
               x))))
       (values (read-1 read)
               (read-1 read-line)
-              (^[] (consume-trailing-whitespaces buffer))))
-    (values #f #f #f)))                    ;no default console
+              (^[] (consume-trailing-whitespaces buffer))
+              ctx))
+    (values #f #f #f #f)))                  ;no default console
 
 ;; We have to handle both toplevel command (begins with comma, ends with
 ;; newline) and the complete sexp.

--- a/lib/gauche/interactive/windows.scm
+++ b/lib/gauche/interactive/windows.scm
@@ -145,9 +145,11 @@
         (set! ces 'CP932))]
      [else])
     ;; check a ces conversion
-    (if stdin-flag
-      (check-ces ces ces2 ces)
-      (check-ces ces2 ces ces))
+    (guard (e [(<error> e)
+               (set! conv #f)])
+      (if stdin-flag
+        (check-ces ces ces2 ces)
+        (check-ces ces2 ces ces)))
     ;; check a redirection
     (if rdir (set! use-api #f))
     ;; return parameters

--- a/lib/gauche/interactive/windows.scm
+++ b/lib/gauche/interactive/windows.scm
@@ -1,0 +1,189 @@
+;;;
+;;; gauche.interactive.windows - windows console code page support
+;;;
+;;;   Copyright (c) 2017  Hamayama  https://github.com/Hamayama
+;;;
+;;;   Redistribution and use in source and binary forms, with or without
+;;;   modification, are permitted provided that the following conditions
+;;;   are met:
+;;;
+;;;   1. Redistributions of source code must retain the above copyright
+;;;      notice, this list of conditions and the following disclaimer.
+;;;
+;;;   2. Redistributions in binary form must reproduce the above copyright
+;;;      notice, this list of conditions and the following disclaimer in the
+;;;      documentation and/or other materials provided with the distribution.
+;;;
+;;;   3. Neither the name of the authors nor the names of its contributors
+;;;      may be used to endorse or promote products derived from this
+;;;      software without specific prior written permission.
+;;;
+;;;   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+;;;   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+;;;   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+;;;   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+;;;   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+;;;   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+;;;   TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+;;;   PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+;;;   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+;;;   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+;;;   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+;;;
+
+(define-module gauche.interactive.windows
+  (use gauche.charconv)
+  (use gauche.vport)
+  (use gauche.uvector)
+  (use gauche.sequence)
+  (use os.windows)
+  (export wrap-windows-console-standard-ports))
+(select-module gauche.interactive.windows)
+
+;; check a standard handle redirection
+(define (redirected-handle? hdl)
+  (guard (e [(<system-error> e) #t])
+    (sys-get-console-mode hdl) #f))
+
+;; make a getc procedure
+(define (make-conv-getc port hdl ces ces2 use-api)
+  (if use-api
+    (make-conv-getc-sub port hdl 'UTF-16LE ces2 #t 4 2 2)
+    (make-conv-getc-sub port hdl ces       ces2 #f 6 0 1)))
+(define (make-conv-getc-sub port hdl ces ces2 use-api
+                            maxbytes extrabytes readbytes)
+  (^[]
+    (rlet1 chr #\null
+      ;; we have to allocate extra bytes because ReadConsole might writes
+      ;; extra 1 byte more than a specified buffer size.
+      (let1 buf (make-u8vector (+ maxbytes extrabytes) 0)
+        (let loop ([i 0])
+          (if (if use-api
+                (zero? (sys-read-console hdl (uvector-alias <u8vector> buf i (+ i readbytes))))
+                (eof-object? (read-uvector! buf port i (+ i readbytes))))
+            (set! chr (eof-object))
+            (let1 str (ces-convert (u8vector->string buf 0 (+ i readbytes)) ces ces2)
+              (guard (e [(<error> e)
+                         ;; a character is incomplete
+                         (if (< (+ i readbytes) maxbytes)
+                           (loop (+ i readbytes)))])
+                ;; a character is complete
+                (set! chr (string-ref str 0))))))))))
+
+;; make a puts procedure
+(define (make-conv-puts port conv crlf hdl ces ces2 use-api)
+  (if use-api
+    (make-conv-puts-sub1 hdl ces ces2 4096)
+    (make-conv-puts-sub2 port conv crlf ces ces2)))
+(define (make-conv-puts-sub1 hdl ces ces2 maxchars)
+  ;; windows api WriteConsole adjustment
+  (define (sys-write-console-sub str)
+    (cond-expand
+     [gauche.ces.utf8
+      ;; unicode version api needs a workaroud for the line wrapping of
+      ;; surrogate pair characters.
+      (let* ([cinfo (sys-get-console-screen-buffer-info hdl)]
+             [w     (+ 1 (- (~ cinfo'window.right)
+                            (~ cinfo'window.left)))]
+             [i1    0])
+        (for-each-with-index
+         (^[i2 c]
+           (when (>= (char->integer c) #x10000)
+             (sys-write-console hdl (string-copy str i1 i2))
+             (set! i1 i2)
+             (let* ([cinfo (sys-get-console-screen-buffer-info hdl)]
+                    [x     (~ cinfo'cursor-position.x)]
+                    [y     (~ cinfo'cursor-position.y)])
+               (when (> x (- w 4))
+                 (sys-set-console-cursor-position hdl (- w 1) y)
+                 (sys-write-console hdl " ")))))
+         str)
+        (sys-write-console hdl (string-copy str i1)))]
+     [else
+      ;; ansi version api needs a ces conversion
+      (set! str (ces-convert str ces2 ces))
+      (sys-write-console hdl str)]))
+  (^[str/char]
+    (let1 str (x->string str/char)
+      (let loop ([i 0])
+        (cond
+         [(<= (string-length str) (+ i maxchars))
+          (sys-write-console-sub (string-copy str i))]
+         [else
+          (sys-write-console-sub (string-copy str i (+ i maxchars)))
+          (loop (+ i maxchars))])))))
+(define (make-conv-puts-sub2 port conv crlf ces ces2)
+  (^[str/char]
+    (let1 str (x->string str/char)
+      (if crlf (set! str (regexp-replace-all #/\n/ str "\r\n")))
+      (if conv (set! str (ces-convert str ces2 ces)))
+      (let1 buf (string->u8vector str)
+        (write-uvector buf port)
+        (flush port)))))
+
+;; get conversion parameters
+(define (get-conv-param rmode hdl ces use-api stdin-flag)
+  (define (check-ces ces1 ces2 ces-err)
+    (unless (ces-conversion-supported? ces1 ces2)
+      (errorf "ces \"~a\" is not supported" ces-err)))
+  (let* ([rdir (redirected-handle? hdl)]
+         [conv (if rdir (if (or (= rmode 2) (= rmode 3)) #t #f) #t)]
+         [crlf (if rdir (if (or (= rmode 1) (= rmode 3)) #t #f) #f)]
+         [ces2 (gauche-character-encoding)])
+    ;; automatic detection of ces
+    (unless ces
+      (let1 cp (if stdin-flag (sys-get-console-cp) (sys-get-console-output-cp))
+        (case cp
+          [(65001) (set! ces 'UTF-8)
+                   (set! use-api #t)]
+          [else    (set! ces (string->symbol (format "CP~d" cp)))])))
+    ;; a workaroud for the yen mark conversion error
+    (cond-expand
+     [gauche.ces.sjis
+      (set! ces2 'CP932)
+      (if (#/^(SJIS|SHIFT[\-_]?JIS)$/i (x->string ces))
+        (set! ces 'CP932))]
+     [else])
+    ;; check a ces conversion
+    (if stdin-flag
+      (check-ces ces ces2 ces)
+      (check-ces ces2 ces ces))
+    ;; check a redirection
+    (if rdir (set! use-api #f))
+    ;; return parameters
+    (values conv crlf hdl ces ces2 use-api)))
+
+;; make a standard input conversion port
+(define (make-stdin-conv-port :optional (rmode 0) (ces '#f) (use-api #f))
+  (receive (conv crlf hdl ces ces2 use-api)
+      (get-conv-param rmode (sys-get-std-handle STD_INPUT_HANDLE) ces use-api #t)
+    (if conv
+      (make <virtual-input-port>
+        :getc (make-conv-getc (standard-input-port) hdl ces ces2 use-api))
+      #f)))
+;; make a standard output conversion port
+(define (make-stdout-conv-port :optional (rmode 0) (ces '#f) (use-api #f))
+  (receive (conv crlf hdl ces ces2 use-api)
+      (get-conv-param rmode (sys-get-std-handle STD_OUTPUT_HANDLE) ces use-api #f)
+    (if (or conv crlf)
+      (make <virtual-output-port>
+        :putc (make-conv-puts (standard-output-port) conv crlf hdl ces ces2 use-api)
+        :puts (make-conv-puts (standard-output-port) conv crlf hdl ces ces2 use-api))
+      #f)))
+;; make a standard error conversion port
+(define (make-stderr-conv-port :optional (rmode 0) (ces '#f) (use-api #f))
+  (receive (conv crlf hdl ces ces2 use-api)
+      (get-conv-param rmode (sys-get-std-handle STD_ERROR_HANDLE) ces use-api #f)
+    (if (or conv crlf)
+      (make <virtual-output-port>
+        :putc (make-conv-puts (standard-error-port) conv crlf hdl ces ces2 use-api)
+        :puts (make-conv-puts (standard-error-port) conv crlf hdl ces ces2 use-api))
+      #f)))
+
+;; wrap windows console standard ports
+(define (wrap-windows-console-standard-ports :optional (rmode 0) (ces '#f) (use-api #f))
+  (if-let1 port (make-stdin-conv-port  rmode ces use-api) (current-input-port  port))
+  (if-let1 port (make-stdout-conv-port rmode ces use-api) (current-output-port port))
+  (if-let1 port (make-stderr-conv-port rmode ces use-api) (current-error-port  port))
+  (values))
+


### PR DESCRIPTION
Windows コンソールのコードページにREPLを対応させるパッチです。
Windows ユーザーが文字化けにあう確率を減らせると思います。

- lib/gauche/interactive.scm
  - Windows コンソールの場合に、標準入出力のポートをラップするようにした。
    また、text.line-edit の context が存在すれば、それも設定する。
    設定は、環境変数2個で調整可能とした。
    環境変数がなければ、コードページは自動検出する。

- lib/gauche/interactive/editable-reader.scm
  - make-editable-reader で、text.line-edit の context を戻り値に追加

- lib/gauche/interactive/windows.scm
  - 以下のソースを元に作成
    https://github.com/Hamayama/msjis

- lib/gauche/test.scm
  - 標準入出力のポートをラップしたため、
    (sys-isatty (current-error-port)) が #f になってしまい、
    標準出力と標準エラー出力で、表示が2重になってしまったため対策した。
    ただ、MSYS (mintty) 上では、sys-isatty の結果が常に #f になっているため、
    同様の対策は必要だった。

現状、以下の気になる点があります。

1. Windows 10 で確認していない

2. 日本語版 Windows コンソールのデフォルトのコードページは、いつまで CP932 なのか

3. 1文字ずつ変換するので表示が遅くなる
  (大量に表示すると、けっこう分かります)

4. 標準入出力のリダイレクトの判定が素直にできなくなる
  (ただ、MSYS (mintty) 上でも、現状は %sys-mintty でないと判定できない)

5. 標準入出力のポートをラップしたため、問題発生時に切り分けが難しいケースが出るかも
  (環境変数を設定したときだけラップするという方がよいでしょうか？)
  (ただ、これまでのユーザーの報告等をみていると、デフォルトで機能してほしい気もする。。。)
