### PR TITLE
Fix display of syntax-error

### DIFF
--- a/lib/gauche/common-macros.scm
+++ b/lib/gauche/common-macros.scm
@@ -60,7 +60,7 @@
                       f 'original #f)])
        (if original
          (raise (make-compound-condition
-                 (make-error (car args) (cdr args))
+                 (apply make-error (car args) (cdr args))
                  (make <compile-error-mixin> :expr original)))
          (apply error args))))))
 

--- a/test/macro.scm
+++ b/test/macro.scm
@@ -1577,7 +1577,7 @@
 ;; Our purpose here is to make sure syntax-error preserves the offending macro
 ;; call (test-syntax-error ...).
 (test "syntax-error"
-      '("bad number of arguments (x y z)"
+      '("bad number of arguments x y z"
         (test-syntax-error x y z)
         (list (test-syntax-error x y z)))
       (lambda ()


### PR DESCRIPTION
syntax-error の表示で、括弧が一段多く表示されていたので修正しました。
