### PR TITLE
Change with-exception-handler for R7RS

### DIFF
--- a/doc/corelib.texi
+++ b/doc/corelib.texi
@@ -16134,37 +16134,41 @@ sets @var{handler} to the current exception handler and calls
 @var{handler}は1引数を取る手続きです。この手続きは、@var{handler}を
 現在の例外ハンドラにセットし、@var{thunk}を呼び出します。
 @c COMMON
+
+@c EN
+When an exception is raised in @var{thunk}, @var{handler} is invoked.
+@var{handler} is evaluated in the dynamic environment of the call to
+@var{handler}, except that the current exception handler is that in
+place for the call to @code{with-exception-handler}.
+@c JP
+@var{thunk}内で例外が発生すると、@var{handler}が呼び出されます。
+@var{handler}は、@var{handler}呼び出し時の動的環境で評価されます。
+ただし、@var{handler}内における例外ハンドラは、
+@code{with-exception-handler}呼び出し時の例外ハンドラになります。
+@c COMMON
+
+@c EN
+If the exception is not continuable, it is reraised after evaluating
+@var{handler} and handled by the exception handler in place for the
+call to @code{with-exception-handler}.
+If the exception is continuable, @var{handler} returns to the caller of
+@var{handler} and processing is continued.
+@c JP
+例外が継続不可能な場合、@var{handler}の評価後にさらに例外が発生し、それは
+@code{with-exception-handler}呼び出し時の例外ハンドラで処理されます。
+例外が継続可能な場合は、@var{handler}の呼び出し元に戻って処理を継続します。
+@c COMMON
+
+@c EN
+(Until Gauche 0.9.5, the exception handler in @var{handler} was
+@var{handler} itself. So if you raised an exception inside @var{handler},
+it was captured by @var{handler} again.)
+@c JP
+(Gauche 0.9.5 までは、@var{handler}内における例外ハンドラは、
+@var{handler}自身でした。したがって、@var{handler}内部で例外を発生させると、
+再度@var{handler}によって捕捉されていました。)
+@c COMMON
 @end defun
-
-@c EN
-Generally, if you want to handle non-continuable exception such as
-errors using this low-level mechanism,
-you have to transfer the control from the handler explicitly
-(See the explanation of @code{with-error-handler} above).
-@code{raise} detects if the handler returns on the
-non-continuable exceptions and reports an error using the
-default error handler mechanism, but it is just a safety net.
-@c JP
-一般的に、エラーのような継続不可能な例外をこの低レベルなメカニズムで
-扱いたい場合は、明示的にそのハンドラから制御を移さなければなりません
-(前述の@code{with-error-handler}の説明を参照して下さい)。
-@code{raise}は、ハンドラが継続不可能な例外を返したことを検知し、
-デフォルトのエラーハンドラメカニズムを使ってエラーを報告しますが、
-それは単に安全ネットにしか過ぎません。
-@c COMMON
-
-@c EN
-Note also that @var{handler} is called in the same dynamic environment
-of @code{raise}.  So if you raise an exception inside @var{handler},
-it is captured by @var{handler} again.   It is the programmer's
-responsibility to propagate the exception handling to the ``outer''
-exception handlers.
-@c JP
-@var{handler}は@code{raise}の動的な環境と同じ環境で呼ばれることにも
-注意して下さい。したがって、@var{handler}内部で例外を発生させると、
-再度@var{handler}によって捕捉されます。その例外処理を``外側''の例外
-ハンドラへ伝播させるのはプログラマの責任です。
-@c COMMON
 
 @c EN
 The behavior of those procedures can be explained in

--- a/src/vm.c
+++ b/src/vm.c
@@ -2172,6 +2172,8 @@ ScmObj Scm_VMThrowException2(ScmVM *vm, ScmObj exception, u_long raise_flags)
             Scm_Error("user-defined exception handler returned on non-continuable exception %S", exception);
         }
         return vm->val0;
