### PR TITLE
Fix gen-staticinit for MinGW 32bit

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -407,7 +407,7 @@ $(LIBGAUCHE_STATIC).a : all staticinit.$(OBJEXT) staticinit_gdbm.$(OBJEXT)
             `"$(srcdir)/list-ext-objects.sh" "$(top_builddir)"`
 
 staticinit.c staticinit_gdbm.c : all gen-staticinit.scm
-	./gosh -ftest $(srcdir)/gen-staticinit.scm $(top_srcdir) $(top_builddir)
+	$(BUILD_GOSH) $(srcdir)/gen-staticinit.scm $(top_srcdir) $(top_builddir)
 
 # tests -----------------------------------------------
 TESTFILES  = `cat ../test/TESTS`

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -407,7 +407,7 @@ $(LIBGAUCHE_STATIC).a : all staticinit.$(OBJEXT) staticinit_gdbm.$(OBJEXT)
             `"$(srcdir)/list-ext-objects.sh" "$(top_builddir)"`
 
 staticinit.c staticinit_gdbm.c : all gen-staticinit.scm
-	$(BUILD_GOSH) $(srcdir)/gen-staticinit.scm $(top_srcdir) $(top_builddir)
+	./gosh -ftest $(srcdir)/gen-staticinit.scm $(top_srcdir) $(top_builddir)
 
 # tests -----------------------------------------------
 TESTFILES  = `cat ../test/TESTS`

--- a/src/preload.scm
+++ b/src/preload.scm
@@ -19,6 +19,7 @@
 (use gauche.record)
 (use gauche.generator)
 (use gauche.interpolate)
+(use gauche.threads)
 (use srfi-1)
 (use srfi-13)
 (use file.util)


### PR DESCRIPTION
- 32bit 時の build-standalone のテストで、
  リンクエラー(undefined reference)が出ていたため、
  src/gen-staticinit.scm を修正しました。

- 32bit の dll では、シンボル名の前に `_` が付くようです。
  また、インポート名は `__imp_` ではなく `_imp_` が前に付くようです。

- また、64bit の gosh を使って 32bit の gosh をビルドした場合に、
  staticinit.c の生成のところで `gauche--threads.dll` のロードエラーになったため、
  src/Makefile.in 内で、staticinit.c の生成には
  `$(BUILD_GOSH)` ではなく `./gosh -ftest` を使うようにしました。


＜テスト結果＞
OS : Windows 8.1 (64bit)
Gauche : コミット 70c2458 + 変更

開発環境1 : MSYS2/MinGW-w64 (64bit) (gcc version 7.2.0 (Rev1, Built by MSYS2 project))
Total: 19296 tests, 19296 passed,     0 failed,     0 aborted.

開発環境2 : MSYS2/MinGW-w64 (32bit) (gcc version 7.2.0 (Rev1, Built by MSYS2 project))
Total: 19296 tests, 19296 passed,     0 failed,     0 aborted.

開発環境3 : MinGW.org (32bitのみ) (gcc version 6.3.0 (MinGW.org GCC-6.3.0-1))
Total: 19300 tests, 19300 passed,     0 failed,     0 aborted.
