### PR TITLE
Fix sxml.serializer generating broken html

### DIFF
--- a/ext/sxml/src/serializer.scm
+++ b/ext/sxml/src/serializer.scm
@@ -845,14 +845,15 @@
                            (and (pair? node) (eq? (car node) '@))))
                         elem))))
                     (start-tag
-                     (if
-                      (or (not empty?)
-                          (and (eq? method 'html)
-                               (not elem-prefix)
-                               (srl:member-ci
-                                elem-local
-                                srl:void-elements)))
-                      '(">") '("/>")))
+                     (if (eq? method 'xml)
+                         (if empty? '("/>") '(">"))
+                         (if (or (not empty?)
+                                 (and (not elem-prefix)
+                                      (srl:member-ci
+                                       elem-local
+                                       srl:void-elements)))
+                             '(">")
+                             (list "></" (srl:qname->string elem-prefix elem-local) ">"))))
                     (ns-prefix-assig ns-prefix-assig)
                     (namespace-assoc namespace-assoc)
                     (declared-ns-prefixes

--- a/ext/sxml/src/serializer.scm
+++ b/ext/sxml/src/serializer.scm
@@ -806,6 +806,11 @@
               #t  ; in any case, prefix declaration is required
               )))))))))
 
+(define srl:void-elements
+  '("area" "base" "basefont" "br" "col"
+    "frame" "hr" "img" "input" "isindex"
+    "link" "meta" "param"))
+
 ; Constructs start and end tags for an SXML element `elem'
 ; method ::= 'xml | 'html
 ; Returns: (values start-tag end-tag
@@ -846,11 +851,7 @@
                                (not elem-prefix)
                                (srl:member-ci
                                 elem-local
-                                ; ATTENTION: should probably move this list
-                                ; to a global const
-                                '("area" "base" "basefont" "br" "col"
-                                  "frame" "hr" "img" "input" "isindex"
-                                  "link" "meta" "param"))))
+                                srl:void-elements)))
                       '(">") '("/>")))
                     (ns-prefix-assig ns-prefix-assig)
                     (namespace-assoc namespace-assoc)

--- a/ext/sxml/src/serializer.scm
+++ b/ext/sxml/src/serializer.scm
@@ -807,9 +807,9 @@
               )))))))))
 
 (define srl:void-elements
-  '("area" "base" "basefont" "br" "col"
-    "frame" "hr" "img" "input" "isindex"
-    "link" "meta" "param"))
+  '("area" "base" "basefont" "br" "col" "embed"
+    "frame" "hr" "img" "input" "isindex" "keygen"
+    "link" "meta" "param" "source" "track" "wbr"))
 
 ; Constructs start and end tags for an SXML element `elem'
 ; method ::= 'xml | 'html

--- a/ext/sxml/test.scm
+++ b/ext/sxml/test.scm
@@ -41,7 +41,7 @@
     (t srl:sxml->html
        "<foo a=\"b\" c=\"d&quot;e&apos;f\">\n  <g>h<i>j<k/></i></g>\n</foo>")
     (t srl:sxml->html-noindent
-       "<foo a=\"b\" c=\"d&quot;e&apos;f\"><g>h<i>j<k/></i></g></foo>")
+       "<foo a=\"b\" c=\"d&quot;e&apos;f\"><g>h<i>j<k></k></i></g></foo>")
     ))
 
 (test-end)


### PR DESCRIPTION
HTML5 (which basically is all modern browsers nowadays) seems to have a slightly different HTML syntax than html4. Things like "<a />" will not be considered equivalent to "<a></a>", just "<a>" but that is what we generate. As a result, the output html code could be rendered completely broken.

This attempts to fix that (in my own clumsy way because I haven't spent that much time studying this code). I know this is imported code but I don't know exactly how you want to handle this, maybe deal with upstream first, then import changes back?