### PR TITLE
Suppress warning on windows (ext directory except for ext/tls)

### DIFF
--- a/ext/data/queue.scm
+++ b/ext/data/queue.scm
@@ -359,7 +359,10 @@
        (set! ok (queue-peek-both-int q (& h) (& t)))
        (with-mtq-light-lock q (set! ok (queue-peek-both-int q (& h) (& t)))))
      (cond [ok (return h t)]
-           [(SCM_UNBOUNDP fallback) (Scm_Error "queue is empty: %S" q)]
+           [(SCM_UNBOUNDP fallback)
+            (set! SCM_RESULT0 0)
+            (set! SCM_RESULT1 0)
+            (Scm_Error "queue is empty: %S" q)]
            [else (return fallback fallback)])))
  )
 
@@ -420,7 +423,7 @@
 
  ;; API
  (define-cproc enqueue! (q::<queue> obj :rest more-objs)
-   (let* ([head (Scm_Cons obj more-objs)] [tail] [cnt::u_int])
+   (let* ([head (Scm_Cons obj more-objs)] [tail] [cnt::ScmSmallInt])
      (if (SCM_NULLP more-objs)
        (set! tail head cnt 1)
        (set! tail (Scm_LastPair more-objs) cnt (Scm_Length head)))
@@ -470,7 +473,7 @@
      (set! (Q_LENGTH q) (+ (Q_LENGTH q) cnt))))
 
  (define-cproc queue-push! (q::<queue> obj :rest more-objs)
-   (let* ([objs (Scm_Cons obj more-objs)] [head] [tail] [cnt::u_int])
+   (let* ([objs (Scm_Cons obj more-objs)] [head] [tail] [cnt::ScmSmallInt])
      (if (SCM_NULLP more-objs)
        (set! head objs tail objs cnt 1)
        (set! head (Scm_ReverseX objs)

--- a/ext/fcntl/fcntl.c
+++ b/ext/fcntl/fcntl.c
@@ -91,6 +91,7 @@ ScmObj Scm_MakeSysFlock(void)
 /*
  * Fcntl bridge
  */
+#if !defined(GAUCHE_WINDOWS)
 static const char *flag_name(int flag)
 {
 #define FLAG_NAME(n) case n: return #n
@@ -128,6 +129,7 @@ static const char *flag_name(int flag)
     return "(unknown flag)";
 #undef FLAG_NAME
 }
+#endif /* !GAUCHE_WINDOWS */
 
 ScmObj Scm_SysFcntl(ScmObj port_or_fd, int op, ScmObj arg)
 {
@@ -190,6 +192,9 @@ ScmObj Scm_SysFcntl(ScmObj port_or_fd, int op, ScmObj arg)
         return SCM_UNDEFINED;   /* dummy */
     }
 #else  /*GAUCHE_WINDOWS*/
+    (void)port_or_fd; /* suppress unused var warning */
+    (void)op;         /* suppress unused var warning */
+    (void)arg;        /* suppress unused var warning */
     Scm_Error("fcntl not supported on MinGW port");
     return SCM_UNDEFINED; /*dummy*/
 #endif /*GAUCHE_WINDOWS*/

--- a/ext/net/gauche-net.h
+++ b/ext/net/gauche-net.h
@@ -228,8 +228,13 @@ typedef struct ScmSocketRec {
 #endif /*GAUCHE_WINDOWS*/
 } ScmSocket;
 
+#if defined(GAUCHE_WINDOWS)
+#define SOCKET_CLOSED(fd)  ((Socket)(fd) == INVALID_SOCKET)
+#define SOCKET_INVALID(fd) ((Socket)(fd) == INVALID_SOCKET)
+#else  /* !GAUCHE_WINDOWS */
 #define SOCKET_CLOSED(fd)  ((fd) == INVALID_SOCKET)
 #define SOCKET_INVALID(fd) ((fd) == INVALID_SOCKET)
+#endif /* !GAUCHE_WINDOWS */
 
 enum {
     SCM_SOCKET_STATUS_NONE,

--- a/ext/net/netlib.scm
+++ b/ext/net/netlib.scm
@@ -65,7 +65,8 @@
 
  (define-cmethod sockaddr-name ((addr "Scm_SockAddrUnClass"))
    (return
-    (?: (> (-> (cast ScmSockAddr* addr) addrlen) (sizeof (struct sockaddr)))
+    (?: (> (cast unsigned (-> (cast ScmSockAddr* addr) addrlen))
+           (sizeof (struct sockaddr)))
         (SCM_MAKE_STR (ref (-> (cast ScmSockAddrUn* addr) addr) sun_path))
         (SCM_MAKE_STR ""))))
 

--- a/ext/syslog/syslog.scm
+++ b/ext/syslog/syslog.scm
@@ -51,10 +51,17 @@
 
  (define-cproc sys-openlog
    (ident::<const-cstring> option::<fixnum> facility::<fixnum>) ::<void>
-   (.if "defined(HAVE_SYSLOG)" (openlog ident option facility)))
+   (.if "defined(HAVE_SYSLOG)"
+        (openlog ident option facility)
+        (begin (cast void ident)       ; suppress unused var warning
+               (cast void option)      ; suppress unused var warning
+               (cast void facility)))) ; suppress unused var warning
 
  (define-cproc sys-syslog (prio::<fixnum> message::<const-cstring>) ::<void>
-   (.if "defined(HAVE_SYSLOG)" (syslog prio "%s" message)))
+   (.if "defined(HAVE_SYSLOG)"
+        (syslog prio "%s" message)
+        (begin (cast void prio)       ; suppress unused var warning
+               (cast void message)))) ; suppress unused var warning
 
  (define-cproc sys-closelog () ::<void>
    (.if "defined(HAVE_SYSLOG)" (closelog)))
@@ -63,10 +70,16 @@
    (initcode "Scm_AddFeature(\"gauche.sys.syslog\", NULL);"))
 
  (define-cproc sys-logmask (prio::<fixnum>) ::<fixnum>
-   (.if "defined(HAVE_SETLOGMASK)" (return (LOG_MASK prio)) (return 0)))
+   (.if "defined(HAVE_SETLOGMASK)"
+        (return (LOG_MASK prio))
+        (begin (cast void prio) ; suppress unused var warning
+               (return 0))))
 
  (define-cproc sys-setlogmask (mask::<fixnum>) ::<fixnum>
-   (.if "defined(HAVE_SETLOGMASK)" (return (setlogmask mask)) (return 0)))
+   (.if "defined(HAVE_SETLOGMASK)"
+        (return (setlogmask mask))
+        (begin (cast void mask) ; suppress unused var warning
+               (return 0))))
 
  (when "defined(HAVE_SETLOGMASK)"
    (initcode "Scm_AddFeature(\"gauche.sys.setlogmask\", NULL);"))

--- a/ext/termios/termios.c
+++ b/ext/termios/termios.c
@@ -187,6 +187,7 @@ void Scm_Init_termios(void)
 {
     SCM_INIT_EXTENSION(gauche__termios);
     ScmModule *mod = SCM_FIND_MODULE("gauche.termios", SCM_FIND_MODULE_CREATE);
+    (void)mod; /* suppress unused var warning */
 
 #if !defined(GAUCHE_WINDOWS)
     Scm_InitStaticClass(&Scm_SysTermiosClass, "<sys-termios>", mod,

--- a/ext/threads/threads.c
+++ b/ext/threads/threads.c
@@ -131,11 +131,13 @@ static SCM_INTERNAL_THREAD_PROC_RETTYPE thread_entry(void *data)
     return SCM_INTERNAL_THREAD_PROC_RETVAL;
 }
 
+#if defined(GAUCHE_USE_PTHREADS)
 /* The default signal mask on the thread creation */
 static struct threadRec {
     int dummy;                  /* required to place this in data area */
     sigset_t defaultSigmask;
 } threadrec = { 0 };
+#endif /* GAUCHE_USE_PTHREADS */
 #endif /* defined(GAUCHE_HAS_THREADS) */
 
 /* Start a thread.  If the VM is in "NEW" state, create a new thread and

--- a/ext/windows/console.stub
+++ b/ext/windows/console.stub
@@ -41,10 +41,10 @@
 (when "defined(GAUCHE_WINDOWS)"
 
 ;; ConsoleBufferHandle
-(define-cfn make_console_buffer (h::HANDLE) :static
-  (return (Scm_MakeWinHandle h 'console-buffer)))
-(define-cfn console_buffer (h) ::HANDLE :static
-  (return (Scm_WinHandle h 'console-buffer)))
+;(define-cfn make_console_buffer (h::HANDLE) :static
+;  (return (Scm_MakeWinHandle h 'console-buffer)))
+;(define-cfn console_buffer (h) ::HANDLE :static
+;  (return (Scm_WinHandle h 'console-buffer)))
 
 (define-cise-stmt handle
   [(_ type expr)

--- a/ext/windows/windows.stub
+++ b/ext/windows/windows.stub
@@ -98,7 +98,7 @@
                                :optional (caption::<const-cstring>? #f)
                                          (type::<uint> 0))
   ::<int>
-  (let* ([h::HANDLE]
+  (let* ([h::HANDLE NULL]
          [wtext::(const TCHAR*) NULL]
          [wcaption::(const TCHAR*) NULL]
          [r::int 0])


### PR DESCRIPTION
Windows 環境における Warning の対処の続きです。
(ext ディレクトリの ext/tls 以外です)

- ext/data/queue.scm
  ./queue.scm:367:12: warning: 'SCM_RESULT0' may be used uninitialized in this function [-Wmaybe-uninitialized]
  → `(set! SCM_RESULT0 0)` を追加 (行番号が違う 367→356)
  ./queue.scm:367:12: warning: 'SCM_RESULT1' may be used uninitialized in this function [-Wmaybe-uninitialized]
  → `(set! SCM_RESULT1 0)` を追加 (行番号が違う 367→356)
  ./queue.scm:430:283: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
  → 変数の型変更 (u_int→ScmSmallInt)
  ./queue.scm:482:283: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
  → 変数の型変更 (u_int→ScmSmallInt)

- ext/threads/threads.c
  threads.c:138:3: warning: 'threadrec' defined but not used [-Wunused-variable]
  → `#if defined(GAUCHE_USE_PTHREADS)` を追加

- ext/net/gauche-net.h
  gauche-net.h:227:34: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
  → キャストを追加 (Socket) (行番号が違う 227→231)

- ext/net/net.c
  net.c:192:18: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
  net.c:222:19: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
  → SOCKET_INVALID マクロを使用
  ../../src/gauche/system.h:66:38: warning: comparison of unsigned expression < 0 is always false [-Wtype-limits]
  net.c:288:5: note: in expansion of macro 'SCM_SYSCALL'
  → SCM_SYSCALL3 に変更
  net.c:384:37: warning: unused parameter 'sock' [-Wunused-parameter]
  net.c:384:50: warning: unused parameter 'msg' [-Wunused-parameter]
  net.c:384:59: warning: unused parameter 'flags' [-Wunused-parameter]
  net.c:491:40: warning: unused parameter 'name' [-Wunused-parameter]
  net.c:491:57: warning: unused parameter 'iov' [-Wunused-parameter]
  net.c:492:34: warning: unused parameter 'control' [-Wunused-parameter]
  net.c:492:47: warning: unused parameter 'flags' [-Wunused-parameter]
  net.c:493:39: warning: unused parameter 'buf' [-Wunused-parameter]
  net.c:654:35: warning: unused parameter 's' [-Wunused-parameter]
  net.c:654:61: warning: unused parameter 'data' [-Wunused-parameter]
  → (void)変数名; を追加

- ext/netlib.scm
  ./netlib.scm:68:39: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
  → キャストを追加 (unsigned)

- ext/termios/termios.c
  termios.c:189:16: warning: unused variable 'mod' [-Wunused-variable]
  → (void)変数名; を追加

- ext/fcntl/fcntl.c
  fcntl.c:94:20: warning: 'flag_name' defined but not used [-Wunused-function]
  → `#if !defined(GAUCHE_WINDOWS)` を追加
  fcntl.c:132:28: warning: unused parameter 'port_or_fd' [-Wunused-parameter]
  fcntl.c:132:44: warning: unused parameter 'op' [-Wunused-parameter]
  fcntl.c:132:55: warning: unused parameter 'arg' [-Wunused-parameter]
  → (void)変数名; を追加

- ext/syslog/syslog.scm
  gauche--syslog.c:731:16: warning: variable 'ident' set but not used [-Wunused-but-set-variable]
  gauche--syslog.c:733:15: warning: variable 'option' set but not used [-Wunused-but-set-variable]
  gauche--syslog.c:735:15: warning: variable 'facility' set but not used [-Wunused-but-set-variable]
  → (cast void 変数名) を追加 (行番号が違う 731→52)
  ./syslog.scm:70:15: warning: variable 'prio' set but not used [-Wunused-but-set-variable]
  ./syslog.scm:72:16: warning: variable 'message' set but not used [-Wunused-but-set-variable]
  → (cast void 変数名) を追加 (行番号が違う 70→60)
  ./syslog.scm:76:15: warning: variable 'prio' set but not used [-Wunused-but-set-variable]
  → (cast void 変数名) を追加 (行番号が違う 76→72)
  ./syslog.scm:79:15: warning: variable 'mask' set but not used [-Wunused-but-set-variable]
  → (cast void 変数名) を追加 (行番号が違う 79→78)

- ext/windows/windows.stub
  windows.stub:110:2: warning: 'h' may be used uninitialized in this function [-Wmaybe-uninitialized]
  → 初期値を設定 (NULL)

- ext/windows/console.stub
  console.stub:48:15: warning: 'console_buffer' defined but not used [-Wunused-function]
  → コメントアウト (行番号が違う 48→46)
  console.c:920:15: warning: 'make_console_buffer' defined but not used [-Wunused-function]
  → コメントアウト (行番号が違う 920→44)


＜テスト結果＞
OS : Windows 8.1 (64bit)
Gauche : コミット 10b5d32 + #386 + 変更

開発環境1 : MSYS2/MinGW-w64 (64bit) (gcc version 7.3.0 (Rev2, Built by MSYS2 project))
Total: 19417 tests, 19417 passed,     0 failed,     0 aborted.

開発環境2 : MSYS2/MinGW-w64 (32bit) (gcc version 7.3.0 (Rev2, Built by MSYS2 project))
Total: 19417 tests, 19417 passed,     0 failed,     0 aborted.

開発環境3 : MinGW.org (32bitのみ) (gcc version 6.3.0 (MinGW.org GCC-6.3.0-1))
Total: 19421 tests, 19421 passed,     0 failed,     0 aborted.
