### PR TITLE
Workaround for build-standalone tests on Windows

### DIFF
--- a/test/scripts.scm
+++ b/test/scripts.scm
@@ -518,6 +518,9 @@
                              "foo/baz.scm")))
   (test* "static link executable" "ARGS: (A b CdE)"
          (process-output->string '(test.o/staticmain A b CdE)))
+  (cond-expand
+   [gauche.os.windows (sys-sleep 1)]
+   [else])
   )
 
 (wrap-with-test-directory static-test-1)


### PR DESCRIPTION
test/scripts.scm の "static link executable" のテストでエラーが出ていました。

テスト自体は ok になっており、テスト後の削除処理で、以下のいずれかのエラーが出ます。
(a) test.o/staticmain.exe 削除時に Permission Denied
(b) test.o ディレクトリの削除時に Directory not empty

どうも、staticmain.exe の実行後、すぐに削除しようとすると発生するようなので、
sleep を入れたところ成功するようになりました。
環境依存かもしれませんが。。。
(Windows 8.1 (64bit))
