### PR TITLE
read-char-set may prints error message with garbage

### DIFF
--- a/src/char.c
+++ b/src/char.c
@@ -936,7 +936,7 @@ ScmObj Scm_CharSetRead(ScmPort *input, int *complement_p,
         /* TODO: We should deal with the case when input contains \0 */
         Scm_Error("Invalid charset syntax [%s%s...",
                   complement? "^" : "",
-                  Scm_DStringPeek(&buf, NULL, NULL));
+                  Scm_DStringGetz(&buf));
     }
     return SCM_FALSE;
 }


### PR DESCRIPTION
The comment of Scm_DStringPeek says "The returned pointer may not be NUL-terminated." and actually so (this is true on both HEAD and 0.9.5).  But read-char-set passes it Scm_Error and prints it with format "%s".

Here is an example of an error with garbage:
```
$ LC_CTYPE= vis typescript
Script started on Fri Dec  1 09:47:27 2017
\^[[?1034hbash-3.2$ ./gosh -ftest\^M
gosh> (call-with-input-string "12345678901234567890"\^M
  read-char-set)\^M
*** ERROR: Invalid charset syntax [12345678901234567890\M-c\M^[\^U...\^M
Stack Trace:\^M
_______________________________________\^M
  0  (eval expr env)\^M
        at "../lib/gauche/interactive.scm":267\^M
gosh> ^D\^H\^Hbash-3.2$ exit\^M
exit\^M

Script done on Fri Dec  1 09:47:39 2017
```

Above test is executed on macOS 10.13.1.


