### PR TITLE
Change return value of some procedures in gauche.array

### DIFF
--- a/ext/uvector/array.scm
+++ b/ext/uvector/array.scm
@@ -363,11 +363,13 @@
     (let* ([rank (s32vector-length Vb)]
            [Vb2 (make-s32vector rank 0)]
            [Ve2 (s32vector-sub Ve Vb)]
-           [new-shape (start/end-vector->shape Vb2 Ve2)])
-      (tabulate-array new-shape
-                      (^[ind] (array-ref ar (s32vector->vector
-                                             (s32vector-add Vb ind))))
-                      (make-vector rank)))))
+           [new-shape (start/end-vector->shape Vb2 Ve2)]
+           [res (make-array-internal (class-of ar) new-shape)])
+      (array-retabulate! res new-shape
+                         (^[ind] (array-ref ar (s32vector->vector
+                                                (s32vector-add Vb ind))))
+                         (make-vector rank))
+      res)))
 
 (define (array? obj)
   (is-a? obj <array-base>))

--- a/ext/uvector/matrix.scm
+++ b/ext/uvector/matrix.scm
@@ -63,7 +63,7 @@
     (array-set! sh dim1 1 (array-ref sh dim2 1))
     (array-set! sh dim2 0 tmp0)
     (array-set! sh dim2 1 tmp1)
