### PR TITLE
Fix built-in syntax-rules (compare, rename, etc.)

### DIFF
--- a/src/compile-1.scm
+++ b/src/compile-1.scm
@@ -817,19 +817,21 @@
 (define-pass1-syntax (syntax-rules form cenv) :null
   (match form
     [(_ (literal ...) rule ...)
-     ($const (compile-syntax-rules (cenv-exp-name cenv) form '... literal rule
+     ($const (compile-syntax-rules (cenv-exp-name cenv)
+                                   form
+                                   #t ; default ellipsis (...)
+                                   literal
+                                   rule
                                    (cenv-module cenv)
                                    (cenv-frames cenv)))]
     [(_ (? variable-or-keyword? elli) (literal ...) rule ...)
-     ;; NB: Stripping identifier from elli may be broken in macro-defining-macro.
-     ;; Fix it once we have proper low-level macro system.
      ;; NB: We allow keyword for ellipsis, so that something like ::: can be
      ;; used.
-     ($const (compile-syntax-rules (cenv-exp-name cenv) form
-                                   (if (identifier? elli)
-                                     (slot-ref elli 'name)
-                                     elli)
-                                   literal rule
+     ($const (compile-syntax-rules (cenv-exp-name cenv)
+                                   form
+                                   elli
+                                   literal
+                                   rule
                                    (cenv-module cenv)
                                    (cenv-frames cenv)))]
     [_ (error "syntax-error: malformed syntax-rules:" form)]))
@@ -1641,7 +1643,7 @@
                                        :allow-archive #t
                                        :relative-dot-path #t)
       (if (pair? (cddr path&rest)) ; archive hook is in effect.
-        ((caddr path&rest))
+        ((caddr path&rest) (car path&rest))
         (open-input-file (car path&rest) :encoding #t))
       (error "include file is not readable: " path))))
 

--- a/src/compile.scm
+++ b/src/compile.scm
@@ -1527,12 +1527,12 @@
               (loop (+ i 1) vec dict))))))]
    [else (values form dict)]))
 
-;; er-comparer :: (Sym-or-id, Sym-or-id, Env, Env) -> Bool
-(define (er-comparer a b uenv cenv)
+;; er-comparer :: (Sym-or-id, Sym-or-id) -> Bool
+(define (er-comparer a b module env)
   (if (and (variable? a)
            (variable? b))
-    (let ([a1 (cenv-lookup-syntax uenv a)]
-          [b1 (cenv-lookup-syntax uenv b)])
+    (let ([a1 (env-lookup a module env)]
+          [b1 (env-lookup b module env)])
       (or (eq? a1 b1)
           (free-identifier=? a1 b1)))
     ;; This path is for GAUCHE_KEYWORD_DISJOINT
@@ -1544,14 +1544,16 @@
 (define (%make-er-transformer xformer def-env)
   (define def-module (cenv-module def-env))
   (define def-frames (cenv-frames def-env))
-  (define (expand form uenv)
+  (define (expand form use-env)
+    (define use-module (cenv-module use-env))
+    (define use-frames (cenv-frames use-env))
     (let1 dict '()
       (xformer form
                (^[sym]
                  (receive [id dict_] (er-renamer sym dict def-module def-frames)
                    (set! dict dict_)
                    id))
-               (^[a b] (er-comparer a b uenv def-env)))))
+               (^[a b] (er-comparer a b use-module use-frames)))))
   (%make-macro-transformer (cenv-exp-name def-env) expand))
 
 ;; Call to this procedure can be inserted in the output of er-macro expander

--- a/src/gauche/priv/identifierP.h
+++ b/src/gauche/priv/identifierP.h
@@ -41,8 +41,27 @@ struct ScmIdentifierRec {
     ScmObj name;          /* symbol or identifier */
     ScmModule *module;
     ScmObj frames;        /* opaque - see compaux.c for the details */
+    int flags;            /* see below */
 };
 
+/* contents of flags */
+#define SCM_IDENTIFIER_FLAG_DELAYED 0x01 /* for delaying frame truncation
+                                            (see compaux.c) */
+#define SCM_IDENTIFIER_FLAG_RENAMED 0x02 /* for renaming an identifier
+                                            (see macro.c) */
+
+#define SCM_IDENTIFIER_FLAG_DELAYED_P(id) \
+    (SCM_IDENTIFIER(id)->flags & SCM_IDENTIFIER_FLAG_DELAYED)
+#define SCM_IDENTIFIER_FLAG_DELAYED_SET(id) \
+    (SCM_IDENTIFIER(id)->flags |= SCM_IDENTIFIER_FLAG_DELAYED)
+#define SCM_IDENTIFIER_FLAG_DELAYED_RESET(id) \
+    (SCM_IDENTIFIER(id)->flags &= ~SCM_IDENTIFIER_FLAG_DELAYED)
+#define SCM_IDENTIFIER_FLAG_RENAMED_P(id) \
+    (SCM_IDENTIFIER(id)->flags & SCM_IDENTIFIER_FLAG_RENAMED)
+#define SCM_IDENTIFIER_FLAG_RENAMED_SET(id) \
+    (SCM_IDENTIFIER(id)->flags |= SCM_IDENTIFIER_FLAG_RENAMED)
+#define SCM_IDENTIFIER_FLAG_RENAMED_RESET(id) \
+    (SCM_IDENTIFIER(id)->flags &= ~SCM_IDENTIFIER_FLAG_RENAMED)
 
 SCM_DECL_END
 

--- a/src/macro.c
+++ b/src/macro.c
@@ -391,6 +391,7 @@ static ScmObj rename_variable(PatternContext *ctx, ScmObj var)
         SCM_ASSERT(SCM_IDENTIFIERP(var));
         id = Scm_WrapIdentifier(SCM_IDENTIFIER(var));
     }
+    SCM_IDENTIFIER_FLAG_RENAMED_SET(id);
     ctx->renames = Scm_Acons(var, id, ctx->renames);
     return id;
 }
