### PR TITLE
Fix scope reference of internal definition and macro expansion

### DIFF
--- a/lib/gauche/cgen/precomp.scm
+++ b/lib/gauche/cgen/precomp.scm
@@ -1022,7 +1022,7 @@
   ((id-name        :init-keyword :id-name)
    (module-literal :init-keyword :module-literal))
   (make (value)
-    (unless (null? (~ value'env))
+    (unless ((with-module gauche.internal identifier-unbound?) value)
       (error "identifier with compiler environment can't be compiled" value))
     (make <cgen-scheme-identifier> :value value
           :c-name (cgen-allocate-static-datum)

--- a/src/gauche/vm.h
+++ b/src/gauche/vm.h
@@ -198,6 +198,7 @@ SCM_EXTERN ScmObj Scm_WrapIdentifier(ScmIdentifier *id);
 SCM_EXTERN int    Scm_IdentifierBindingEqv(ScmIdentifier *id, ScmSymbol *sym,
                                            ScmObj env);
 SCM_EXTERN int    Scm_FreeVariableEqv(ScmObj var, ScmObj sym, ScmObj env);
+SCM_EXTERN ScmObj Scm_IdentifierUnboundP(ScmIdentifier *id);
 
 SCM_EXTERN ScmIdentifier *Scm_OutermostIdentifier(ScmIdentifier *id);
 SCM_EXTERN ScmSymbol     *Scm_UnwrapIdentifier(ScmIdentifier *id);

--- a/src/libsym.scm
+++ b/src/libsym.scm
@@ -168,3 +168,7 @@
     (if-let1 first-id (find identifier? args)
       (make-identifier r (identifier-module first-id) (identifier-env first-id))
       r)))
+
+(define-cproc identifier-unbound? (id::<identifier>)
+  Scm_IdentifierUnboundP)
+

--- a/test/macro.scm
+++ b/test/macro.scm
@@ -1011,7 +1011,7 @@
               [(_) x]))
           (foo))))
 
-'(test "internal define-syntax and scope 2" 'inner
+(test "internal define-syntax and scope 2" 'inner
       (let ((x 'outer))
         (lambda ()
           (define-syntax foo
@@ -1020,7 +1020,7 @@
           (define x 'inner)
           (foo))))
 
-'(test "internal define-syntax and scope 3" '(inner inner)
+(test "internal define-syntax and scope 3" '(inner inner)
       (let ((x 'outer))
         (lambda ()
           (define-syntax def
@@ -1030,7 +1030,7 @@
           (def y)
           (list x y))))
 
-'(test "internal define-syntax and scope 3" '(inner inner)
+(test "internal define-syntax and scope 4" '(inner inner)
       (let ((x 'outer))
         (lambda ()
           (define-syntax def
@@ -1592,7 +1592,7 @@
 
 '(test-section "srfi-147 begin")
 
-'(test "srfi-147 begin (internal)"
+'(test "srfi-147 begin (internal) 1"
       '(yes no)
       (lambda ()
         (define-syntax foo
@@ -1602,7 +1602,7 @@
         (list (foo 'yes 'no (zero? 0))
               (foo 'yes 'no (zero? 1)))))
 
-'(test "srfi-147 begin (internal)"
+'(test "srfi-147 begin (internal) 2"
       11
       (lambda ()
         (let-syntax ([foo (syntax-rules ()


### PR DESCRIPTION
内部 define とマクロ展開の組み合わせで、
外側のスコープを参照してしまう件について調べました。

ちょっと影響範囲が読めない感じですが、まずは情報としてあげておきます。

#327 の (2)-(a)(b)(c) については、本パッチでOKになることを確認しました。


＜原因＞
pass1/body-rec の処理で、内部 define 用の frame (vframe) が作られて、
内部 define の変数は、そこに順番に追加されていく。

しかし、マクロ展開時に呼ばれる Scm_MakeIdentifier では、ヒットしない frame を
除外して identifier の env を記憶するようになっている。

このため、変数が vframe に登録される前にマクロ展開が行われると、
マクロ展開結果の identifier には vframe を除外した env が記憶されてしまい、
後から vframe に変数が追加されても、identifier からは参照できない。

結果として、identifier が外側のスコープを参照してしまう。


＜対策＞
Scm_MakeIdentifier で、frame の除外を行わないようにする。


＜気になる点＞
(1) frame を除外しないことで、identifier 検索時の負荷が増えると思われる。

(2) identifier の env が「ヒットする frame だけを持つこと」を当てにしている
プログラムがあると、不具合が発生すると思われる。
→ 実際に precomp.scm で 以下のエラー
「identifier with compiler environment can't be compiled」
→ identifier-unbound? を追加して対応した
→ あと、Scm_IdentifierBindingEqv も、まずそうだったので変更


＜テスト結果＞
OS : Windows 8.1 (64bit)
Gauche : コミット bb58efd + 変更
開発環境 : MSYS2/MinGW-w64 (64bit) (gcc version 7.1.0 (Rev2, Built by MSYS2 project))
Total: 19268 tests, 19268 passed,     0 failed,     0 aborted.
