### PR TITLE
Fix format ~f for x < 1

### DIFF
--- a/test/io.scm
+++ b/test/io.scm
@@ -758,6 +758,8 @@
 (test* "format ~6,2:f" "  5.02"  (format "~6,2:f" 5.015))
 (test* "format ~6,2:f" "-10.00"   (format "~6,2:f" -9.995))
 (test* "format ~10f" "     abcde"  (format "~10,2f" 'abcde))
+(test* "format ~1,2f" "0.00"     (format "~1,2f" 0.003))
+(test* "format ~1,0f" "-1."      (format "~1,0f" -0.555))
 
 (test* "format carry over ~,4f" "0.0100" (format "~,4f" 0.00999))
 (test* "format carry over across decimal point ~,1f" "124.0"


### PR DESCRIPTION
(format "~1,2f" 0.003) が "0.00" でなく "0.003" となる件を修正してみました。

POINT == 0 のときの繰り上がり処理を、POINT <= 0 のときにも適用するようにしました。

＜テスト＞
OS : Windows 8.1 (64bit)
Gauche : コミット 7eb99e1 + 変更

開発環境1 : MSYS2/MinGW-w64 (64bit) (gcc version 7.1.0 (Rev2, Built by MSYS2 project))
Total: 19263 tests, 19263 passed,     0 failed,     0 aborted.
