### PR TITLE
Fix test of call-with-temporary-file on Windows

### DIFF
--- a/ext/file/test.scm
+++ b/ext/file/test.scm
@@ -641,7 +641,7 @@
                   :directory "test.o"
                   :prefix "ooo")
                (list exists
-                     (boolean (#/test.o\/ooo\w+$/ name))
+                     (boolean (#/test.o[\/\\]ooo\w+$/ name))
                      (file-exists? name))))
          (remove-files '("test.o"))))
 
@@ -656,7 +656,7 @@
                   :directory "test.o"
                   :prefix "ooo")
                (list exists
-                     (boolean (#/test.o\/ooo\w+$/ name))
+                     (boolean (#/test.o[\/\\]ooo\w+$/ name))
                      (file-exists? name))))
          (remove-files '("test.o"))))
 


### PR DESCRIPTION
Windows 環境における call-with-temporary-file のテストの修正です。

- ext/file/test.scm
  - パス区切りのバックスラッシュに対応
