### PR TITLE
Certificate validation and SNI extension support for axTLS

### DIFF
--- a/doc/modutil.texi
+++ b/doc/modutil.texi
@@ -15035,8 +15035,8 @@ individual subsystems can be checked with feature identifiers
 @code{gauche.net.tls.axtls} and @code{gauche.net.tls.mbedtls}, respectively.
 @xref{Feature conditional}, for more about feature identifiers.
 
-In the current version, we don't verify certificates by default in axTLS,
-but we do in mbedTLS.  You need to specify the location of CA certificates
+In the current version, we verify certificates by default in axTLS
+and mbedTLS.  You need to specify the location of CA certificates
 explicitly when you want to verify, unless the CA certificate location
 is specified at the configuration time.  In future, we might set the
 default CA certificate file automatically so that users don't need

--- a/ext/tls/tls-mbed.c
+++ b/ext/tls/tls-mbed.c
@@ -71,21 +71,6 @@ typedef struct ScmMbedTLSRec {
     ScmString *server_name;
 } ScmMbedTLS;
 
-/* NB: This is a dupe from tls.c;  */
-static const uint8_t* get_message_body(ScmObj msg, u_int *size)
-{
-    if (SCM_UVECTORP(msg)) {
-        *size = Scm_UVectorSizeInBytes(SCM_UVECTOR(msg));
-        return (const uint8_t*) SCM_UVECTOR_ELEMENTS(msg);
-    } else if (SCM_STRINGP(msg)) {
-        return (const uint8_t*)Scm_GetStringContent(SCM_STRING(msg), size, 0, 0);
-    } else {
-        Scm_TypeError("TLS message", "uniform vector or string", msg);
-        *size = 0;
-        return 0;
-    }
-}
-
 
 static void mbed_context_check(ScmMbedTLS* t, const char* op)
 {

--- a/ext/tls/tls.c
+++ b/ext/tls/tls.c
@@ -192,6 +192,7 @@ typedef struct ScmAxTLSRec {
     ScmTLS common;
     SSL_CTX* ctx;
     SSL* conn;
+    SSL_EXTENSIONS* extensions;
 } ScmAxTLS;
 
 static void ax_context_check(ScmAxTLS* t, const char* op)
@@ -318,6 +319,7 @@ static ScmObj ax_allocate(ScmClass *klass, ScmObj initargs)
 
     t->ctx = ssl_ctx_new(options, num_sessions);
     t->conn = NULL;
+    t->extensions = NULL;
     t->common.in_port = t->common.out_port = SCM_UNDEFINED;
 
     t->common.connect = ax_connect;

--- a/ext/tls/tls.c
+++ b/ext/tls/tls.c
@@ -283,7 +283,6 @@ static ScmObj ax_close(ScmTLS *tls)
     if (t->ctx && t->conn) {
         ssl_free(t->conn);
         t->conn = 0;
-        ssl_ext_free(t->extensions);
         t->extensions = NULL;
         t->server_name = NULL;
         t->common.in_port = t->common.out_port = SCM_UNDEFINED;

--- a/ext/tls/tls.c
+++ b/ext/tls/tls.c
@@ -284,6 +284,7 @@ static ScmObj ax_close(ScmTLS *tls)
         ssl_free(t->conn);
         t->conn = 0;
         ssl_ext_free(t->extensions);
+        t->extensions = NULL;
         t->server_name = NULL;
         t->common.in_port = t->common.out_port = SCM_UNDEFINED;
     }

--- a/ext/tls/tls.c
+++ b/ext/tls/tls.c
@@ -333,6 +333,7 @@ static ScmObj ax_allocate(ScmClass *klass, ScmObj initargs)
     t->ctx = ssl_ctx_new(options, num_sessions);
     t->conn = NULL;
     t->extensions = ssl_ext_new();
+    t->server_name = SCM_STRING(server_name);
     t->common.in_port = t->common.out_port = SCM_UNDEFINED;
 
     t->common.connect = ax_connect;

--- a/ext/tls/tls.c
+++ b/ext/tls/tls.c
@@ -73,6 +73,9 @@ static ScmParameterLoc ca_bundle_path;
 static ScmParameterLoc default_tls_class;
 static ScmObj k_options;
 static ScmObj k_num_sessions;
+#if defined(GAUCHE_USE_AXTLS)
+static ScmObj k_server_name;
+#endif
 
 /*
  * Common operations
@@ -173,6 +176,7 @@ void Scm_Init_tls(ScmModule *mod)
                                  &ca_bundle_path);
     k_options = SCM_MAKE_KEYWORD("options");
     k_num_sessions = SCM_MAKE_KEYWORD("num-sessions");
+    k_server_name = SCM_MAKE_KEYWORD("server-name");
 }
 
 static const uint8_t* get_message_body(ScmObj msg, size_t *size)
@@ -187,8 +191,6 @@ static const uint8_t* get_message_body(ScmObj msg, size_t *size)
  */
 
 #if defined(GAUCHE_USE_AXTLS)
-
-static ScmObj k_server_name;
 
 typedef struct ScmAxTLSRec {
     ScmTLS common;

--- a/ext/tls/tls.c
+++ b/ext/tls/tls.c
@@ -325,7 +325,7 @@ static ScmObj ax_allocate(ScmClass *klass, ScmObj initargs)
     }
     ScmObj server_name = Scm_GetKeyword(k_server_name, initargs, SCM_UNBOUND);
     if (!SCM_STRINGP(server_name) && !SCM_FALSEP(server_name)) {
-        Scm_TypeError("mbed-tls server-name", "string or #f", server_name);
+        Scm_TypeError("ax-tls server-name", "string or #f", server_name);
     }
 
     t->ctx = ssl_ctx_new(options, num_sessions);

--- a/ext/tls/tls.c
+++ b/ext/tls/tls.c
@@ -229,7 +229,8 @@ static ScmObj ax_connect(ScmTLS* tls, int fd)
         Scm_Error("CA bundle can't load: file=%S", s_ca_file);
     }
 