@@ -946,6 +947,11 @@ static ScmObj realize_template_rec(ScmObj template,
         if (SCM_PAIRP(p)) return SCM_CDR(p);
         else {
             ScmObj id = Scm_WrapIdentifier(SCM_IDENTIFIER(template));
+            if (SCM_IDENTIFIER_FLAG_RENAMED_P(template)) {
+                /* remove a temporary wrapping */
+                SCM_IDENTIFIER(id)->name = SCM_IDENTIFIER(template)->name;
+                SCM_IDENTIFIER_FLAG_RENAMED_RESET(id);
+            }
             *idlist = Scm_Acons(template, id, *idlist);
             return id;
         }

--- a/src/macro.c
+++ b/src/macro.c
@@ -764,29 +764,6 @@ static inline void match_insert(ScmObj pvref, ScmObj matched, MatchVar *mvec)
     }
 }
 
-/* see if literal identifier ID in the pattern matches the given object */
-static inline int match_identifier(ScmIdentifier *id, ScmObj obj,
-                                   ScmObj mod, ScmObj env)
-{
-    if (SCM_SYMBOLP(obj)) {
-        /* This is temporary: We don't want to allocate identifier for
-           every bare symbol we want to match.  But this is the shortcut
-           to do the right thing (using free-identifier=? to comapre literals.
-           Let's think optimization later. */
-        SCM_ASSERT(SCM_MODULEP(mod));
-        obj = Scm_MakeIdentifier(obj, SCM_MODULE(mod), env);
-    }
-    if (SCM_IDENTIFIERP(obj)) {
-        /* free-identifier=? is defined in Scheme (libmod.scm)  */
-        static ScmObj free_identifier_eq_proc = SCM_UNDEFINED;
-        SCM_BIND_PROC(free_identifier_eq_proc, "free-identifier=?",
-                      Scm_GaucheInternalModule());
-        return !SCM_FALSEP(Scm_ApplyRec2(free_identifier_eq_proc,
-                                         SCM_OBJ(id), obj));
-    }
-    return FALSE;
-}
-
 static inline int match_subpattern(ScmObj form, ScmSyntaxPattern *pat,
                                    ScmObj rest, ScmObj mod, ScmObj env,
                                    MatchVar *mvec)

