### PR TITLE
Change save/restore cursor in text.console.generic

### DIFF
--- a/lib/text/console/generic.scm
+++ b/lib/text/console/generic.scm
@@ -308,11 +308,11 @@
 ;; No portable way to directly query it, so we take a kind of heuristic approach.
 (define-method query-screen-size ((con <vt100>))
   (define *max-dim* 2000)
-  (putstr con "\x1b;[s") ; save cursor pos
+  (putstr con "\x1b;7") ; save cursor pos
   (move-cursor-to con *max-dim* *max-dim*)
   (unwind-protect (receive (h w) (query-cursor-position con)
                     (values (+ h 1) (+ w 1)))
-    (putstr con "\x1b;[u"))) ;restore cursor pos
+    (putstr con "\x1b;8"))) ;restore cursor pos
 
 (define-method set-character-attribute ((con <vt100>) spec)
   (define (color->n color)


### PR DESCRIPTION
ESC [s , ESC [u が使えないターミナルが存在するらしく、
ESC 7 , ESC 8 に切り換えてみました。

＜参考URL＞
https://stackoverflow.com/questions/28986776/ansi-escape-sequence-save-restore-cursor-position-support
https://github.com/mattn/go-colorable/issues/27
https://twitter.com/search?f=tweets&q=GAUCHE_READ_EDIT&src=typd

＜テスト結果＞
OS : Windows 8.1 (64bit)
Gauche : コミット 2ccad81 + 変更

開発環境1 : MSYS2/MinGW-w64 (64bit) (gcc version 7.2.0 (Rev1, Built by MSYS2 project))
Total: 19336 tests, 19336 passed,     0 failed,     0 aborted.
