### PR TITLE
Add experimental syntax-rules

### DIFF
--- a/lib/Makefile.in
+++ b/lib/Makefile.in
@@ -49,7 +49,8 @@ SCMFILES = srfi-0.scm \
        srfi-117.scm srfi-118.scm srfi-121.scm srfi-125.scm srfi-127.scm \
        srfi-128.scm srfi-129.scm srfi-131.scm srfi-132.scm srfi-134.scm \
        srfi-141.scm srfi-143.scm srfi-146.scm srfi-146/hash.scm \
-       srfi-151.scm srfi-152.scm srfi-154.scm srfi-155.scm srfi-158.scm \
+       srfi-149-mod.scm srfi-151.scm srfi-152.scm srfi-154.scm srfi-155.scm \
+       srfi-158.scm \
        srfi/*.scm \
        slib.scm	 \
        check-script \

--- a/lib/srfi-149-mod.scm
+++ b/lib/srfi-149-mod.scm
@@ -15,11 +15,9 @@
 
 (define (identifier->symbol-149 x)
   (cond
-   ((symbol? x)
-    x)
-   ((keyword? x)
-    ;(string->symbol (string-append ":" (keyword->string x))))
-    x)
+   ((symbol? x) x)
+   ((keyword? x) x)
+   ;((keyword? x) (string->symbol (string-append ":" (keyword->string x))))
    (else
     (identifier->symbol x))))
 
@@ -51,7 +49,9 @@
         i
         (loop (+ i 1) (cdr ls)))))))
 
-(define (cons-source-149 kar kdr source) (cons kar kdr))
+;(define (cons-source-149 kar kdr source) (cons kar kdr))
+(define (cons-source-149 kar kdr source)
+  (with-module gauche.internal (with-original-source (cons kar kdr) source)))
 
 (define %number->string-149 number->string)
 

--- a/lib/srfi-149-mod.scm
+++ b/lib/srfi-149-mod.scm
@@ -1,0 +1,302 @@
+;;;
+;;; SRFI-149 Basic Syntax-rules Template Extensions
+;;;
+;;; modified for Gauche ( EXPERIMENTAL )
+;;;
+
+(define-module srfi-149-mod
+  (export syntax-rules))
+(select-module srfi-149-mod)
+
+(define (identifier?-149 x)
+  (or (symbol? x)
+      (keyword? x)
+      (identifier? x)))
+
+(define (identifier->symbol-149 x)
+  (cond
+   ((symbol? x)
+    x)
+   ((keyword? x)
+    ;(string->symbol (string-append ":" (keyword->string x))))
+    x)
+   (else
+    (identifier->symbol x))))
+
+;; (from Sagittarius Scheme's comments)
+;; Chibi allow 'ls' to be non pair as its extension.
+;; syntax-rules depends on this behaviour so we need to allow it
+(define (any-149 pred ls)
+  (cond
+   ((list? ls)
+    (any pred ls))
+   (else
+    (let loop ((ls ls))
+      (if (not (pair? ls))
+        #f
+        (or (pred (car ls))
+            (loop (cdr ls))))))))
+
+;; (from Sagittarius Scheme's comments)
+;; Chibi's length* returns element count of car parts of inproper list
+;; e.g) (length* '(1 2 3 . 4)) ;; => 3
+;; And syntax-rules depends on this behaviour. So provide it.
+(define (length*-149 ls)
+  (cond
+   ((list? ls)
+    (length ls))
+   (else
+    (let loop ((i 0) (ls ls))
+      (if (not (pair? ls))
+        i
+        (loop (+ i 1) (cdr ls)))))))
+
+(define (cons-source-149 kar kdr source) (cons kar kdr))
+
+(define %number->string-149 number->string)
+
+;(define (strip-syntactic-closures-149 x) x)
+(define strip-syntactic-closures-149 unwrap-syntax)
+
+(define (syntax-rules-transformer expr rename compare)
+  (let ((ellipsis-specified? (identifier?-149 (cadr expr)))
+        (count 0)
+        (_er-macro-transformer (rename 'er-macro-transformer))
+        (_lambda (rename 'lambda))      (_let (rename 'let))
+        (_begin (rename 'begin))        (_if (rename 'if))
+        (_and (rename 'and))            (_or (rename 'or))
+        (_eq? (rename 'eq?))            (_equal? (rename 'equal?))
+        (_car (rename 'car))            (_cdr (rename 'cdr))
+        (_cons (rename 'cons))          (_pair? (rename 'pair?))
+        (_null? (rename 'null?))        (_expr (rename 'expr))
+        (_rename (rename 'rename))      (_compare (rename 'compare))
+        (_quote (rename 'syntax-quote)) (_apply (rename 'apply))
+        (_append (rename 'append))      (_map (rename 'map))
+        (_vector? (rename 'vector?))    (_list? (rename 'list?))
+        (_len (rename'len))             (_length (rename 'length*-149))
+        (_- (rename '-))   (_>= (rename '>=))   (_error (rename 'error))
+        (_ls (rename 'ls)) (_res (rename 'res)) (_i (rename 'i))
+        (_reverse (rename 'reverse))
+        (_vector->list (rename 'vector->list))
+        (_list->vector (rename 'list->vector))
+        (_cons3 (rename 'cons-source-149))
+        (_underscore (rename '_)))
+    (define ellipsis (if ellipsis-specified? (cadr expr) (rename '...)))
+    (define lits (if ellipsis-specified? (car (cddr expr)) (cadr expr)))
+    (define forms (if ellipsis-specified? (cdr (cddr expr)) (cddr expr)))
+    (define (next-symbol s)
+      (set! count (+ count 1))
+      (rename (string->symbol (string-append s (%number->string-149 count)))))
+    (define (expand-pattern pat tmpl)
+      (let lp ((p (cdr pat))
+               (x (list _cdr _expr))
+               (dim 0)
+               (vars '())
+               (k (lambda (vars)
+                    (list _cons (expand-template tmpl vars) #f))))
+        (let ((v (next-symbol "v.")))
+          (list
+           _let (list (list v x))
+           (cond
+            ((identifier?-149 p)
+             (if (any-149 (lambda (l) (compare p l)) lits)
+                 (list _and
+                       (list _compare v (list _rename (list _quote p)))
+                       (k vars))
+                 (if (compare p _underscore)
+                     (k vars)
+                     (list _let (list (list p v)) (k (cons (cons p dim) vars))))))
+            ((ellipsis? p)
+             (cond
+              ((not (null? (cdr (cdr p))))
+               (cond
+                ((any-149 (lambda (x) (and (identifier?-149 x) (compare x ellipsis)))
+                          (cddr p))
+                 (error "multiple ellipses" p))
+                (else
+                 (let ((len (length*-149 (cdr (cdr p))))
+                       (_lp (next-symbol "lp.")))
+                   `(,_let ((,_len (,_length ,v)))
+                      (,_and (,_>= ,_len ,len)
+                             (,_let ,_lp ((,_ls ,v)
+                                          (,_i (,_- ,_len ,len))
+                                          (,_res (,_quote ())))
+                                    (,_if (,_>= 0 ,_i)
+                                        ,(lp `(,(cddr p)
+                                               (,(car p) ,(car (cdr p))))
+                                             `(,_cons ,_ls
+                                                      (,_cons (,_reverse ,_res)
+                                                              (,_quote ())))
+                                             dim
+                                             vars
+                                             k)
+                                        (,_lp (,_cdr ,_ls)
+                                              (,_- ,_i 1)
+                                              (,_cons3 (,_car ,_ls)
+                                                       ,_res
+                                                       ,_ls))))))))))
+              ((identifier?-149 (car p))
+               (list _and (list _list? v)
+                     (list _let (list (list (car p) v))
+                           (k (cons (cons (car p) (+ 1 dim)) vars)))))
+              (else
+               (let* ((w (next-symbol "w."))
+                      (_lp (next-symbol "lp."))
+                      (new-vars (all-vars (car p) (+ dim 1)))
+                      (ls-vars (map (lambda (x)
+                                      (next-symbol
+                                       (string-append
+                                        (symbol->string
+                                         (identifier->symbol-149 (car x)))
+                                        "-ls")))
+                                    new-vars))
+                      (once
+                       (lp (car p) (list _car w) (+ dim 1) '()
+                           (lambda (_)
+                             (cons
+                              _lp
+                              (cons
+                               (list _cdr w)
+                               (map (lambda (x l)
+                                      (list _cons (car x) l))
+                                    new-vars
+                                    ls-vars)))))))
+                 (list
+                  _let
+                  _lp (cons (list w v)
+                            (map (lambda (x) (list x (list _quote '()))) ls-vars))
+                  (list _if (list _null? w)
+                        (list _let (map (lambda (x l)
+                                          (list (car x) (list _reverse l)))
+                                        new-vars
+                                        ls-vars)
+                              (k (append new-vars vars)))
+                        (list _and (list _pair? w) once)))))))
+            ((pair? p)
+             (list _and (list _pair? v)
+                   (lp (car p)
+                       (list _car v)
+                       dim
+                       vars
+                       (lambda (vars)
+                         (lp (cdr p) (list _cdr v) dim vars k)))))
+            ((vector? p)
+             (list _and
+                   (list _vector? v)
+                   (lp (vector->list p) (list _vector->list v) dim vars k)))
+            ((null? p) (list _and (list _null? v) (k vars)))
+            (else (list _and (list _equal? v p) (k vars))))))))
+    (define (ellipsis-escape? x) (and (pair? x) (compare ellipsis (car x))))
+    (define (ellipsis? x)
+      (and (pair? x) (pair? (cdr x)) (compare ellipsis (cadr x))))
+    (define (ellipsis-depth x)
+      (if (ellipsis? x)
+          (+ 1 (ellipsis-depth (cdr x)))
+          0))
+    (define (ellipsis-tail x)
+      (if (ellipsis? x)
+          (ellipsis-tail (cdr x))
+          (cdr x)))
+    (define (all-vars x dim)
+      (let lp ((x x) (dim dim) (vars '()))
+        (cond ((identifier?-149 x)
+               (if (any-149 (lambda (lit) (compare x lit)) lits)
+                   vars
+                   (cons (cons x dim) vars)))
+              ((ellipsis? x) (lp (car x) (+ dim 1) (lp (cddr x) dim vars)))
+              ((pair? x) (lp (car x) dim (lp (cdr x) dim vars)))
+              ((vector? x) (lp (vector->list x) dim vars))
+              (else vars))))
+    (define (free-vars x vars dim)
+      (let lp ((x x) (free '()))
+        (cond
+         ((identifier?-149 x)
+          (if (and (not (memq x free))
+                   (cond ((assq x vars) => (lambda (cell) (>= (cdr cell) dim)))
+                         (else #f)))
+              (cons x free)
+              free))
+         ((pair? x) (lp (car x) (lp (cdr x) free)))
+         ((vector? x) (lp (vector->list x) free))
+         (else free))))
+    (define (expand-template tmpl vars)
+      (let lp ((t tmpl) (dim 0))
+        (cond
+         ((identifier?-149 t)
+          (cond
+           ((find (lambda (v) (eq? t (car v))) vars)
+            => (lambda (cell)
+                 (if (<= (cdr cell) dim)
+                     t
+                     (error "too few ...'s"))))
+           (else
+            (list _rename (list _quote t)))))
+         ((pair? t)
+          (cond
+           ((ellipsis-escape? t)
+            (list _quote
+                  (if (pair? (cdr t))
+                      (if (pair? (cddr t)) (cddr t) (cadr t))
+                      (cdr t))))
+           ((ellipsis? t)
+            (let* ((depth (ellipsis-depth t))
+                   (ell-dim (+ dim depth))
+                   (ell-vars (free-vars (car t) vars ell-dim)))
+              (cond
+               ((null? ell-vars)
+                (error "too many ...'s"))
+               ((and (null? (cdr (cdr t))) (identifier?-149 (car t)))
+                ;; shortcut for (var ...)
+                (lp (car t) ell-dim))
+               (else
+                (let* ((once (lp (car t) ell-dim))
+                       (nest (if (and (null? (cdr ell-vars))
+                                      (identifier?-149 once)
+                                      (eq? once (car vars)))
+                                 once ;; shortcut
+                                 (cons _map
+                                       (cons (list _lambda ell-vars once)
+                                             ell-vars))))
+                       (many (do ((d depth (- d 1))
+                                  (many nest
+                                        (list _apply _append many)))
+                                 ((= d 1) many))))
+                  (if (null? (ellipsis-tail t))
+                      many ;; shortcut
+                      (list _append many (lp (ellipsis-tail t) dim))))))))
+           (else (list _cons3 (lp (car t) dim) (lp (cdr t) dim) (list _quote t)))))
+         ((vector? t) (list _list->vector (lp (vector->list t) dim)))
+         ((null? t) (list _quote '()))
+         (else t))))
+    (list
+     _er-macro-transformer
+     (list _lambda (list _expr _rename _compare)
+           (list
+            _car
+            (cons
+             _or
+             (append
+              (map
+               (lambda (clause) (expand-pattern (car clause) (cadr clause)))
+               forms)
+              (list
+               (list _cons
+                     (list _error "no expansion for"
+                           (list (rename 'strip-syntactic-closures-149) _expr))
+                     #f)))))))))
+
+(define-syntax syntax-rules/aux
+  ;; modified to avoid unbound variable error of syntax-rules-transformer
+  ;(er-macro-transformer syntax-rules-transformer))
+  (er-macro-transformer
+   (lambda (expr rename compare)
+     (syntax-rules-transformer expr rename compare))))
+
+(define-syntax syntax-rules
+  (er-macro-transformer
+   (lambda (expr rename compare)
+     (if (identifier?-149 (cadr expr))
+         (list (rename 'let) (list (list (cadr expr) #t))
+               (cons (rename 'syntax-rules/aux) (cdr expr)))
+         (syntax-rules-transformer expr rename compare)))))
+

--- a/src/compile-1.scm
+++ b/src/compile-1.scm
@@ -1025,10 +1025,18 @@
 (define (pass1/quote obj)
   ($const (unwrap-syntax obj)))
 
+(define (pass1/syntax-quote obj)
+  ($const obj))
+
 (define-pass1-syntax (quote form cenv) :null
   (match form
     [(_ obj) (pass1/quote obj)]
     [else (error "syntax-error: malformed quote:" form)]))
+
+(define-pass1-syntax (syntax-quote form cenv) :null
+  (match form
+    [(_ obj) (pass1/syntax-quote obj)]
+    [else (error "syntax-error: malformed syntax-quote:" form)]))
 
 (define-pass1-syntax (quasiquote form cenv) :null
   ;; We want to avoid unnecessary allocation as much as possible.

--- a/src/compile.scm
+++ b/src/compile.scm
@@ -358,7 +358,8 @@
  (define-cproc cenv-toplevel? (cenv)
    (SCM_ASSERT (SCM_VECTORP cenv))
    (dolist [fp (SCM_VECTOR_ELEMENT cenv 1)]
-     (if (== (SCM_CAR fp) '0) (return '#f)))
+     ;; check both lexical and syntax frames
+     (if (or (== (SCM_CAR fp) '0) (== (SCM_CAR fp) '1)) (return '#f)))
    (return '#t))
  )
 

--- a/src/compile.scm
+++ b/src/compile.scm
@@ -1536,12 +1536,18 @@
 
 ;; er-comparer :: (Sym-or-id, Sym-or-id, Env, Env) -> Bool
 (define (er-comparer a b uenv cenv)
-  (and (variable? a)
-       (variable? b)
-       (let ([a1 (cenv-lookup-variable uenv a)]
-             [b1 (cenv-lookup-variable uenv b)])
-         (or (eq? a1 b1)
-             (free-identifier=? a1 b1)))))
+  (cond
+   ;; consider keywords
+   ((and (keyword? a) (keyword? b))
+    (eq? a b))
+   (else
+    (and (variable? a)
+         (variable? b)
+         ;; recognize both variables and macros
+         (let ([a1 (cenv-lookup-syntax uenv a)]
+               [b1 (cenv-lookup-syntax uenv b)])
+           (or (eq? a1 b1)
+               (free-identifier=? a1 b1)))))))
 
 ;; xformer :: (Sexpr, (Sym -> Sym), (Sym, Sym -> Bool)) -> Sexpr
 (define (%make-er-transformer xformer def-env)

--- a/src/main.c
+++ b/src/main.c
@@ -728,6 +728,14 @@ int main(int ac, char **av)
     }
     Scm_AddCleanupHandler(cleanup_main, NULL);
 
+    /* experimental syntax-rules */
+    if (Scm_GetEnv("GAUCHE_EXP_SYNTAX_RULES") != NULL) {
+        if (!Scm_Require(SCM_MAKE_STR("srfi-149-mod"), 0, NULL)) {
+            Scm_EvalCString("(define syntax-rules (with-module srfi-149-mod syntax-rules))",
+                            SCM_OBJ(Scm_GaucheModule()), NULL);
+        }
+    }
+
 #if defined(GAUCHE_WINDOWS)
     /* auto wrap windows console standard ports */
     if (!test_mode && Scm_GetEnv("GAUCHE_WINDOWS_CONSOLE_RAW") == NULL) {

--- a/src/main.c
+++ b/src/main.c
@@ -729,8 +729,8 @@ int main(int ac, char **av)
     Scm_AddCleanupHandler(cleanup_main, NULL);
 
     /* experimental syntax-rules */
-    if (Scm_GetEnv("GAUCHE_EXP_SYNTAX_RULES") != NULL) {
-        if (!Scm_Require(SCM_MAKE_STR("srfi-149-mod"), 0, NULL)) {
+    if (!Scm_Require(SCM_MAKE_STR("srfi-149-mod"), 0, NULL)) {
+        if (Scm_GetEnv("GAUCHE_EXP_SYNTAX_RULES") != NULL) {
             Scm_EvalCString("(define syntax-rules (with-module srfi-149-mod syntax-rules))",
                             SCM_OBJ(Scm_GaucheModule()), NULL);
         }


### PR DESCRIPTION
実験的に SRFI-149 の syntax-rules を追加してみました。

環境変数 GAUCHE_EXP_SYNTAX_RULES を設定すると、
srfi-149-mod.scm の syntax-rules を使用します。

現状、マージできるレベルではなく、make check で以下のエラーが出ます。
また、環境変数ありで Gauche をビルドしてしまうと、
以後、環境変数なしで Gauche を実行したときにエラーが出たりするようです。。。

```
Testing macro ...                                                failed.
discrepancies found.  Errors are:
test bad ellipsis 6: expects #<error> => got #<undef>
test alt-elli3: expects literal => got ellipsis

Testing SRFIs ...                                                *** ERROR: unbound variable: test-assert
    While loading "../test/srfi.scm" at line 1568
Stack Trace:
_______________________________________
  0  (test-assert '(hash-table-exists? ht 'dog) (hash-table-exists ...
        expanded from (test-assert (hash-table-exists? ht 'dog))
        at "../test/srfi.scm":1419
  1  (test-assert '(hash-table-exists? ht 'dog) (hash-table-exists ...
        expanded from (test-assert (hash-table-exists? ht 'dog))
        at "../test/srfi.scm":1419

Total: 16546 tests, 16544 passed,     2 failed,     1 aborted.
```

ただ、齊藤さんの
https://github.com/SaitoAtsushi/pattern-match-lambda
については、正常に動作するようでした。

デバッグは、compile.scm 等に print を追加して行っていますが、結構つらい感じです。

Sagittarius Scheme のソースのコメントが大変参考になりました。

まずは、make check が正常に終了することを目指してみようと思います。

気になる点等がありましたら、連絡をお願いします。

＜テスト環境＞
OS : Windows 8.1 (64bit)
Gauche : コミット e541e38 + 変更
開発環境 : MSYS2/MinGW-w64 (64bit) (gcc version 7.1.0 (Rev2, Built by MSYS2 project))
