### PR TITLE
Fix warning of system.c on Windows

### DIFF
--- a/src/system.c
+++ b/src/system.c
@@ -1613,7 +1613,9 @@ int win_process_active_child_p(ScmObj process)
 ScmObj *win_process_get_array(int *size /*out*/)
 {
     SCM_INTERNAL_MUTEX_LOCK(process_mgr.mutex);
-    ScmObj *r = Scm_ListToArray(process_mgr.children, size, NULL, TRUE);
+    ScmSize array_size;
+    ScmObj *r = Scm_ListToArray(process_mgr.children, &array_size, NULL, TRUE);
+    *size = (int)array_size;
     SCM_INTERNAL_MUTEX_UNLOCK(process_mgr.mutex);
     return r;
 }


### PR DESCRIPTION
system.c の win_process_get_array 関数のコンパイルで、
warning が出ていたため修正しました。
Windows API (MsgWaitForMultipleObjects) の引数は 32bit 固定であるため、
ScmSize を int にキャストしました。


＜テスト結果＞
OS : Windows 8.1 (64bit)
Gauche : コミット 0d3afaa + 変更

開発環境1 : MSYS2/MinGW-w64 (64bit) (gcc version 7.3.0 (Rev2, Built by MSYS2 project))
Total: 19397 tests, 19397 passed,     0 failed,     0 aborted.