-    (rlet1 res (make-array sh)
+    (rlet1 res (copy-object a)
       (array-for-each-index a
         (^[vec1] (let* ([vec2 (vector-copy vec1)]
                         [tmp (vector-ref vec2 dim1)])
@@ -82,7 +82,7 @@
     (array-set! sh dim1 1 (array-ref sh dim2 1))
     (array-set! sh dim2 0 tmp0)
     (array-set! sh dim2 1 tmp1)
-    (rlet1 res (make-array sh)
+    (rlet1 res (copy-object a)
       (array-for-each-index a
         (^[vec1] (let* ([vec2 (vector-copy vec1)]
                         [tmp (vector-ref vec2 dim1)])
@@ -293,7 +293,7 @@
 (define (array-expt ar pow)
   (let loop ([a ar] [n pow])
     (case n
-      [(0) (identity-array (s32vector-length (start-vector-of a)))]
+      [(0) (identity-array (s32vector-length (start-vector-of a)) (class-of a))]
       [(1) a]
       [(2) (array-mul a a)]
       [(3) (array-mul (array-mul a a) a)]

--- a/ext/uvector/test.scm
+++ b/ext/uvector/test.scm
@@ -2299,7 +2299,9 @@
   (< (abs (- x y)) (get-optional opt 0.0000001)))
 
 (define (array-approx-equal? a b)
-  (or (eq? a b) (array-equal? a b approx-equal?)))
+  (or (eq? a b)
+      (and (eq? (class-of a) (class-of b))
+           (array-equal? a b approx-equal?))))
 
 (let1 i 0
   (for-each
@@ -2307,7 +2309,7 @@
          (test* (format "array-inverse-~D" (inc! i)) inv
                 (array-inverse ar)
                 array-approx-equal?)
-         (when inv
+         (when (and inv (eq? (class-of ar) (class-of inv)))
            (test* (format "array-inverse-~D" (inc! i)) (array-normalize ar)
                   (array-inverse inv)
                   array-approx-equal?))
@@ -2333,6 +2335,18 @@
       #,(<array> (0 3 0 3) 1 -1 -1 -1.2 1.4 0.8 -0.4 0.8 0.6)
       5)
      (#,(<array> (0 2 0 2) 1 2 3 6))
+     (#,(<u8array> (0 2 0 2) 1 2 3 4)
+      #,(<array>   (0 2 0 2) -2.0 1.0 1.5 -0.5)
+      -2)
+     (#,(<s16array> (0 2 0 2) 1 2 3 4)
+      #,(<array>    (0 2 0 2) -2.0 1.0 1.5 -0.5)
+      -2)
+     (#,(<f32array> (0 2 0 2) 1 2 3 4)
+      #,(<f32array> (0 2 0 2) -2.0 1.0 1.5 -0.5)
+      -2)
+     (#,(<f64array> (0 2 0 2) 1 2 3 4)
+      #,(<f64array> (0 2 0 2) -2.0 1.0 1.5 -0.5)
+      -2)
      )))
 
 (let ((i 0))
@@ -2353,8 +2367,151 @@
      (#,(<s16array> (3 4 1 9) 1 -2 3 -4 5 -6 7 -8)
       #,(<s16array> (3 11 5 6) 1 -2 3 -4 5 -6 7 -8)
       #,(<s16array> (0 1 0 1) 204))
+     (#,(<f32array> (0 2 0 2) 1 2 3 4)
+      #,(<f32array> (0 2 0 2) 4 3 2 1)
+      #,(<f32array> (0 2 0 2) 8 5 20 13))
+     (#,(<f64array> (0 2 0 2) 1 2 3 4)
+      #,(<f64array> (0 2 0 2) 4 3 2 1)
+      #,(<f64array> (0 2 0 2) 8 5 20 13))
      )))
 
+(let ((i 0))
+  (for-each
+   (^t (let-optionals* t (a pow b)
+         (test* (format "array-expt-~D" (inc! i)) b
+                (array-expt a pow)
+                array-approx-equal?)))
+   '((#,(<array> (0 2 0 2) 1 2 3 4)
+      0
+      #,(<array> (0 2 0 2) 1 0 0 1))
+     (#,(<u8array> (0 2 0 2) 1 2 3 4)
+      0
+      #,(<u8array> (0 2 0 2) 1 0 0 1))
+     (#,(<s16array> (0 2 0 2) 1 2 3 4)
+      0
+      #,(<s16array> (0 2 0 2) 1 0 0 1))
+     (#,(<f32array> (0 2 0 2) 1 2 3 4)
+      0
+      #,(<f32array> (0 2 0 2) 1 0 0 1))
+     (#,(<f64array> (0 2 0 2) 1 2 3 4)
+      0
+      #,(<f64array> (0 2 0 2) 1 0 0 1))
+     (#,(<array> (0 2 0 2) 1 2 3 4)
+      2
+      #,(<array> (0 2 0 2) 7 10 15 22))
+     (#,(<u8array> (0 2 0 2) 1 2 3 4)
+      2
+      #,(<u8array> (0 2 0 2) 7 10 15 22))
+     (#,(<s16array> (0 2 0 2) 1 2 3 4)
+      2
+      #,(<s16array> (0 2 0 2) 7 10 15 22))
+     (#,(<f32array> (0 2 0 2) 1 2 3 4)
+      2
+      #,(<f32array> (0 2 0 2) 7 10 15 22))
+     (#,(<f64array> (0 2 0 2) 1 2 3 4)
+      2
+      #,(<f64array> (0 2 0 2) 7 10 15 22))
+     )))
+
+(let ((i 0))
+  (for-each
+   (^t (let-optionals* t (a b c)
+         (test* (format "array-div-left-~D" (inc! i)) c
+                (array-div-left a b)
+                array-approx-equal?)))
+   '((#,(<array> (0 2 0 2) 1 2 3 4)
+      #,(<array> (0 2 0 2) 5 6 7 8)
+      #,(<array> (0 2 0 2) 5 4 -4 -3))
+     (#,(<u8array> (0 2 0 2) 1 2 3 4)
+      #,(<u8array> (0 2 0 2) 5 6 7 8)
+      #,(<array>   (0 2 0 2) 5 4 -4 -3))
+     (#,(<s16array> (0 2 0 2) 1 2 3 4)
+      #,(<s16array> (0 2 0 2) 5 6 7 8)
+      #,(<array>    (0 2 0 2) 5 4 -4 -3))
+     (#,(<f32array> (0 2 0 2) 1 2 3 4)
+      #,(<f32array> (0 2 0 2) 5 6 7 8)
+      #,(<f32array> (0 2 0 2) 5 4 -4 -3))
+     (#,(<f64array> (0 2 0 2) 1 2 3 4)
+      #,(<f64array> (0 2 0 2) 5 6 7 8)
+      #,(<f64array> (0 2 0 2) 5 4 -4 -3))
+     )))
+
+(let ((i 0))
+  (for-each
+   (^t (let-optionals* t (a b c)
+         (test* (format "array-div-right-~D" (inc! i)) c
+                (array-div-right a b)
+                array-approx-equal?)))
+   '((#,(<array> (0 2 0 2) 1 2 3 4)
+      #,(<array> (0 2 0 2) 5 6 7 8)
+      #,(<array> (0 2 0 2) 3 -2 2 -1))
+     (#,(<u8array> (0 2 0 2) 1 2 3 4)
+      #,(<u8array> (0 2 0 2) 5 6 7 8)
+      #,(<array>   (0 2 0 2) 3 -2 2 -1))
+     (#,(<s16array> (0 2 0 2) 1 2 3 4)
+      #,(<s16array> (0 2 0 2) 5 6 7 8)
+      #,(<array>    (0 2 0 2) 3 -2 2 -1))
+     (#,(<f32array> (0 2 0 2) 1 2 3 4)
+      #,(<f32array> (0 2 0 2) 5 6 7 8)
+      #,(<f32array> (0 2 0 2) 3 -2 2 -1))
+     (#,(<f64array> (0 2 0 2) 1 2 3 4)
+      #,(<f64array> (0 2 0 2) 5 6 7 8)
+      #,(<f64array> (0 2 0 2) 3 -2 2 -1))
+     )))
+
+(let ((i 0))
+  (for-each
+   (^t (let-optionals* t (a b)
+         (test* (format "array-transpose-~D" (inc! i)) b
+                (array-transpose a)
+                array-approx-equal?)))
+   '((#,(<array> (0 2 0 2) 1 2 3 4)
+      #,(<array> (0 2 0 2) 1 3 2 4))
+     (#,(<u8array> (0 2 0 2) 1 2 3 4)
+      #,(<u8array> (0 2 0 2) 1 3 2 4))
+     (#,(<s16array> (0 2 0 2) 1 2 3 4)
+      #,(<s16array> (0 2 0 2) 1 3 2 4))
+     (#,(<f32array> (0 2 0 2) 1 2 3 4)
+      #,(<f32array> (0 2 0 2) 1 3 2 4))
+     (#,(<f64array> (0 2 0 2) 1 2 3 4)
+      #,(<f64array> (0 2 0 2) 1 3 2 4))
+     )))
+
+(let ((i 0))
+  (for-each
+   (^t (let-optionals* t (a b)
+         (test* (format "array-rotate-90-~D" (inc! i)) b
+                (array-rotate-90 a)
+                array-approx-equal?)))
+   '((#,(<array> (0 2 0 2) 1 2 3 4)
+      #,(<array> (0 2 0 2) 3 1 4 2))
+     (#,(<u8array> (0 2 0 2) 1 2 3 4)
+      #,(<u8array> (0 2 0 2) 3 1 4 2))
+     (#,(<s16array> (0 2 0 2) 1 2 3 4)
+      #,(<s16array> (0 2 0 2) 3 1 4 2))
+     (#,(<f32array> (0 2 0 2) 1 2 3 4)
+      #,(<f32array> (0 2 0 2) 3 1 4 2))
+     (#,(<f64array> (0 2 0 2) 1 2 3 4)
+      #,(<f64array> (0 2 0 2) 3 1 4 2))
+     )))
+
+(let ((i 0))
+  (for-each
+   (^t (let-optionals* t (a b)
+         (test* (format "array-flip-~D" (inc! i)) b
+                (array-flip a)
+                array-approx-equal?)))
+   '((#,(<array> (0 2 0 2) 1 2 3 4)
+      #,(<array> (0 2 0 2) 3 4 1 2))
+     (#,(<u8array> (0 2 0 2) 1 2 3 4)
+      #,(<u8array> (0 2 0 2) 3 4 1 2))
+     (#,(<s16array> (0 2 0 2) 1 2 3 4)
+      #,(<s16array> (0 2 0 2) 3 4 1 2))
+     (#,(<f32array> (0 2 0 2) 1 2 3 4)
+      #,(<f32array> (0 2 0 2) 3 4 1 2))
+     (#,(<f64array> (0 2 0 2) 1 2 3 4)
+      #,(<f64array> (0 2 0 2) 3 4 1 2))
+     )))
 
 ;;-------------------------------------------------------------------
 ;; NB: copy-port uses read-block! and write-block for block copy,


### PR DESCRIPTION
- gauche.array のいくつかの手続きの戻り値のクラスを見直しました。
  (元は `<f64array>` 等を渡しても `<array>` が返るようになっていました)
  
  array-transpose : 入力と同じタイプの array クラスを返すようにした。
  array-rotate-90 : 入力と同じタイプの array クラスを返すようにした。
  array-expt      : べき乗の引数が 0 のときも、入力と同じタイプの array クラスを返すようにした。
  array-inverse   : `<array>`,`<f32array>`,`<f64array>` のいずれかを返すようにした。
  array-div-left  : `<array>`,`<f32array>`,`<f64array>` のいずれかを返すようにした。
  array-div-right : `<array>`,`<f32array>`,`<f64array>` のいずれかを返すようにした。


＜テスト結果＞
OS : Windows 8.1 (64bit)
Gauche : コミット 9803dd2 + 変更

開発環境1 : MSYS2/MinGW-w64 (64bit) (gcc version 7.3.0 (Rev2, Built by MSYS2 project))
Total: 19397 tests, 19397 passed,     0 failed,     0 aborted.
