### PR TITLE
Fix and enhancement of profiler function

### DIFF
--- a/src/gauche/prof.h
+++ b/src/gauche/prof.h
@@ -117,7 +117,7 @@ struct ScmVMProfilerRec {
     HANDLE hObserverThread;     /* observer thread */
     HANDLE hTimerEvent;         /* sampling timer event */
     char *samplerFileName;      /* temporary file name to remove the file */
-#endif
+#endif /* GAUCHE_WINDOWS */
     ScmProfSample samples[SCM_PROF_SAMPLES_IN_BUFFER];
     ScmProfCount  counts[SCM_PROF_COUNTER_IN_BUFFER];
 };


### PR DESCRIPTION
プロファイラ機能の修正と改善をしました。

1. 戻り値のチェックの修正 (Windows のみ)
   SuspendThread と ResumeThread について、
   MSDN の記述では「失敗すると、-1 が返ります」となっていましたが、
   戻り値の型が DWORD (unsigned) であるため、キャストが必要でした。
   (gcc の Warning のおかげで見つかりました。。。)

2. デッドロックの対策 (Windows のみ)
   たまにデッドロックして固まることがありました。
   原因は、gc.h で _beginthreadex が GC_beginthreadex として define されており、
   サンプリング用スレッドと本体スレッドが、互いに SuspendThread を発行して、
   レアケースで両方とも suspend 状態になったためでした。
   サンプリング用スレッドの起動には、通常の _beginthreadex を使い、
   GC 時にサスペンド対象にならないようにしました。
   また、SuspendThread と ResumeThread の処理も少し見直しを行いました。

3. カウンタのオーバーフロー対策
   呼び出し回数のカウンタが、オーバーフローしてマイナスになることがありました。
   Scm_Add を使うようにしました。

4. Scm_ProfilerCountBufferFlush の中で、
   func を Scheme-defined method で上書きしている処理があり、
   しかし結果を使わずに無効になっていました。
   これを結果を使うように変更しました。
   (結果は特に変わらないように見えますが。。。)

5. その他、エラーチェックの追加等 (Windows のみ)


＜テスト結果＞
OS : Windows 8.1 (64bit)
Gauche : コミット 77facc2 + 変更

開発環境1 : MSYS2/MinGW-w64 (64bit) (gcc version 7.3.0 (Rev2, Built by MSYS2 project))
Total: 19417 tests, 19417 passed,     0 failed,     0 aborted.

＜プロファイラの実行例＞
```
;; test_ack.scm
(define (ack m n)
  (cond ((= m 0) (+ n 1))
        ((= n 0) (ack (- m 1) 1))
        (else (ack (- m 1) (ack m (- n 1))))))
(print (ack 4 1))
```
```
> gosh -ptime test_ack.scm
65533
Profiler statistics (total 3933 samples, 39.33 seconds)
                                                    num    time/    total
Name                                                calls  call(ms) samples
---------------------------------------------------+------+-------+-----------
ack                                                2862984010  0.0000  3932(100%
)
(number->string obj optional radix flags precision)       1 10.0000     1(  0%)
(id->bound-gloc id)                                   7447  0.0000     0(  0%)
lvar-immutable?                                       4954  0.0000     0(  0%)
variable?                                             4176  0.0000     0(  0%)
pass3/rec                                             4107  0.0000     0(  0%)
pass2/rec                                             3823  0.0000     0(  0%)
reset-lvars/rec                                       3678  0.0000     0(  0%)
pass4/scan                                            3672  0.0000     0(  0%)
pass5/rec                                             3402  0.0000     0(  0%)
global-identifier=?                                   3334  0.0000     0(  0%)
pass1                                                 3048  0.0000     0(  0%)
$const?                                               2864  0.0000     0(  0%)
$lref?                                                2836  0.0000     0(  0%)
(list? obj)                                           2806  0.0000     0(  0%)
(cenv-lookup-syntax cenv name)                        2244  0.0000     0(  0%)
pass1/lookup-head                                     2236  0.0000     0(  0%)
(%map1c proc lis c)                                   2221  0.0000     0(  0%)
null-list?                                            2211  0.0000     0(  0%)
pass2/lref-eliminate                                  2185  0.0000     0(  0%)
(%imax x y)                                           2135  0.0000     0(  0%)
(lvar-ref++! lvar)                                    2100  0.0000     0(  0%)
bottom-context?                                       1765  0.0000     0(  0%)
(global-call-type id cenv)                            1714  0.0000     0(  0%)
lvar?                                                 1524  0.0000     0(  0%)
(cenv-lookup-variable cenv name)                      1310  0.0000     0(  0%)
(reverse! list optional tail)                         1295  0.0000     0(  0%)
pass4/add-lvar                                        1214  0.0000     0(  0%)
(compiled-code-emit-PUSH! cc)                         1162  0.0000     0(  0%)
$lref                                                 1087  0.0000     0(  0%)
pass2/$LREF                                           1074  0.0000     0(  0%)
pass3/$LREF                                           1073  0.0000     0(  0%)
(renv-lookup renv lvar)                                998  0.0000     0(  0%)
reset-lvars/rec/$LREF                                  968  0.0000     0(  0%)
pass4/scan/$LREF                                       967  0.0000     0(  0%)
(compiled-code-emit2i! cc code arg0 arg1 info)         966  0.0000     0(  0%)
(%map1cc proc lis c1 c2)                               959  0.0000     0(  0%)
pass5/$LREF                                            945  0.0000     0(  0%)
every                                                  908  0.0000     0(  0%)
(slot-ref obj slot)                                    903  0.0000     0(  0%)
normal-context                                         903  0.0000     0(  0%)
tail-context?                                          894  0.0000     0(  0%)
(macro? obj)                                           878  0.0000     0(  0%)
(call-syntax-handler syn program cenv)                 867  0.0000     0(  0%)
pass2/check-constant-asm                               854  0.0000     0(  0%)
(compiled-code-emit1i! cc code arg0 info)              789  0.0000     0(  0%)
$it?                                                   787  0.0000     0(  0%)
cenv-sans-name                                         724  0.0000     0(  0%)
pass4/subst                                            723  0.0000     0(  0%)
(pair-attribute-set! pair key value)                   718  0.0000     0(  0%)
```
