### PR TITLE
Suppress warning on windows (src directory only)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -519,13 +519,16 @@ AC_CHECK_LIB(rt, clock_gettime)
 dnl For Windows/MinGW, manually adds several libraries
 dnl Also adds -DUNICODE to CFLAGS enable Windows wchar API,
 dnl  if GAUCHE_CHAR_ENCODING is UTF_8.
+dnl Also adds -D__USE_MINGW_ANSI_STDIO to CFLAGS to support
+dnl  C99 printf format string.
 dnl ALTERNATIVE_GOSH is no-console version of gosh; only built on Windows.
 case "$host" in
   *mingw*) LIBS="$LIBS -lnetapi32 -lshlwapi -lws2_32"
            ALTERNATIVE_GOSH="gosh-noconsole.exe"
            case "$GAUCHE_CHAR_ENCODING" in
              utf8) CFLAGS="$CFLAGS -DUNICODE" ;;
-           esac ;;
+           esac
+           CFLAGS="$CFLAGS -D__USE_MINGW_ANSI_STDIO" ;;
   *)       ALTERNATIVE_GOSH="" ;;
 esac
 AC_SUBST(ALTERNATIVE_GOSH)

--- a/src/char.c
+++ b/src/char.c
@@ -712,9 +712,9 @@ static int cs_contains_range(ScmCharSet *s, ScmChar lo, ScmChar hi)
         ye = Scm_BinarySearchU32(s->large.frozen.vec, s->large.frozen.size,
                                  (uint32_t)lo, 1, &yl, NULL);
         if (ye != (size_t)-1) { /* case 1 */
-            if (s->large.frozen.vec[ye+1] < hi) return FALSE;
+            if (s->large.frozen.vec[ye+1] < (unsigned)hi) return FALSE;
         } else if (yl != (size_t)-1) { /* case 2 */
-            if (s->large.frozen.vec[yl+1] < hi) return FALSE;
+            if (s->large.frozen.vec[yl+1] < (unsigned)hi) return FALSE;
         } else {
             return FALSE;
         }
@@ -891,7 +891,7 @@ int Scm_CharSetContains(ScmCharSet *cs, ScmChar c)
                                            (uint32_t)c,
                                            1, &lo, NULL);
             if ((k != (size_t)-1)
-                || (lo != (size_t)-1 && c <= cs->large.frozen.vec[lo+1]))
+                || (lo != (size_t)-1 && (unsigned)c <= cs->large.frozen.vec[lo+1]))
                 return TRUE;
             else
                 return FALSE;

