### PR TITLE
Force static linking of pthread library on MinGW-w64

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -516,7 +516,8 @@ AC_CHECK_LIB(sunmath, isinf)
 dnl clock_gettime may be in librt
 AC_CHECK_LIB(rt, clock_gettime)
 
-dnl For Windows/MinGW, manually adds several libraries
+dnl For Windows/MinGW, manually adds several libraries.
+dnl For MinGW-w64, force static linking of pthread library.
 dnl Also adds -DUNICODE to CFLAGS enable Windows wchar API,
 dnl  if GAUCHE_CHAR_ENCODING is UTF_8.
 dnl Also adds -D__USE_MINGW_ANSI_STDIO to CFLAGS to support
@@ -524,6 +525,12 @@ dnl  C99 printf format string.
 dnl ALTERNATIVE_GOSH is no-console version of gosh; only built on Windows.
 case "$host" in
   *mingw*) LIBS="$LIBS -lnetapi32 -lshlwapi -lws2_32"
+           case "$host" in
+             *w64-mingw*)
+               case "`gcc -v 2>&1 > /dev/null | grep '^Thread model:'`" in
+                 *posix*) LIBS="$LIBS -Wl,-dn,-lpthread,-dy" ;;
+               esac ;;
+           esac
            ALTERNATIVE_GOSH="gosh-noconsole.exe"
            case "$GAUCHE_CHAR_ENCODING" in
              utf8) CFLAGS="$CFLAGS -DUNICODE" ;;

--- a/src/mingw-dist.sh
+++ b/src/mingw-dist.sh
@@ -119,16 +119,17 @@ make install-examples
 rm -rf $distdir/lib/libgauche.dll*
 case "$MSYSTEM" in
   MINGW64|MINGW32)
-    for dll in libwinpthread-1.dll; do
-      if [ -f $mingwdir/bin/$dll ]; then
-        cp $mingwdir/bin/$dll $distdir/bin
-      fi
-    done
-    ;;
+    mingw_dll="";;
   *)
-    cp $mingwdir/bin/mingwm10.dll $distdir/bin
-    ;;
+    mingw_dll="mingwm10.dll";;
 esac
+if [ -n "$mingw_dll" ]; then
+  for dll in $mingw_dll; do
+    if [ -f $mingwdir/bin/$dll ]; then
+      cp $mingwdir/bin/$dll $distdir/bin
+    fi
+  done
+fi
 
 # Enable using freshly-built gosh for the subsequent operations.
 PATH=$distdir/bin:$PATH


### PR DESCRIPTION
MinGW-w64 のスレッドモデルが posix の場合に、
libwinpthread をスタティックリンクするようにしてみました。
libwinpthread-1.dll への依存がなくなることを確認しました。
(関連 #389)


＜テスト結果＞
OS : Windows 8.1 (64bit)
Gauche : コミット 9dd4eb6 + 変更

開発環境1 : MSYS2/MinGW-w64 (64bit) (gcc version 7.3.0 (Rev2, Built by MSYS2 project))
Total: 19431 tests, 19431 passed,     0 failed,     0 aborted.

開発環境2 : MSYS2/MinGW-w64 (32bit) (gcc version 7.3.0 (Rev2, Built by MSYS2 project))
Total: 19431 tests, 19431 passed,     0 failed,     0 aborted.

開発環境3 : MinGW.org (32bitのみ) (gcc version 6.3.0 (MinGW.org GCC-6.3.0-1))
Total: 19435 tests, 19435 passed,     0 failed,     0 aborted.
