### PR TITLE
Fix load verbose mode error on windows console

### DIFF
--- a/ext/windows/windows/console/codepage.scm
+++ b/ext/windows/windows/console/codepage.scm
@@ -33,15 +33,10 @@
 
 (define-module os.windows.console.codepage
   (use os.windows)
-  (autoload gauche.vport
-            <virtual-input-port>
-            <virtual-output-port>)
-  (autoload gauche.uvector
-            <u8vector> make-u8vector uvector-alias
-            read-uvector! write-uvector u8vector->string string->u8vector
-            string->u32vector u32vector-range-check u32vector-ref)
-  (autoload gauche.charconv
-            ces-convert ces-conversion-supported? ces-equivalent?)
+  (use gauche.vport)
+  (use gauche.uvector)
+  (use gauche.charconv)
+  (use gauche.portutil)
   (export wrap-windows-console-standard-ports
           auto-wrap-windows-console-standard-ports))
 (select-module os.windows.console.codepage)


### PR DESCRIPTION
- Windows コンソール上で `gosh -fload-verbose` を実行すると、
  以下のエラーが出ました。
  ```
  Unhandled error occurred during reporting an error.  Process aborted.
  ```

- それで、error.c を改造してデバッグしたところ、以下のエラーが検出されていました。
  ```
  Attempted to trigger the same autoload #<module os.windows.console.codepage>#ces-conversion-supported? recursively.
  Maybe circular autoloaddependency?
  ```

- どうも、起動時のロード情報の表示のところで、os.windows.console.codepage のフックによって、
  さらに autoload が実行されるために、エラーになっているようです。

- とりあえずは、autoload を use に戻しました。
  高速化については、別途検討してみます。
  (現状、手動で起動する分には、気になるほどの遅延はみられません)

＜テスト＞
OS : Windows 8.1 (64bit)
Gauche : コミット 8bcae69 + 変更

開発環境1 : MSYS2/MinGW-w64 (64bit) (gcc version 7.1.0 (Rev2, Built by MSYS2 project))
Total: 18364 tests, 18364 passed,     0 failed,     0 aborted.

gosh -pload
→ 2017-9-28 OK (コマンドプロンプトとminttyの両方で確認)
gosh -fload-verbose
→ 2017-9-28 OK (コマンドプロンプトとminttyの両方で確認)