--- a/src/compile.scm
+++ b/src/compile.scm
@@ -1746,7 +1746,8 @@
    (let* ([mod::ScmModule* (-> (SCM_IDENTIFIER id) module)]
           [gloc::ScmGloc* (Scm_IdentifierGlobalBinding (SCM_IDENTIFIER id))])
      (set! SCM_RESULT0 '#f SCM_RESULT1 '#f)
-     (cast void mod) ; suppress unused var warning
+     (cast void cenv) ; suppress unused var warning
+     (cast void mod)  ; suppress unused var warning
      (when gloc
        (let* ([gval (SCM_GLOC_GET gloc)])
          (cond [(SCM_MACROP gval)

--- a/src/gauche/priv/dws_adapter.h
+++ b/src/gauche/priv/dws_adapter.h
@@ -15,10 +15,10 @@
  *
  *                      32bit platform           64bit platform
  *
- * dws32hash.c       Scm__DwSipDefaultHash          (none)
- *                   Scm__DwSipPortableHash
+ * dws32hash.c       Scm__DwSipDefaultHash
+ *                   Scm__DwSipPortableHash    Scm__DwSipPortableHash
  *
- * dwsiphash.c       Scm__DwSipPortableHash    Scm__DwSipDefaultHash
+ * dwsiphash.c            (none)               Scm__DwSipDefaultHash
  */
 
 #include <gauche/config.h>
@@ -55,6 +55,7 @@ uint32_t Scm__DwSipPortableHash(uint8_t *str, uint32_t len,
 #endif /* DwSH_BWIDTH == 64 */
 
 /* forward declaration to make these file-scope */
+#if (DwSH_BWIDTH == 32 || SIZEOF_LONG > 4)
 static void DwSip_round(DwSH_WORD *v0, DwSH_WORD *v1,
                         DwSH_WORD *v2, DwSH_WORD *v3);
 static void DwSip_ksetup(DwSH_WORD *k0, DwSH_WORD *k1,
@@ -63,6 +64,7 @@ static void DwSip_ksetup(DwSH_WORD *k0, DwSH_WORD *k1,
 static DwSH_WORD DwSip_getword(uint32_t *offset, uint8_t *str, uint32_t len);
 static DwSH_WORD DwSip_hash(uint8_t *str, uint32_t len,
                             DwSH_WORD k1, DwSH_WORD k2);
+#endif /* (DwSH_BWIDTH == 32 || SIZEOF_LONG > 4) */
 
 #if SIZEOF_LONG == 4
 

--- a/src/genconfig.in
+++ b/src/genconfig.in
@@ -366,6 +366,10 @@ static int process(const char *arg, int check)
 
 int main(int argc, char **argv)
 {
+#if (defined(__MINGW32__) || defined(_MSC_VER)) && defined(UNICODE)
+    (void)&mbs2wcs; /* suppress unused function warning */
+#endif /* (defined(__MINGW32__) || defined(_MSC_VER)) && defined(UNICODE) */
+
     if (argc < 2) usage();
     if (strcmp(argv[1], "--fixup-extension") == 0) {
         fixup_extension(argc, argv);

--- a/src/hash.c
+++ b/src/hash.c
@@ -710,9 +710,9 @@ void Scm_HashCoreInitSimple(ScmHashCore *core,
                             unsigned int initSize,
                             void *data)
 {
-    SearchProc  *accessfn;
-    ScmHashProc *hashfn;
-    ScmHashCompareProc *cmpfn;
+    SearchProc  *accessfn = NULL;
+    ScmHashProc *hashfn = NULL;
+    ScmHashCompareProc *cmpfn = NULL;
 
     if (hash_core_predef_procs(type, &accessfn, &hashfn, &cmpfn) == FALSE) {
         Scm_Error("[internal error]: wrong TYPE argument passed to Scm_HashCoreInitSimple: %d", type);

--- a/src/port.c
+++ b/src/port.c
@@ -1951,6 +1951,9 @@ void Scm__SetupPortsForWindows(int has_console)
             Scm_VM()->curout = SCM_PORT(scm_stdout);
             Scm_VM()->curerr = SCM_PORT(scm_stderr);
         }
+        (void)orig_stdin;  /* suppress unused var warning */
+        (void)orig_stdout; /* suppress unused var warning */
+        (void)orig_stderr; /* suppress unused var warning */
     }
 }
 #endif /*defined(GAUCHE_WINDOWS)*/

--- a/src/read.c
+++ b/src/read.c
@@ -1249,7 +1249,7 @@ static ScmObj read_char(ScmPort *port, ScmReadContext *ctx)
 
         struct char_name *cntab = char_names;
         while (cntab->name) {
-            if (cntab->size == namesize
+            if (cntab->size == (unsigned)namesize
                 && strncmp(cntab->name, cname, namesize) == 0) {
                 return cntab->ch;
             }

--- a/src/signal.c
+++ b/src/signal.c
@@ -649,7 +649,8 @@ int sigaction(int signum, const struct sigaction *act,
     }
 }
 
-int sigprocmask_win(int how, const sigset_t *set, sigset_t *oldset)
+int sigprocmask_win(int how SCM_UNUSED, const sigset_t *set SCM_UNUSED,
+                    sigset_t *oldset SCM_UNUSED)
 {
     return 0;
 }
@@ -663,12 +664,12 @@ ScmObj Scm_SetSignalHandler(ScmObj sigs, ScmObj handler, ScmSysSigset *mask)
     sigset_t sigset;
     int badproc = FALSE, sigactionfailed = FALSE;
 
+    sigemptyset(&sigset);
     if (SCM_INTP(sigs)) {
         int signum = SCM_INT_VALUE(sigs);
         if (signum < 0 || signum >= SCM_NSIG) {
             Scm_Error("bad signal number: %d", signum);
         }
-        sigemptyset(&sigset);
         sigaddset(&sigset, signum);
     } else if (SCM_SYS_SIGSET_P(sigs)) {
         sigset = SCM_SYS_SIGSET(sigs)->set;
@@ -928,6 +929,7 @@ static void scm_sigsuspend(sigset_t *mask)
     SIGPROCMASK(SIG_SETMASK, &omask, NULL);
     SCM_SIGCHECK(vm);
 #else  /* GAUCHE_WINDOWS */
+    (void)mask; /* suppress unused var warning */
     Scm_Error("sigsuspend not supported on Windows port");
 #endif /* GAUCHE_WINDOWS */
 }
@@ -1036,6 +1038,7 @@ int Scm_SigWait(ScmSysSigset *mask)
     }
     return sig;
 #else  /* !HAVE_SIGWAIT */
+    (void)mask; /* suppress unused var warning */
     Scm_Error("sigwait not supported on this platform");
     return 0;
 #endif

--- a/src/win-compat.c
+++ b/src/win-compat.c
@@ -27,6 +27,7 @@ static WCHAR *mbs2wcs(const char *s, int use_gc,
     if (use_gc) wb = SCM_NEW_ATOMIC_ARRAY(WCHAR, nc);
     else        wb = (WCHAR*)malloc(nc * sizeof(WCHAR));
 #else
+    (void)use_gc; /* suppress unused var warning */
     wb = (WCHAR*)malloc(nc * sizeof(WCHAR));
 #endif
     if (MultiByteToWideChar(CP_UTF8, 0, s, -1, wb, nc) == 0) {
@@ -47,6 +48,7 @@ static const char *wcs2mbs(const WCHAR *s, int use_gc,
     if (use_gc) mb = SCM_NEW_ATOMIC_ARRAY(char, nb);
     else        mb = (char*)malloc(nb);
 #else
+    (void)use_gc; /* suppress unused var warning */
     mb = (char*)malloc(nb);
 #endif
     if (WideCharToMultiByte(CP_UTF8, 0, s, -1, mb, nb, 0, 0) == 0) {


### PR DESCRIPTION
Windows 環境における Warning の対処を行いました。
(src ディレクトリのみです)

- src/char.c
  char.c:715:43: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
  char.c:717:43: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
  char.c:894:43: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
  → キャストを追加 (unsigned)

- src/hash.c
  hash.c:720:5: warning: 'cmpfn' may be used uninitialized in this function [-Wmaybe-uninitialized]
  hash.c:720:5: warning: 'hashfn' may be used uninitialized in this function [-Wmaybe-uninitialized]
  hash.c:720:5: warning: 'accessfn' may be used uninitialized in this function [-Wmaybe-uninitialized]
  → ポインタの初期値を設定 (NULL)

- src/gauche/priv/dws_adapter.h
  gauche/priv/dws_adapter.h:51:21: warning: 'Scm__DwSip64_round' declared 'static' but never defined [-Wunused-function]
  gauche/priv/dws_adapter.h:52:22: warning: 'Scm__DwSip64_ksetup' declared 'static' but never defined [-Wunused-function]
  gauche/priv/dws_adapter.h:53:23: warning: 'Scm__DwSip64_getword' declared 'static' but never defined [-Wunused-function]
  gauche/priv/dws_adapter.h:54:20: warning: 'Scm__DwSip64_hash' declared 'static' but never defined [-Wunused-function]
  → 32bit platform では宣言しないようにした

- src/port.c
  port.c:1924:32: warning: variable 'orig_stdin' set but not used [-Wunused-but-set-variable]
  port.c:1925:32: warning: variable 'orig_stdout' set but not used [-Wunused-but-set-variable]
  port.c:1926:32: warning: variable 'orig_stderr' set but not used [-Wunused-but-set-variable]
  → (void)変数名; を追加

- src/read.c
  read.c:1252:29: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
  → キャストを追加 (unsigned)

- src/vector.c
  vector.c:596:26: warning: unknown conversion type character 'l' in format [-Wformat=]
  vector.c:609:26: warning: unknown conversion type character 'l' in format [-Wformat=]
  → configure.ac に `CFLAGS="$CFLAGS -D__USE_MINGW_ANSI_STDIO"` を追加

- src/signal.c
  signal.c:652:25: warning: unused parameter 'how' [-Wunused-parameter]
  signal.c:652:46: warning: unused parameter 'set' [-Wunused-parameter]
  signal.c:652:61: warning: unused parameter 'oldset' [-Wunused-parameter]
  → SCM_UNUSED を追加
  signal.c:913:38: warning: unused parameter 'mask' [-Wunused-parameter]
  signal.c:974:31: warning: unused parameter 'mask' [-Wunused-parameter]
  → (void)変数名; を追加
  ./gauche/win-compat.h:139:41: warning: 'sigset' may be used uninitialized in this function [-Wmaybe-uninitialized]
  signal.c:663:14: note: 'sigset' was declared here
  → sigemptyset(&sigset); を前に移動

- src/system.c
  system.c:775:47: warning: unused parameter 'arg' [-Wunused-parameter]
  → SCM_UNUSED を追加
  system.c:1273:38: warning: unknown conversion type character 'e' in format [-Wformat=]
  → Windows のときは %e を %d に変更
  system.c:1273:41: warning: unknown conversion type character 'T' in format [-Wformat=]
  → Windows のときは %T を %H:%M:%S に変更
  system.c:1623:32: warning: unused parameter 'data' [-Wunused-parameter]
  → SCM_UNUSED を追加
  system.c:1683:34: warning: unused parameter 'mask' [-Wunused-parameter]
  system.c:1686:11: warning: unused variable 'pid' [-Wunused-variable]
  → (void)変数名; を追加
  system.c:2184:11: warning: comparison of unsigned expression >= 0 is always true [-Wtype-limits]
  → キャストを追加 (int)
  system.c:2502:31: warning: unused parameter 'name' [-Wunused-parameter]
  → (void)変数名; を追加
  system.c:2710:15: warning: missing initializer for field 'pw_passwd' of 'struct passwd' [-Wmissing-field-initializers]
  → 構造体の初期値を設定
  system.c:2724:31: warning: unused parameter 'uid' [-Wunused-parameter]
  system.c:2744:30: warning: unused parameter 'gid' [-Wunused-parameter]
  system.c:2749:36: warning: unused parameter 'name' [-Wunused-parameter]
  system.c:2875:19: warning: unused parameter 'desc' [-Wunused-parameter]
  → SCM_UNUSED を追加
  system.c:2905:11: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
  → 戻り値の型を修正
  system.c:2945:33: warning: unused parameter 'seconds' [-Wunused-parameter]
  system.c:3000:32: warning: unused parameter 'data' [-Wunused-parameter]
  → SCM_UNUSED を追加
  system.c:2880:12: warning: 'win_truncate' defined but not used [-Wunused-function]
  → #ifndef __MINGW64_VERSION_MAJOR を前に移動
  system.c:406:20: warning: 'expand_tilde' defined but not used [-Wunused-function]
  → #if !defined(GAUCHE_WINDOWS) を追加
  system.c:2656:16: warning: 'parentid' may be used uninitialized in this function [-Wmaybe-uninitialized]
  system.c:2069:38: warning: 'pid' may be used uninitialized in this function [-Wmaybe-uninitialized]
  → 初期値を設定 (0)
  system.c:1344:25: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
  → キャストを追加 (unsigned)

- src/compile.scm
  compile.scm: In function 'compileglobal_call_type':
  compile.scm:1627:10: warning: variable 'cenv' set but not used [-Wunused-but-set-variable]
  → (cast void 変数名) を追加 (行番号が違う 1627→1745)

- src/libsys.scm
  libsys.scm:573:7: warning: variable 'nsamples' set but not used [-Wunused-but-set-variable]
  → (cast void 変数名) を追加 (行番号が違う 573→515)
  libsys.scm:856:7: warning: variable 'status' set but not used [-Wunused-but-set-variable]
  → (cast void 変数名) を追加 (行番号が違う 856→761)
  libsys.scm:907:7: warning: variable 'group' set but not used [-Wunused-but-set-variable]
  → (cast void 変数名) を追加 (行番号が違う 907→878)
  libsys.scm:905:7: warning: variable 'owner' set but not used [-Wunused-but-set-variable]
  → (cast void 変数名) を追加 (行番号が違う 905→878)
  libsys.scm:1079:7: warning: variable 'mode' set but not used [-Wunused-but-set-variable]
  → (cast void 変数名) を追加 (行番号が違う 1079→1074)
  libsys.scm:1100:7: warning: variable 'no_retry' set but not used [-Wunused-but-set-variable]
  → (cast void 変数名) を追加 (行番号が違う 1100→1095)
  libsys.scm:1324:63: warning: unused parameter 'c' [-Wunused-parameter]
  → (cast void 変数名) を追加 (行番号が違う 1324→1330)
  libsys.scm:1364:1: warning: control reaches end of non-void function [-Wreturn-type]
  → return を追加 (行番号が違う 1364→1371)
  libsys.scm: In function 'libsyssys_getloadavg':
  ./gauche.h:521:50: warning: 'SCM_RESULT' is used uninitialized in this function [-Wuninitialized]
  → (set! SCM_RESULT 0) を追加 (行番号が違う libsys.scm 521→515)

- src/main.c
  main.c:393:27: warning: unknown conversion type character 'z' in format [-Wformat=]
  main.c:393:42: warning: unknown conversion type character 'z' in format [-Wformat=]
  → configure.ac に `CFLAGS="$CFLAGS -D__USE_MINGW_ANSI_STDIO"` を追加

- src/win-compat.c
  win-compat.c:18:42: warning: unused parameter 'use_gc' [-Wunused-parameter]
  win-compat.c:38:48: warning: unused parameter 'use_gc' [-Wunused-parameter]
  → (void)変数名; を追加

- src/gauche-config.c → src/genconfig.in
  win-compat.c:18:15: warning: 'mbs2wcs' defined but not used [-Wunused-function]
  → (void)&関数名; を追加


＜テスト結果＞
OS : Windows 8.1 (64bit)
Gauche : コミット a7dfc76 + 変更

開発環境1 : MSYS2/MinGW-w64 (64bit) (gcc version 7.3.0 (Rev2, Built by MSYS2 project))
Total: 19417 tests, 19417 passed,     0 failed,     0 aborted.

開発環境2 : MSYS2/MinGW-w64 (32bit) (gcc version 7.3.0 (Rev2, Built by MSYS2 project))
Total: 19417 tests, 19417 passed,     0 failed,     0 aborted.

開発環境3 : MinGW.org (32bitのみ) (gcc version 6.3.0 (MinGW.org GCC-6.3.0-1))
Total: 19421 tests, 19421 passed,     0 failed,     0 aborted.
