### PR TITLE
Typo fix

### DIFF
--- a/doc/program.texi
+++ b/doc/program.texi
@@ -1168,7 +1168,7 @@ gosh> (call-with-input-file "Info.plist" (cut ssax:xml->sxml <> '()))
 (*TOP*
  (*PI* xml "version=\"1.0\" encoding=\"UTF-8\"")
  (plist
-  (|@|
+  (|@@|
    (version "1.0"))
   (dict
    (key "CFBundleDevelopmentRegion")


### PR DESCRIPTION
This typo breaks TeX based document processor like PDF and DVI. 