### PR TITLE
Fix ces-convert using iconv

### DIFF
--- a/ext/charconv/jconv.c
+++ b/ext/charconv/jconv.c
@@ -1331,14 +1331,14 @@ static ScmSize jconv_iconv(ScmConvInfo *info, const char **iptr, ScmSize *iroom,
 #endif
     size_t ir = *iroom, or = *oroom;
     size_t r = iconv(info->handle, (char **)iptr, &ir, optr, &or);
+    *iroom = ir;
+    *oroom = or;
     info->ostate = JIS_UNKNOWN;
     if (r == (size_t)-1) {
         if (errno == EINVAL) return INPUT_NOT_ENOUGH;
         if (errno == E2BIG)  return OUTPUT_NOT_ENOUGH;
         return ILLEGAL_SEQUENCE;
     } else {
-        *iroom = ir;
-        *oroom = or;
         return (ScmSize)r;
     }
 }


### PR DESCRIPTION
コミット 15ff6ff (2018-8-15) の変更で、
ces-convert の iconv 使用時に変換できないケースがあったため、
修正しました。

```
(use gauche.charconv)
(ces-convert "あいうえおかきくけこ" 'utf-8 'cp932) ; ==> ""
```

バッファサイズが更新されないパスがありました。