+#if 0
+    /* Disabled for R7RS's with-exception-handler */
     } else if (!SCM_SERIOUS_CONDITION_P(exception)) {
         /* The system's default handler does't care about
            continuable exception.  See if there's a user-defined
@@ -2181,6 +2183,7 @@ ScmObj Scm_VMThrowException2(ScmVM *vm, ScmObj exception, u_long raise_flags)
                 return Scm_ApplyRec(ep->xhandler, SCM_LIST1(exception));
             }
         }
+#endif
     }
     Scm_VMDefaultExceptionHandler(exception);
     /* this never returns */

--- a/test/error.scm
+++ b/test/error.scm
@@ -440,7 +440,8 @@
 ;;----------------------------------------------------------------
 (test-section "nesting exception/error handlers")
 
-(prim-test "propagating continuable exception" '(a b c)
+;(prim-test "propagating continuable exception 1" '(a b c)
+(prim-test "nesting exception/error handlers 1" '(a z)
       (lambda ()
         (let ((x '()))
           (with-exception-handler
@@ -454,7 +455,8 @@
                 (push! x 'c)))))
           (reverse x))))
 
-(prim-test "propagating continuable exception" '(a b c d e f g h)
+;(prim-test "propagating continuable exception 2" '(a b c d e f g h)
+(prim-test "nesting exception/error handlers 2" '(a b c f g h)
       (lambda ()
         (let ((x '()))
           (with-exception-handler

--- a/test/exception.scm
+++ b/test/exception.scm
@@ -278,7 +278,8 @@
             (foo (lambda () (raise 'boo)))
             (push! aaa 'e))
            aaa))
-  (test* "unwind-protect (raise & continue)" '(e d c boo b a)
+;  (test* "unwind-protect (raise & continue)" '(e d c boo b a)
+  (test* "unwind-protect (raise-2)" '(boo d b a)
          (begin
            (set! aaa '())
            (with-exception-handler

--- a/test/include/r7rs-tests.scm
+++ b/test/include/r7rs-tests.scm
@@ -1761,9 +1761,6 @@
                  'negative))
           (raise v)))))))
 
-(cond-expand
- [gauche] ; this is Gauche's bug
- [else
 ;; From SRFI-34 "Examples" section - #5
 (let* ((out (open-output-string))
        (value (test-exception-handler-4 1 out)))
@@ -1779,7 +1776,6 @@
        (value (test-exception-handler-4 0 out)))
   (test "reraised 0!" (get-output-string out))
   (test 'zero value))
-])
 
 ;; From SRFI-34 "Examples" section - #8
 (test 42


### PR DESCRIPTION
with-exception-handler の動作をR7RSに近づくように変更してみました。

これで、r7rs-tests のスキップされていたテストはすべて通るようになりました。

ただ、Gauche の元の動作と互換性がなくなるため、既存のプログラムが動かなくなる可能性があります。
(テストも 3 件 NG になり、変更しています)

元の動作を残して、r7rs:with-exception-handler を新設しようとすると、
vm->exceptionHandler に種別のような情報が必要になる感じでしょうか。
(ややこしくなりそうですが。。。元の動作は必要でしょうか?)

あと、マニュアルも変更しようとしてみましたが。。。


＜変更内容＞
1. handlerの実行時には外側の例外ハンドラを有効にする

2. 「例外が <serious-condition> でない場合に、
   vm->escapePoint を使用する例外処理 (with-error-handler, guard, unwind-protect)
   よりも優先される」
   という条件を無効化 (Scm_VMThrowException2)


＜テスト結果＞
OS : Windows 8.1 (64bit)
Gauche : コミット 31bea27 + 変更
開発環境 : MSYS2/MinGW-w64 (64bit) (gcc version 7.2.0 (Rev1, Built by MSYS2 project))
Total: 12550 tests, 12550 passed,     0 failed,     0 aborted.