--- a/test/include/r7rs-tests.scm
+++ b/test/include/r7rs-tests.scm
@@ -459,9 +459,6 @@
 (test '#((10 43) (31 41 51) (32 42 52) (63 77) ("rest:" . "tail"))
     (part-2x (10 (+ 21 22) (31 32) (41 42) (51 52) (+ 61 2) 77 . "tail")))
 
-(cond-expand
- [gauche] ; this is Gauche's bug
- [else
 ;; underscore
 (define-syntax count-to-2
   (syntax-rules ()
@@ -481,7 +478,6 @@
 (test '(2 0 fail fail)
     (list (count-to-2_ _ _) (count-to-2_)
           (count-to-2_ a b) (count-to-2_ a b c d)))
-])
 
 (define-syntax jabberwocky
   (syntax-rules ()

--- a/test/macro.scm
+++ b/test/macro.scm
@@ -1600,6 +1600,45 @@
                 (interaction-environment)))))
 
 ;;----------------------------------------------------------------------
+;; 'compare-ellipsis-1' test should output the following error.
+;;
+;; *** ERROR: in definition of macro mac-sub1:
+;; template's ellipsis nesting is deeper than pattern's:
+;; (#<identifier user#list.2d80660> #<identifier user#x.2d80690>
+;;  #<identifier user#ooo.2d806f0>)
+;;
+;; 'compare-ellipsis-2' test should output the following error.
+;;
+;; *** ERROR: in definition of macro mac-sub1:
+;; template's ellipsis nesting is deeper than pattern's:
+;; (#<identifier user#list.2969870> #<identifier user#x.29698a0>
+;;  #<identifier user#ooo.2969900>)
+
+(test-section "compare ellipsis")
+
+(define-syntax ell-test
+  (syntax-rules (ooo)
+    ((_ zzz)
+     (let-syntax
+         ((mac-sub1
+           (syntax-rules ooo ()
+             ((_ x zzz)
+              (list x ooo)))))
+       (mac-sub1 1 2 3)))))
+
+(test* "compare-ellipsis-1"
+       (test-error <error> #/^in definition of macro/)
+       (eval
+        '(ell-test ooo)
+        (interaction-environment)))
+
+(test* "compare-ellipsis-2"
+       (test-error <error> #/^in definition of macro/)
+       (eval
+        '(let ((ooo 'yyy)) (ell-test ooo))
+        (interaction-environment)))
+
+;;----------------------------------------------------------------------
 ;; 'compare-literals-2' test should output the following error.
 ;;
 ;; *** ERROR: malformed #<identifier user#lit-test-2.29d4060>:

--- a/test/macro.scm
+++ b/test/macro.scm
@@ -1600,6 +1600,104 @@
                 (interaction-environment)))))
 
 ;;----------------------------------------------------------------------