-    t->extensions->host_name = t->server_name ? Scm_GetStringConst(t->server_name) : NULL;
+    const char* hostname = t->server_name ? Scm_GetStringConst(t->server_name) : NULL;
+    t->extensions->host_name = hostname;
 
     t->conn = ssl_client_new(t->ctx, fd, 0, 0, t->extensions);
     int r = ssl_handshake_status(t->conn);

--- a/ext/tls/tls.c
+++ b/ext/tls/tls.c
@@ -219,7 +219,7 @@ static ScmObj ax_connect(ScmTLS* tls, int fd)
                   " but got: %S", s_ca_file);
     }
     const char *ca_file = Scm_GetStringConst(SCM_STRING(s_ca_file));
-    if (ssl_obj_load(t->ctx, SSL_OBJ_X509_CACERT, ca_file, NULL)) {
+    if (!(t->common.loadObject(SCM_TLS(t), SCM_MAKE_INT(SSL_OBJ_X509_CACERT), ca_file, NULL))) {
         Scm_Error("CA bundle can't load: file=%S", s_ca_file);
     }
 

--- a/ext/tls/tls.c
+++ b/ext/tls/tls.c
@@ -304,7 +304,7 @@ static ScmObj ax_allocate(ScmClass *klass, ScmObj initargs)
 {
     ScmAxTLS* t = SCM_NEW_INSTANCE(ScmAxTLS, klass);
 
-    uint32_t options = SSL_SERVER_VERIFY_LATER;
+    uint32_t options = 0;
     ScmObj s_options = Scm_GetKeyword(k_options, initargs, SCM_UNDEFINED);
     if (SCM_INTEGERP(s_options)) {
         options = Scm_GetIntegerU32Clamp(s_options, SCM_CLAMP_ERROR, NULL);

--- a/ext/tls/tls.c
+++ b/ext/tls/tls.c
@@ -181,13 +181,6 @@ void Scm_Init_tls(ScmModule *mod)
     k_server_name = SCM_MAKE_KEYWORD("server-name");
 }
 
-static const uint8_t* get_message_body(ScmObj msg, size_t *size)
-{
-    if (SCM_UVECTORP(msg) || SCM_STRINGP(msg)) {
-    }
-    return Scm_GetBytes(msg, size);
-}
-
 /*=========================================================
  * axTLS
  */

--- a/ext/tls/tls.c
+++ b/ext/tls/tls.c
@@ -282,8 +282,8 @@ static ScmObj ax_close(ScmTLS *tls)
     ScmAxTLS *t = (ScmAxTLS*)tls;
     if (t->ctx && t->conn) {
         ssl_free(t->conn);
-        ssl_ext_free(t->extensions);
         t->conn = 0;
+        ssl_ext_free(t->extensions);
         t->server_name = NULL;
         t->common.in_port = t->common.out_port = SCM_UNDEFINED;
     }

--- a/ext/tls/tls.c
+++ b/ext/tls/tls.c
@@ -151,11 +151,13 @@ ScmObj Scm_TLSOutputPort(ScmTLS* t)
 ScmObj Scm_TLSInputPortSet(ScmTLS* t, ScmObj port)
 {
     t->in_port = port;
+    return SCM_UNDEFINED;
 }
 
 ScmObj Scm_TLSOutputPortSet(ScmTLS* t, ScmObj port)
 {
     t->out_port = port;
+    return SCM_UNDEFINED;
 }
 
 void Scm_Init_tls(ScmModule *mod)
@@ -246,6 +248,8 @@ static ScmObj ax_accept(ScmTLS* tls, int fd)
     ax_context_check(t, "accept");
     if (t->conn) Scm_SysError("attempt to connect already-connected TLS %S", t);
     t->conn = ssl_server_new(t->ctx, fd);
+
+    return SCM_UNDEFINED;
 }
 
 static ScmObj ax_read(ScmTLS* tls)
@@ -288,6 +292,8 @@ static ScmObj ax_close(ScmTLS *tls)
         t->server_name = NULL;
         t->common.in_port = t->common.out_port = SCM_UNDEFINED;
     }
+
+    return SCM_UNDEFINED;
 }
 
 static ScmObj ax_loadObject(ScmTLS* tls, ScmObj obj_type,

--- a/lib/rfc/http.scm
+++ b/lib/rfc/http.scm
@@ -898,7 +898,7 @@
   (when (~ conn'secure-agent) (shutdown-secure-agent conn))
   (ecase (~ conn'secure)
     [(tls)
-     (let1 tls (make-tls :server-name (~ conn'server))
+     (let1 tls (make-tls :server-name (~ conn'server) :options 0)
        (set! (~ conn'secure-agent) tls)
        (tls-connect tls (socket-fd (~ conn'socket))))]
     [(stunnel)

--- a/lib/rfc/http.scm
+++ b/lib/rfc/http.scm
@@ -898,7 +898,7 @@
   (when (~ conn'secure-agent) (shutdown-secure-agent conn))
   (ecase (~ conn'secure)
     [(tls)
-     (let1 tls (make-tls :server-name (~ conn'server) :options 0)
+     (let1 tls (make-tls :server-name (~ conn'server))
        (set! (~ conn'secure-agent) tls)
        (tls-connect tls (socket-fd (~ conn'socket))))]
     [(stunnel)


### PR DESCRIPTION
This pull request adds certificate validation and SNI extension support for axTLS.

Note:
Because of limitation of axTLS, some HTTPS server will not works well that the server uses wrong certificates.
