### PR TITLE
OpenBSD build fix

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -114,10 +114,8 @@ case $GAUCHE_THREAD_TYPE in
       GAUCHE_THREAD_TYPE=pthreads
       ;;
     *-*-openbsd*)
-      AC_DEFINE(GC_OPENBSD_THREADS,1,[Define to use OpenBSD threads])
-      THREADLIBS="-lpthread"
-      THREADDLLIBS="-lpthread"
-      GAUCHE_THREAD_TYPE=pthreads
+      dnl NB: "pthread" is not works properly for Gauche.
+      GAUCHE_THREAD_TYPE=none
       ;;      
     *-*-solaris*)
       AC_DEFINE(GC_SOLARIS_THREADS,1,[Define to use Solaris threads])

--- a/src/gauche/config.h.in
+++ b/src/gauche/config.h.in
@@ -74,9 +74,6 @@
 /* Define to use NetBSD threads */
 #undef GC_NETBSD_THREADS
 
-/* Define to use OpenBSD threads */
-#undef GC_OPENBSD_THREADS
-
 /* Define to use pthreads */
 #undef GC_PTHREADS
 


### PR DESCRIPTION
This is trivial fix for OpenBSD.

I use FuguIta as described in #347 , and build current HEAD with this patch.
Build and tests was successful with this status:
```
Total: 19404 tests, 19404 passed,     0 failed,     0 aborted.
```

This patch is not a complete fix for #334 and #276 , but it helps OpenBSD users.