### PR TITLE
Auto expand gc heap

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -628,6 +628,24 @@ static const char *safe_basename(const char *path)
     return Scm_GetStringConst(SCM_STRING(bn));
 }
 
+/* Experimental: auto expand gc heap */
+static void auto_expand_gc_heap(GC_word hs_now1) {
+    static size_t hs_next = 0;
+    size_t hs_now = hs_now1;
+
+    if (hs_now > hs_next) {
+        if      (hs_now < 1024*1024*10)  { hs_next = 1024*1024*10; }
+        else if (hs_now < 1024*1024*50)  { hs_next = 1024*1024*50; }
+        else if (hs_now < 1024*1024*100) { hs_next = 1024*1024*100; }
+        else { hs_next = hs_now + 1024*1024*100 - (hs_now % (1024*1024*100)); }
+        if (hs_next - hs_now > 0) {
+            GC_set_on_heap_resize(NULL);
+            GC_expand_hp(hs_next - hs_now);
+            GC_set_on_heap_resize(auto_expand_gc_heap);
+        }
+    }
+}
+
 /*-----------------------------------------------------------------
  * MAIN
  */
@@ -655,6 +673,7 @@ int main(int ac, char **av)
     }
     
     GC_INIT();
+    GC_set_on_heap_resize(auto_expand_gc_heap);
     Scm_Init(GAUCHE_SIGNATURE);
     sig_setup();
 


### PR DESCRIPTION
- 最適化の一案として、GC のヒープの拡張を、
  ある程度まとめて行うようにしてみました。
  (10MB → 50MB → 100MB → 以後 100MB 単位)

- R7RSベンチマークの結果は以下のようになりました。
  https://drive.google.com/open?id=1aawGwHCBIIi9EVkr1K415IcwuFqjU25QtEe1R9qqLYs
  いくつかのベンチマークで、実行時間が 60～80% 程度に短縮されています。

- ただ、現状、以下の気になる点があります。
  - メモリ使用量が増える
  - 特定の種類のプログラムにしか効果がない
    (メモリの割り当て回数が多い等?)
  - 自分のPC (Windows) でしか確認していない
    (他の PC や OS では効果がないかも。。。)
  - スレッドを考慮していない
    (スレッドごとのGCの仕組みがよく分かっていない)
    (examples/aobench.scm は普通に動くようですが。。。)
  - GC_INIT が main.c 以外にもあるが、対応していない
    (core.c  static.h  test-extra.c 等)
  - 環境変数かオプションスイッチで設定を可能にすべき?

- まずはアイデアとして挙げておきます。

＜テスト結果＞
OS : Windows 8.1 (64bit)
Gauche : コミット c7497ce + 変更

開発環境1 : MSYS2/MinGW-w64 (64bit) (gcc version 7.3.0 (Rev2, Built by MSYS2 project))
Total: 19337 tests, 19337 passed,     0 failed,     0 aborted.
