### PR TITLE
Update test vector to follow HTML5

### DIFF
--- a/ext/sxml/test.scm
+++ b/ext/sxml/test.scm
@@ -39,7 +39,7 @@
     (t srl:sxml->xml-noindent
        "<foo a=\"b\" c=\"d&quot;e&apos;f\"><g>h<i>j<k/></i></g></foo>")
     (t srl:sxml->html
-       "<foo a=\"b\" c=\"d&quot;e&apos;f\">\n  <g>h<i>j<k/></i></g>\n</foo>")
+       "<foo a=\"b\" c=\"d&quot;e&apos;f\">\n  <g>h<i>j<k></k></i></g>\n</foo>")
     (t srl:sxml->html-noindent
        "<foo a=\"b\" c=\"d&quot;e&apos;f\"><g>h<i>j<k></k></i></g></foo>")
     ))


### PR DESCRIPTION
This test was missed by previous fix.

See also:
77fa6d81286fb00214c87e3028aa264b4561ec4a