### PR TITLE
Change default element-type in open-{input|output}-file

### DIFF
--- a/src/libio.scm
+++ b/src/libio.scm
@@ -185,7 +185,7 @@
 (define-cproc %open-input-file (path::<string>
                                 :key (if-does-not-exist :error)
                                 (buffering #f)
-                                (element-type :character))
+                                (element-type :binary))
   (let* ([ignerr::int FALSE]
          [flags::int O_RDONLY])
     (cond [(SCM_FALSEP if-does-not-exist) (set! ignerr TRUE)]
@@ -214,7 +214,7 @@
                                  (if-does-not-exist :create)
                                  (mode::<fixnum> #o666)
                                  (buffering #f)
-                                 (element-type :character))
+                                 (element-type :binary))
   (let* ([ignerr-noexist::int FALSE]
          [ignerr-exist::int FALSE]
          [flags::int O_WRONLY])


### PR DESCRIPTION
コミット d065621 (2018-8-15) で、
open-{input|output}-file の :element-type 引数が有効になりましたが、
デフォルトの設定が :character であるため、
Windows で 生成されるファイルの改行コードが LF から CRLF に変わりました。

このため、doc/makedoc.scm の実行でエラーが発生するようになりました。
(改行コードが CRLF だと、makeinfo が行末の @ を行継続と判定できなくて、
エラーになるようです)

他にも影響がありそうなので、デフォルトの設定を :binary にして、
改行コードを LF に戻すようにしました。

＜テスト結果＞
OS : Windows 8.1 (64bit)
Gauche : コミット cd52492 + 変更

開発環境1 : MSYS2/MinGW-w64 (64bit) (gcc version 7.3.0 (Rev2, Built by MSYS2 project))
Total: 19350 tests, 19350 passed,     0 failed,     0 aborted.
