### PR TITLE
Some workaround for TeX-based document generation

### DIFF
--- a/doc/gauche-ref.texi
+++ b/doc/gauche-ref.texi
@@ -3,7 +3,7 @@
 @c JP
 \input texinfo-ja @c -*- mode: texinfo; coding: utf-8; -*-
 @c COMMON
-@comment %**start of header
+@c %**start of header
 @documentencoding UTF-8
 @c EN
 @setfilename gauche-refe.info
@@ -24,7 +24,7 @@
 @end direntry
 @documentlanguage ja
 @c COMMON
-@comment %**end of header
+@c %**end of header
 
 @c module, class and lexical-syntax index
 @defcodeindex md

--- a/doc/gauche-ref.texi
+++ b/doc/gauche-ref.texi
@@ -6,7 +6,6 @@
 @comment %**start of header
 @documentencoding UTF-8
 @c EN
-@documentlanguage en
 @setfilename gauche-refe.info
 @settitle Gauche Users' Reference
 @afourpaper
@@ -14,6 +13,7 @@
 @direntry
 * Gauche: (gauche-refe.info).	        An R7RS Scheme implementation.
 @end direntry
+@documentlanguage en
 @c JP
 @setfilename gauche-refj.info
 @settitle Gauche ユーザリファレンス

--- a/doc/gauche-ref.texi
+++ b/doc/gauche-ref.texi
@@ -15,7 +15,6 @@
 * Gauche: (gauche-refe.info).	        An R7RS Scheme implementation.
 @end direntry
 @c JP
-@documentlanguage ja
 @setfilename gauche-refj.info
 @settitle Gauche ユーザリファレンス
 @afourpaper
@@ -23,6 +22,7 @@
 @direntry
 * Gauche (ja): (gauche-refj.info).	An R7RS Scheme implementation.
 @end direntry
+@documentlanguage ja
 @c COMMON
 @comment %**end of header
 


### PR DESCRIPTION
Current Japanese TeX-based Texinfo processor makes some error when `@setfilename` and `@dircategory` command exists after `@documentlanguage`.

This workaround avoids this error.