### PR TITLE
sxml: remove special handling for html boolean attributes

### DIFF
--- a/ext/sxml/src/serializer.scm
+++ b/ext/sxml/src/serializer.scm
@@ -637,9 +637,7 @@
                   srl:string->att-value) attval)
              "\""))
       ((eq? method 'html)
-       (if (string=? local-part attval)  ; boolean attribute
-           (list " " local-part)
-           (list " " local-part "=\"" (srl:string->html-att attval) "\"")))
+       (list " " local-part "=\"" (srl:string->html-att attval) "\""))
       (else  ; unprefixed attribute, XML output method
        (list " " local-part "=\"" (srl:string->att-value attval) "\"")))))
 


### PR DESCRIPTION
HTML boolean attributes can be specified without a value to represent "true". The presence of the attribute itself is enough to represent true. The value will be ignored (and to represent false, the attribute must _not_ be present).

This special handling for boolean attribute (i.e. hiding the value) causes problems because this code does not really know if the attribute in question is boolean. This code would trip with this element

    (a (@ (href "foo") (title "title")))

and render "title" attribute as a boolean, e.g.

    <a href="foo" title>

which is wrong (i.e. empty title) because it is the same as

    <a href="foo" title="">

Remove this code. This means boolean attribute will be shown with value, e.g.

    <input checked="checked">

But semantically this is still correct. And it fixes the mistaking "title" as boolean above.