### PR TITLE
Fix static link abi-version on windows

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -420,7 +420,7 @@ $(LIBGAUCHE_STATIC).a : all $(STATICINIT_OBJS)
             `MAKE=$(MAKE) "$(srcdir)/list-ext-objects.sh" "$(top_builddir)"`
 
 $(STATICINIT_SRCS) : all gen-staticinit.scm
-	$(STATIC_GOSH) $(srcdir)/gen-staticinit.scm $(top_srcdir) $(top_builddir)
+	$(STATIC_GOSH) $(srcdir)/gen-staticinit.scm $(top_srcdir) $(top_builddir) $(GAUCHE_ABI_VERSION)
 
 # tests -----------------------------------------------
 TESTFILES  = `cat ../test/TESTS`

--- a/src/gen-staticinit.scm
+++ b/src/gen-staticinit.scm
@@ -34,10 +34,11 @@
 
 (define top-srcdir   (make-parameter ".."))
 (define top-builddir (make-parameter ".."))
+(define abi-version  (make-parameter ""))
 
 (define (usage)
   (exit 1
-   "Usage: gen-staticinit.scm $(top_srcdir) $(top_builddir)\n\
+   "Usage: gen-staticinit.scm $(top_srcdir) $(top_builddir) $(GAUCHE_ABI_VERSION)\n\
     Create statically linked version of libgauche, with all Scheme libraries\n\
     and extensions packaged in.  After building and installing Gauche as\n\
     usual, invoke this script via 'make static' in src directory.\n\
@@ -264,7 +265,7 @@
   (cgen-decl "extern void Scm_RegisterPrelinked(ScmString*, const char *ns[], void (*fns[])(void));")
   (when main?
     (cond-expand
-     [gauche.os.windows (generate-imp-stub "libgauche-0.9.dll")]
+     [gauche.os.windows (generate-imp-stub #"libgauche-~(abi-version).dll")]
      [else])
     (cgen-init "Scm_AddLoadPath(\"@\", FALSE);"))
   (embed-scm name scmfiles)
@@ -293,9 +294,10 @@
 
 (define (main args)
   (match (cdr args)
-    [(%top-srcdir %top-builddir)
+    [(%top-srcdir %top-builddir %abi-version)
      (parameterize ([top-srcdir   %top-srcdir]
-                    [top-builddir %top-builddir])
+                    [top-builddir %top-builddir]
+                    [abi-version  %abi-version])
        (do-everything))]
     [_ (usage)])
   0)


### PR DESCRIPTION
src/gen-staticinit.scm で、
libgauche-X.X.dll の abi-version を引数で受け取るようにしました。

＜テスト結果＞
OS : Windows 8.1 (64bit)
Gauche : コミット e06b055 + 変更

開発環境1 : MSYS2/MinGW-w64 (64bit) (gcc version 7.3.0 (Rev2, Built by MSYS2 project))
Total: 19417 tests, 19417 passed,     0 failed,     0 aborted.

開発環境2 : MSYS2/MinGW-w64 (32bit) (gcc version 7.3.0 (Rev2, Built by MSYS2 project))
Total: 19417 tests, 19417 passed,     0 failed,     0 aborted.

開発環境3 : MinGW.org (32bitのみ) (gcc version 6.3.0 (MinGW.org GCC-6.3.0-1))
Total: 19421 tests, 19421 passed,     0 failed,     0 aborted.

(何か Warning がたくさん出るようになりましたが。。。(コミット 6660cd8 から))
