### PR TITLE
Fix SEGV in Scm_PrintDouble of number.c

### DIFF
--- a/src/number.c
+++ b/src/number.c
@@ -3835,8 +3835,8 @@ size_t Scm_PrintNumber(ScmPort *port, ScmObj n, ScmNumberFormat *fmt)
 /* API.  FMT can be NULL.  Utility to expose Burger&Dybvig algorithm. */
 size_t Scm_PrintDouble(ScmPort *port, double d, ScmNumberFormat *fmt)
 {
+    ScmNumberFormat defaults;
     if (fmt == NULL) {
-        ScmNumberFormat defaults;
         Scm_NumberFormatInit(&defaults);
         fmt = &defaults;
     }


### PR DESCRIPTION
- スコープの関係で SEGV が発生したため 修正しました。
  
  ```
  make[2]: ディレクトリ '/c/Gauche/Gauche/ext/gauche' に入ります
  GAUCHE_TEST_RECORD_FILE="../../test.record" "../../src/gosh" -ftest -I. -I"." "./test.scm" > test.log
  Testing collections and sequences ...                            passed.
  Testing hook ...                                                 passed.
  Testing parameters ...                                           passed.
  Testing records ...                                              /bin/sh: 1 行:  8844 Segmentation fault      GAUCHE_TEST_RECORD_FILE="../../test.record" "../../src/gosh" -ftest -I. -I"." "./test.scm" > test.log
  make[2]: *** [../Makefile.ext:89: check] エラー 139
  make[2]: ディレクトリ '/c/Gauche/Gauche/ext/gauche' から出ます
  make[1]: *** [Makefile:62: check] エラー 1
  make[1]: ディレクトリ '/c/Gauche/Gauche/ext' から出ます
  make: *** [Makefile:47: check] エラー 2
  ```

＜テスト＞
OS : Windows 8.1 (64bit)
Gauche : コミット 8ed08f5 + 変更

開発環境1 : MSYS2/MinGW-w64 (64bit) (gcc version 7.1.0 (Rev2, Built by MSYS2 project))
Total: 19245 tests, 19245 passed,     0 failed,     0 aborted.