+;; 'compare-literals-2' test should output the following error.
+;;
+;; *** ERROR: malformed #<identifier user##<identifier user#lit-test-2.2d9c3c0>.2db85e0>:
+;; (#<identifier user##<identifier user#lit-test-2.2d9c3c0>.2db85e0>
+;;  #<identifier user##<identifier user#temp.2d9c6e0>.2db8600>)
+;; While compiling: (lit-test-2 temp 1)
+
+(test-section "compare literals")
+
+(define-syntax lit-test-1
+  (syntax-rules (temp)
+    ((_ temp x)
+     (lit-test-1 temp))
+    ((_ temp)
+     'passed)))
+
+(test* "compare-literals-1" 'passed (lit-test-1 temp 1))
+
+(define-syntax lit-test-2
+  (syntax-rules (temp)
+    ((_ temp x)
+     (let ((temp 100))
+       (lit-test-2 temp)))
+    ((_ temp)
+     'failed)))
+
+(test* "compare-literals-2"
+       (test-error <error> #/^malformed/)
+       (eval '(lit-test-2 temp 1) (interaction-environment)))
+
+;;----------------------------------------------------------------------
+;; 'gen-underbar-1' test should output the following error.
+;;
+;; *** ERROR: unbound variable:
+;; #<identifier user##<identifier user##<identifier user#_.2cacca0>.2cb7920>.2cb7720>
+
+(test-section "generate underbar")
+
+(define-syntax gen-underbar
+  (syntax-rules (_)
+    ((gen-underbar)
+     (let-syntax
+         ((mac-sub1
+           (syntax-rules ()
+             ((mac-sub1 _)
+              _))))
+       (mac-sub1 'failed)))))
+
+(test* "gen-underbar-1"
+       (test-error <error> #/^unbound variable/)
+       (gen-underbar))
+
+;;----------------------------------------------------------------------
+;; 'pattern-variables-1' test should output the following error.
+;;
+;; *** ERROR: too many pattern variables in the macro definition of pat-vars
+;; While compiling: (syntax-rules () ((_ (z1 (x1 x2 x3 x4 x5 x6 x7 x8 x9 x10
+;; x11 x12 x13 x14 x15 x16 x17 x ...
+;; While compiling: (define-syntax pat-vars (syntax-rules () ((_ (z1 (x1 x2 x3
+;; x4 x5 x6 x7 x8 x9 x10 x11 x ...
+
+(test-section "pattern variables check")
+
+(test* "pattern-variables-1"
+       (test-error <error> #/^too many pattern variables/)
+       (eval
+        '(define-syntax pat-vars
+           (syntax-rules ()
+             ((_ (z1 (x1 x2 x3 x4 x5 x6 x7 x8 x9 x10
+                      x11 x12 x13 x14 x15 x16 x17 x18 x19 x20
+                      x21 x22 x23 x24 x25 x26 x27 x28 x29 x30
+                      x31 x32 x33 x34 x35 x36 x37 x38 x39 x40
+                      x41 x42 x43 x44 x45 x46 x47 x48 x49 x50
+                      x51 x52 x53 x54 x55 x56 x57 x58 x59 x60
+                      x61 x62 x63 x64 x65 x66 x67 x68 x69 x70
+                      x71 x72 x73 x74 x75 x76 x77 x78 x79 x80
+                      x81 x82 x83 x84 x85 x86 x87 x88 x89 x90
+                      x91 x92 x93 x94 x95 x96 x97 x98 x99 x100
+                      x101 x102 x103 x104 x105 x106 x107 x108 x109 x110
+                      x111 x112 x113 x114 x115 x116 x117 x118 x119 x120
+                      x121 x122 x123 x124 x125 x126 x127 x128 x129 x130
+                      x131 x132 x133 x134 x135 x136 x137 x138 x139 x140
+                      x141 x142 x143 x144 x145 x146 x147 x148 x149 x150
+                      x151 x152 x153 x154 x155 x156 x157 x158 x159 x160
+                      x161 x162 x163 x164 x165 x166 x167 x168 x169 x170
+                      x171 x172 x173 x174 x175 x176 x177 x178 x179 x180
+                      x181 x182 x183 x184 x185 x186 x187 x188 x189 x190
+                      x191 x192 x193 x194 x195 x196 x197 x198 x199 x200
+                      x201 x202 x203 x204 x205 x206 x207 x208 x209 x210
+                      x211 x212 x213 x214 x215 x216 x217 x218 x219 x220
+                      x221 x222 x223 x224 x225 x226 x227 x228 x229 x230
+                      x231 x232 x233 x234 x235 x236 x237 x238 x239 x240
+                      x241 x242 x243 x244 x245 x246 x247 x248 x249 x250
+                      x251 x252 x253 x254 x255 x256)))
+              (print z1 " " x255 " " x256))))
+        (interaction-environment)))
+
+;;----------------------------------------------------------------------
 ;; srfi-147 begin
 ;; (not yest supported)
 

--- a/test/macro.scm
+++ b/test/macro.scm
@@ -1602,9 +1602,8 @@
 ;;----------------------------------------------------------------------
 ;; 'compare-literals-2' test should output the following error.
 ;;
-;; *** ERROR: malformed #<identifier user##<identifier user#lit-test-2.2d9c3c0>.2db85e0>:
-;; (#<identifier user##<identifier user#lit-test-2.2d9c3c0>.2db85e0>
-;;  #<identifier user##<identifier user#temp.2d9c6e0>.2db8600>)
+;; *** ERROR: malformed #<identifier user#lit-test-2.29d4060>:
+;; (#<identifier user#lit-test-2.29d4060> #<identifier user#temp.29d40c0>)
 ;; While compiling: (lit-test-2 temp 1)
 
 (test-section "compare literals")
@@ -1633,8 +1632,7 @@
 ;;----------------------------------------------------------------------
 ;; 'gen-underbar-1' test should output the following error.
 ;;
-;; *** ERROR: unbound variable:
-;; #<identifier user##<identifier user##<identifier user#_.2cacca0>.2cb7920>.2cb7720>
+;; *** ERROR: unbound variable: #<identifier user#_.2d4ac00>
 
 (test-section "generate underbar")
 

--- a/test/macro.scm
+++ b/test/macro.scm
@@ -1630,7 +1630,7 @@
        (eval '(lit-test-2 temp 1) (interaction-environment)))
 
 ;;----------------------------------------------------------------------
-;; 'gen-underbar-1' test should output the following error.
+;; 'generate-underbar-1' test should output the following error.
 ;;
 ;; *** ERROR: unbound variable: #<identifier user#_.2d4ac00>
 
@@ -1646,7 +1646,7 @@
               _))))
        (mac-sub1 'failed)))))
 
-(test* "gen-underbar-1"
+(test* "generate-underbar-1"
        (test-error <error> #/^unbound variable/)
        (gen-underbar))
 


### PR DESCRIPTION
#329 とは違うかもしれませんが、literals の判定で問題が出るテストケースを見つけました。

compare-literals-2 というテストで、組み込みの syntax-rules では結果が failed になります。

これは、chibi, sagittarius, racket では、展開エラーになります。

それで、いろいろ調べて変更していくうちに、compare と rename について見直した感じになりました。

(主に srfi-149 参照実装の最新版を参考にしました。
https://github.com/ashinn/chibi-scheme/blob/master/lib/init-7.scm#L687
(srfi-149 文書のものよりも更新されています))


＜変更内容＞
src/macro.c
src/compile.scm
test/macro.scm

1. 比較処理の変更
   (Sym-or-id, Sym-or-id) -> Bool の比較を行うために compare 関数を作成して、
   中で compile.scm の er-comparer を呼び出すようにした。
   (このとき、er-comparer の引数が uenv になっていて、うまく呼び出せなかったため、
   er-comparer の引数を module と env に変更しました)
   そして、compare_ellipsis と match_identifier を、compare に置き換えた。
   (対応テストケース : compare-literals-2)

2. rename の変更
   compile_rule1 で、literals と others のみ rename するようにした。
   (pattern variables は、pattern と templete の比較(Scm_Assq)
   にのみ使われるため rename は不要と思われる)
   また、compile_rule1 で、literals の検出には Scm_Memq を使うようにした(srfi-149 より)。
   また、preprocess_literals では rename をやめた。
   (対応テストケース : compare-literals-2)

3. add_pvar で、level と count の MAX チェックを追加
   (MAX を超えると変な状態になったため)
   (対応テストケース : pattern-variables-1)

4. compile_rules で、`ctx.ellipsis = FALSE;` を `ctx.ellipsis = SCM_FALSE;` に変更
   (compare で SEGV エラーになったため)
   (対応テストケース : alt-elli3)

5. compile_rule1 で、underbar の比較を compare を使うように変更
   (マクロで underbar を生成したときに機能しなかったため)
   (対応テストケース : gen-underbar-1)


＜テスト＞
OS : Windows 8.1 (64bit)
Gauche : コミット 8884cf7 + 変更
開発環境 : MSYS2/MinGW-w64 (64bit) (gcc version 7.1.0 (Rev2, Built by MSYS2 project))
Total: 19273 tests, 19273 passed,     0 failed,     0 aborted.

pattern-match-lambda の test.scm - OK

Ypsilon の syntax-rules stress test - OK
