### PR TITLE
Fix gauche-config on Windows

### DIFF
--- a/src/gauche/win-compat.h
+++ b/src/gauche/win-compat.h
@@ -170,6 +170,7 @@ extern __declspec(dllimport) WCHAR *Scm_MBS2WCS(const char *s);
 extern __declspec(dllimport) const char *Scm_WCS2MBS(const WCHAR *s);
 #endif /*!LIBGAUCHE_BODY*/
 
+#if !defined(SCM_MBS2WCS)
 #if defined(UNICODE)
 #define SCM_MBS2WCS(s)  Scm_MBS2WCS(s)
 #define SCM_WCS2MBS(s)  Scm_WCS2MBS(s)
@@ -177,6 +178,7 @@ extern __declspec(dllimport) const char *Scm_WCS2MBS(const WCHAR *s);
 #define SCM_MBS2WCS(s)  (s)
 #define SCM_WCS2MBS(s)  (s)
 #endif /* !UNICODE */
+#endif /* !SCM_MBS2WCS */
 
 /* Replace some system calls with wide-char counterparts
    NB: Windows' mkdir() and _wmkdir() takes one argument.

--- a/src/genconfig.in
+++ b/src/genconfig.in
@@ -111,6 +111,7 @@ cat > gauche-config.c.tmp.$$ <<EOF
 #if defined(__MINGW32__) || defined(_MSC_VER)
 #define _CRT_SECURE_NO_DEPRECATE 1
 #define _CRT_SECURE_NO_WARNINGS  1
+#include <winsock2.h>  /* MinGW needs this before windows.h */
 #include <windows.h>
 #include <shlwapi.h>
 #endif
@@ -238,11 +239,11 @@ static struct cmd_rec {
 #if (defined(__MINGW32__) || defined(_MSC_VER)) && defined(UNICODE)
 /* mbs <-> wcs stuff */
 #include "win-compat.c"
-#define MBS2WCS(s)   mbs2wcs(s, FALSE, errfn)
-#define WCS2MBS(s)   wcs2mbs(s, FALSE, errfn)
+#define SCM_MBS2WCS(s)   mbs2wcs(s, FALSE, errfn)
+#define SCM_WCS2MBS(s)   wcs2mbs(s, FALSE, errfn)
 #else  /* !(defined(__MINGW32__) || defined(_MSC_VER)) && defined(UNICODE) */
-#define MBS2WCS(s)  (s)
-#define WCS2MBS(s)  (s)
+#define SCM_MBS2WCS(s)  (s)
+#define SCM_WCS2MBS(s)  (s)
 #endif /* !(defined(__MINGW32__) || defined(_MSC_VER)) && defined(UNICODE) */
 
 static void errfn(const char *fmt, ...)
@@ -251,6 +252,7 @@ static void errfn(const char *fmt, ...)
     va_start(ap, fmt);
     vfprintf(stderr, fmt, ap);
     va_end(ap);
+    exit(1);
 }
 
 #define PATH_ALLOC(n) malloc(n)

--- a/src/getdir_win.c
+++ b/src/getdir_win.c
@@ -12,8 +12,6 @@ static const char *get_install_dir(void (*errfn)(const char *msg, ...))
 {
     HMODULE mod;
     DWORD r;
-    int len;
-    const char *mbpath;
     TCHAR path[MAX_PATH];
     const TCHAR *libname = _T("libgauche-"GAUCHE_ABI_VERSION".dll");
 

--- a/src/paths.c
+++ b/src/paths.c
@@ -74,7 +74,7 @@ static const char *substitute_all(const char *input,
     }
 
     if (noccurs == 0) return input;
-    size_t buflen = noccurs * mlen + ilen - noccurs;
+    size_t buflen = noccurs * slen + ilen - noccurs;
     char *buf = (char*)PATH_ALLOC(buflen+1);
     char *q = buf;
     for (p = input; noccurs > 0; noccurs--) {


### PR DESCRIPTION
Windows 環境における gauche-config の修正です。

- src/genconfig.in
  - MBS2WCS を SCM_MBS2WCS にリネーム
  - errfn に exit(1) を追加
  - winsock2.h のインクルードを追加
    (src/paths.c → gauche.h のインクルードにより、Warning が出たため)

- src/gauche/win-compat.h
  - SCM_MBS2WCS の重複定義チェックを追加

- src/getdir_win.c
  - 不要変数を削除

- src/paths.c
  - buflen の計算ミスを修正(落ちることがありました)


＜テスト結果＞
OS : Windows 8.1 (64bit)
Gauche : コミット 323ac48 + #391 + #392 + 変更

開発環境1 : MSYS2/MinGW-w64 (64bit) (gcc version 7.3.0 (Rev2, Built by MSYS2 project))
Total: 19431 tests, 19431 passed,     0 failed,     0 aborted.

開発環境2 : MSYS2/MinGW-w64 (32bit) (gcc version 7.3.0 (Rev2, Built by MSYS2 project))
Total: 19431 tests, 19431 passed,     0 failed,     0 aborted.

開発環境3 : MinGW.org (32bitのみ) (gcc version 6.3.0 (MinGW.org GCC-6.3.0-1))
Total: 19435 tests, 19435 passed,     0 failed,     0 aborted.
