### PR TITLE
Load CA certificates from system certificate store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,6 +171,7 @@ test.record
 /src/gauche-cesconv.in.c
 /src/gauche-config
 /src/gauche-config.c
+/src/*-gauche-config
 /src/gauche-install
 /src/gauche-install.in.c
 /src/gauche-package

--- a/.gitignore
+++ b/.gitignore
@@ -168,10 +168,13 @@ test.record
 /src/char_attr.c
 /src/compile.c
 /src/gauche-cesconv
+/src/gauche-cesconv.in.c
 /src/gauche-config
 /src/gauche-config.c
 /src/gauche-install
+/src/gauche-install.in.c
 /src/gauche-package
+/src/gauche-package.in.c
 /src/gauche/config_threads.h
 /src/gauche/priv/builtin-syms.h
 /src/gauche/priv/unicode_attr.h

--- a/configure.ac
+++ b/configure.ac
@@ -955,5 +955,6 @@ This Gauche has been configured with the following parameters:
               slib: $SLIB_DIR
             thread: $GAUCHE_THREAD_TYPE
            tls/ssl: $GAUCHE_TLS_TYPES
+          CA store: $TLS_CA_TYPE $TLS_CA_PATH
   optional modules: $OPTDBMS$OPTZLIB
 ])

--- a/doc/modutil.texi
+++ b/doc/modutil.texi
@@ -15285,8 +15285,13 @@ Set/get the CA certificate bundle path to be used.  Without arguments, it
 returns the current path.  With one argument, a pathname to the CA bundle
 file, updates the parameter to the new value and returns the previous value.
 
-If you use mbedTLS, you need to set this value to the valid CA bundle
-file.  Unfortunately there's no globally agreed location for such file.
+Some platform can load CA bundle from system certificate store.
+If you sets @code{path} to symbol @code{system} on such platform,
+use system certificate store as CA certificate bundle.
+
+If you use mbedTLS with CA bundle file, you need to set this value to the
+valid CA bundle file path.
+Unfortunately there's no globally agreed location for such file.
 If you need one, one choice is to fetch it from 
 @url{https://curl.haxx.se/ca/cacert.pem}, store it locally and set its path
 to @code{tls-ca-bundle-path}.  (We can't automatically do that, since

--- a/ext/tls/Makefile.in
+++ b/ext/tls/Makefile.in
@@ -19,6 +19,7 @@ TLS_OBJECTS = rfc--tls.$(OBJEXT) \
 
 MBED_OBJECTS = tls-mbed.$(OBJEXT)
 MBEDTLS_LIBS = @MBEDTLS_LIBS@
+SYSTEM_CERT_LIBS = @SYSTEM_CERT_LIBS@
 
 AXTLS_INCLUDES = -I$(srcdir)/axTLS/crypto -I$(srcdir)/axTLS/ssl -I$(srcdir)/axTLS/config
 
@@ -72,7 +73,7 @@ tls.sci rfc--tls.c : tls.scm
 
 rfc--tls--mbed.$(SOEXT) : $(MBED_OBJECTS)
 	$(MODLINK) rfc--tls--mbed.$(SOEXT) $(MBED_OBJECTS) $(EXT_LIBGAUCHE) \
-	   $(MBEDTLS_LIBS)
+	   $(MBEDTLS_LIBS) $(SYSTEM_CERT_LIBS)
 
 # For out-of-source-tree build
 axtls_dirs :

--- a/ext/tls/tls-mbed.c
+++ b/ext/tls/tls-mbed.c
@@ -81,9 +81,30 @@ typedef struct ScmMbedTLSRec {
 
 static inline ScmObj inject_cert(void)
 {
-#if 0
+#ifdef HAVE_WINCRYPT_H
+  HCERTSTORE h;
+
+  h = CertOpenStore(CERT_STORE_PROV_SYSTEM,
+		    X509_ASN_ENCODING,
+		    NULL,
+		    (CERT_STORE_SHARE_STORE_FLAG |
+		     CERT_STORE_SHARE_CONTEXT_FLAG |
+		     CERT_STORE_OPEN_EXISTING_FLAG |
+		     CERT_STORE_MAXIMUM_ALLOWED_FLAG |
+		     CERT_SYSTEM_STORE_LOCAL_MACHINE),
+		    CERT_PHYSICAL_STORE_AUTH_ROOT_NAME);
+  CertControlStore(h, 0, CERT_STORE_CTRL_AUTO_RESYNC, NULL);
+
+  PCCERT_CONTEXT ctx = NULL;
+  do {
+    ctx = CertEnumCertificatesInStore(h, ctx);
+
+
+  } while(ctx != NULL);
+
+  return SCM_TRUE;
 #else
-    return SCM_TRUE;
+    return SCM_FALSE;
 #endif
 }
 

--- a/ext/tls/tls-mbed.c
+++ b/ext/tls/tls-mbed.c
@@ -88,7 +88,7 @@ static inline ScmObj load_system_cert(ScmMbedTLS *t)
 				     (CERT_STORE_SHARE_STORE_FLAG |
 				      CERT_STORE_SHARE_CONTEXT_FLAG |
 				      CERT_STORE_OPEN_EXISTING_FLAG |
-				      CERT_STORE_MAXIMUM_ALLOWED_FLAG |
+				      CERT_STORE_READONLY_FLAG |
 				      CERT_SYSTEM_STORE_LOCAL_MACHINE),
 				     TEXT("Root"));
   if (h == NULL) {

--- a/ext/tls/tls-mbed.c
+++ b/ext/tls/tls-mbed.c
@@ -109,7 +109,7 @@ static inline ScmObj inject_cert(ScmMbedTLS *t)
 
     size_t size = ctx->cbCertEncoded;
 
-    if(mbedtls_x509_crt_parse_der(t->ca, ctx->pbCertEncoded, size) != 0) {
+    if(mbedtls_x509_crt_parse_der(&t->ca, ctx->pbCertEncoded, size) != 0) {
       break;
     }
   }

--- a/ext/tls/tls-mbed.c
+++ b/ext/tls/tls-mbed.c
@@ -176,7 +176,7 @@ static ScmObj mbed_connect(ScmTLS* tls, int fd)
             Scm_SysError("mbedtls_x509_crt_parse_file() failed: file=%S", s_ca_file);
         }
     } else {
-        Scm_Error("Parameter tls-ca-bundle-path must have a string value,"
+        Scm_Error("Parameter tls-ca-bundle-path must have a string value or 'system,"
                   " but got: %S", s_ca_file);
     }
 

--- a/ext/tls/tls-mbed.c
+++ b/ext/tls/tls-mbed.c
@@ -168,7 +168,7 @@ static ScmObj mbed_connect(ScmTLS* tls, int fd)
                   " validate server certs.");
     } else if(SCM_SYMBOLP(SCM_SYMBOL(s_ca_file))) {
         if(SCM_FALSEP(load_system_cert(t))) {
-            Scm_SysError("Can't load certificates from system certificate store");
+            Scm_Error("Can't load certificates from system certificate store");
         }
     } else if(SCM_STRINGP(s_ca_file)) {
         const char *ca_file = Scm_GetStringConst(SCM_STRING(s_ca_file));

--- a/ext/tls/tls-mbed.c
+++ b/ext/tls/tls-mbed.c
@@ -86,7 +86,7 @@ static inline ScmObj inject_cert(ScmMbedTLS *t)
 
   h = CertOpenStore(CERT_STORE_PROV_SYSTEM,
 		    X509_ASN_ENCODING,
-		    NULL,
+		    0,
 		    (CERT_STORE_SHARE_STORE_FLAG |
 		     CERT_STORE_SHARE_CONTEXT_FLAG |
 		     CERT_STORE_OPEN_EXISTING_FLAG |

--- a/ext/tls/tls-mbed.c
+++ b/ext/tls/tls-mbed.c
@@ -92,7 +92,7 @@ static inline ScmObj load_system_cert(ScmMbedTLS *t)
 		     CERT_STORE_OPEN_EXISTING_FLAG |
 		     CERT_STORE_MAXIMUM_ALLOWED_FLAG |
 		     CERT_SYSTEM_STORE_LOCAL_MACHINE),
-		    TEXT("Root"));
+		    TEXT("ROOT"));
   if (h == NULL) {
     Scm_Warn("Can't open certificate store");
     return SCM_FALSE;

--- a/ext/tls/tls-mbed.c
+++ b/ext/tls/tls-mbed.c
@@ -175,7 +175,9 @@ static ScmObj mbed_connect(ScmTLS* tls, int fd)
     }
     const char *ca_file = Scm_GetStringConst(SCM_STRING(s_ca_file));
     if(Scm_StringEqual(SCM_STRING(s_ca_file), SCM_STRING(SCM_MAKE_STR("@system")))) {
-        load_system_cert(t);
+        if(SCM_FALSEP(load_system_cert(t))) {
+            Scm_SysError("Can't load certificates from system certificate store");
+        }
     } else if(mbedtls_x509_crt_parse_file(&t->ca, ca_file) != 0) {
         Scm_SysError("mbedtls_x509_crt_parse_file() failed: file=%S", s_ca_file);
     }

--- a/ext/tls/tls-mbed.c
+++ b/ext/tls/tls-mbed.c
@@ -92,7 +92,7 @@ static inline ScmObj load_system_cert(ScmMbedTLS *t)
 		     CERT_STORE_OPEN_EXISTING_FLAG |
 		     CERT_STORE_MAXIMUM_ALLOWED_FLAG |
 		     CERT_SYSTEM_STORE_LOCAL_MACHINE),
-		    TEXT("ROOT"));
+		    TEXT("Root"));
   if (h == NULL) {
     Scm_Warn("Can't open certificate store");
     return SCM_FALSE;

--- a/ext/tls/tls-mbed.c
+++ b/ext/tls/tls-mbed.c
@@ -161,16 +161,16 @@ static ScmObj mbed_connect(ScmTLS* tls, int fd)
                   SCM_FIND_MODULE("rfc.tls", 0));
     ScmObj s_ca_file = Scm_ApplyRec0(ca_bundle_path);
     if (SCM_FALSEP(s_ca_file)) {
-        if (SCM_FALSEP(inject_cert(t))) {
-	    Scm_Error("mbedTLS: tls-ca-bundle-path isn't set. It is required to"
-		      " validate server certs.");
-        }
+        Scm_Error("mbedTLS: tls-ca-bundle-path isn't set. It is required to"
+                  " validate server certs.");
     } else if (!SCM_STRINGP(s_ca_file)) {
         Scm_Error("Parameter tls-ca-bundle-path must have a string value,"
                   " but got: %S", s_ca_file);
     }
     const char *ca_file = Scm_GetStringConst(SCM_STRING(s_ca_file));
-    if(mbedtls_x509_crt_parse_file(&t->ca, ca_file) != 0) {
+    if(Scm_StringEqual(SCM_STRING(s_ca_file), SCM_STRING(SCM_MAKE_STR("@system")))) {
+        inject_cert(t);
+    } else if(mbedtls_x509_crt_parse_file(&t->ca, ca_file) != 0) {
         Scm_SysError("mbedtls_x509_crt_parse_file() failed: file=%S", s_ca_file);
     }
     mbedtls_ssl_conf_ca_chain(&t->conf, &t->ca, NULL);

--- a/ext/tls/tls-mbed.c
+++ b/ext/tls/tls-mbed.c
@@ -79,7 +79,7 @@ typedef struct ScmMbedTLSRec {
 } ScmMbedTLS;
 
 
-static inline ScmObj inject_cert(ScmMbedTLS *t)
+static inline ScmObj load_system_cert(ScmMbedTLS *t)
 {
 #ifdef HAVE_WINCRYPT_H
   HCERTSTORE h;
@@ -175,7 +175,7 @@ static ScmObj mbed_connect(ScmTLS* tls, int fd)
     }
     const char *ca_file = Scm_GetStringConst(SCM_STRING(s_ca_file));
     if(Scm_StringEqual(SCM_STRING(s_ca_file), SCM_STRING(SCM_MAKE_STR("@system")))) {
-        inject_cert(t);
+        load_system_cert(t);
     } else if(mbedtls_x509_crt_parse_file(&t->ca, ca_file) != 0) {
         Scm_SysError("mbedtls_x509_crt_parse_file() failed: file=%S", s_ca_file);
     }

--- a/ext/tls/tls-mbed.c
+++ b/ext/tls/tls-mbed.c
@@ -173,13 +173,15 @@ static ScmObj mbed_connect(ScmTLS* tls, int fd)
         Scm_Error("Parameter tls-ca-bundle-path must have a string value,"
                   " but got: %S", s_ca_file);
     }
-    const char *ca_file = Scm_GetStringConst(SCM_STRING(s_ca_file));
     if(Scm_StringEqual(SCM_STRING(s_ca_file), SCM_STRING(SCM_MAKE_STR("@system")))) {
         if(SCM_FALSEP(load_system_cert(t))) {
             Scm_SysError("Can't load certificates from system certificate store");
         }
-    } else if(mbedtls_x509_crt_parse_file(&t->ca, ca_file) != 0) {
-        Scm_SysError("mbedtls_x509_crt_parse_file() failed: file=%S", s_ca_file);
+    } else {
+        const char *ca_file = Scm_GetStringConst(SCM_STRING(s_ca_file));
+        if(mbedtls_x509_crt_parse_file(&t->ca, ca_file) != 0) {
+            Scm_SysError("mbedtls_x509_crt_parse_file() failed: file=%S", s_ca_file);
+        }
     }
     mbedtls_ssl_conf_ca_chain(&t->conf, &t->ca, NULL);
     mbedtls_ssl_conf_authmode(&t->conf, MBEDTLS_SSL_VERIFY_REQUIRED);

--- a/ext/tls/tls-mbed.c
+++ b/ext/tls/tls-mbed.c
@@ -79,9 +79,9 @@ typedef struct ScmMbedTLSRec {
 } ScmMbedTLS;
 
 
+#ifdef HAVE_WINCRYPT_H
 static inline ScmObj load_system_cert(ScmMbedTLS *t)
 {
-#ifdef HAVE_WINCRYPT_H
     const HCERTSTORE h = CertOpenStore(CERT_STORE_PROV_SYSTEM,
                                        X509_ASN_ENCODING,
                                        0,
@@ -117,11 +117,10 @@ static inline ScmObj load_system_cert(ScmMbedTLS *t)
 
     CertCloseStore(h, 0);
     return SCM_TRUE;
-#else
-    (void)t;
-    return SCM_FALSE;
-#endif
 }
+#else
+static inline ScmObj load_system_cert(ScmMbedTLS *t SCM_UNUSED) { return SCM_FALSE; }
+#endif
 
 
 static void mbed_context_check(ScmMbedTLS* t SCM_UNUSED,

--- a/ext/tls/tls-mbed.c
+++ b/ext/tls/tls-mbed.c
@@ -79,7 +79,7 @@ typedef struct ScmMbedTLSRec {
 } ScmMbedTLS;
 
 
-static inline ScmObj inject_cert(void)
+static inline ScmObj inject_cert(ScmMbedTLS *t)
 {
 #ifdef HAVE_WINCRYPT_H
   HCERTSTORE h;
@@ -95,12 +95,16 @@ static inline ScmObj inject_cert(void)
 		    CERT_PHYSICAL_STORE_AUTH_ROOT_NAME);
   CertControlStore(h, 0, CERT_STORE_CTRL_AUTO_RESYNC, NULL);
 
-  PCCERT_CONTEXT ctx = NULL;
-  do {
+  while(1) {
+    PCCERT_CONTEXT ctx = NULL;
     ctx = CertEnumCertificatesInStore(h, ctx);
 
+    if (ctx == NULL) { break; }
 
-  } while(ctx != NULL);
+    size_t size = ctx->cbCertEncoded;
+
+    mbedtls_x509_crt_parse_der(t->ca, ctx->pbCertEncoded, size);
+  }
 
   return SCM_TRUE;
 #else
@@ -149,7 +153,7 @@ static ScmObj mbed_connect(ScmTLS* tls, int fd)
                   SCM_FIND_MODULE("rfc.tls", 0));
     ScmObj s_ca_file = Scm_ApplyRec0(ca_bundle_path);
     if (SCM_FALSEP(s_ca_file)) {
-        if (SCM_FALSEP(inject_cert())) {
+        if (SCM_FALSEP(inject_cert(t))) {
 	    Scm_Error("mbedTLS: tls-ca-bundle-path isn't set. It is required to"
 		      " validate server certs.");
         }

--- a/ext/tls/tls-mbed.c
+++ b/ext/tls/tls-mbed.c
@@ -111,8 +111,9 @@ static inline ScmObj inject_cert(ScmMbedTLS *t)
 
     if (ctx == NULL) { break; }
 
-    if(mbedtls_x509_crt_parse_der(&t->ca, ctx->pbCertEncoded, ctx->cbCertEncoded) != 0) {
-      Scm_Warn("Certificate is not accepted");
+    int st = mbedtls_x509_crt_parse_der(&t->ca, ctx->pbCertEncoded, ctx->cbCertEncoded);
+    if(st != 0) {
+      Scm_Warn("Certificate is not accepted: %d", st);
     }
   }
 

--- a/ext/tls/tls-mbed.c
+++ b/ext/tls/tls-mbed.c
@@ -165,7 +165,7 @@ static ScmObj mbed_connect(ScmTLS* tls, int fd)
 	    Scm_Error("mbedTLS: tls-ca-bundle-path isn't set. It is required to"
 		      " validate server certs.");
         }
-    } if (!SCM_STRINGP(s_ca_file)) {
+    } else if (!SCM_STRINGP(s_ca_file)) {
         Scm_Error("Parameter tls-ca-bundle-path must have a string value,"
                   " but got: %S", s_ca_file);
     }

--- a/ext/tls/tls-mbed.c
+++ b/ext/tls/tls-mbed.c
@@ -166,7 +166,7 @@ static ScmObj mbed_connect(ScmTLS* tls, int fd)
     if (SCM_FALSEP(s_ca_file)) {
         Scm_Error("mbedTLS: tls-ca-bundle-path isn't set. It is required to"
                   " validate server certs.");
-    } else if(Scm_EqP(s_ca_file, Scm_MakeSymbol(SCM_MAKE_STR("system"), TRUE))) {
+    } else if(Scm_EqP(s_ca_file, Scm_MakeSymbol(SCM_STRING(SCM_MAKE_STR("system")), TRUE))) {
         if(SCM_FALSEP(load_system_cert(t))) {
             Scm_Error("Can't load certificates from system certificate store");
         }

--- a/ext/tls/tls-mbed.c
+++ b/ext/tls/tls-mbed.c
@@ -93,9 +93,13 @@ static inline ScmObj inject_cert(ScmMbedTLS *t)
 		     CERT_STORE_MAXIMUM_ALLOWED_FLAG |
 		     CERT_SYSTEM_STORE_LOCAL_MACHINE),
 		    CERT_PHYSICAL_STORE_AUTH_ROOT_NAME);
-  if (h == NULL) { return SCM_FALSE; }
+  if (h == NULL) {
+    Scm_Warn("Can't open certificate store");
+    return SCM_FALSE;
+  }
 
   if(!CertControlStore(h, 0, CERT_STORE_CTRL_AUTO_RESYNC, NULL)) {
+    Scm_Warn("Can't resync certificate store");
     CertCloseStore(h, 0);
     return SCM_FALSE;
   }
@@ -108,6 +112,7 @@ static inline ScmObj inject_cert(ScmMbedTLS *t)
     if (ctx == NULL) { break; }
 
     if(mbedtls_x509_crt_parse_der(&t->ca, ctx->pbCertEncoded, ctx->cbCertEncoded) != 0) {
+      Scm_Warn("Certificate is not accepted");
       break;
     }
   }

--- a/ext/tls/tls-mbed.c
+++ b/ext/tls/tls-mbed.c
@@ -95,8 +95,8 @@ static inline ScmObj inject_cert(ScmMbedTLS *t)
 		    CERT_PHYSICAL_STORE_AUTH_ROOT_NAME);
   CertControlStore(h, 0, CERT_STORE_CTRL_AUTO_RESYNC, NULL);
 
+  PCCERT_CONTEXT ctx = NULL;
   while(1) {
-    PCCERT_CONTEXT ctx = NULL;
     ctx = CertEnumCertificatesInStore(h, ctx);
 
     if (ctx == NULL) { break; }

--- a/ext/tls/tls-mbed.c
+++ b/ext/tls/tls-mbed.c
@@ -108,6 +108,7 @@ static inline ScmObj inject_cert(ScmMbedTLS *t)
 
   return SCM_TRUE;
 #else
+    (void)t;
     return SCM_FALSE;
 #endif
 }

--- a/ext/tls/tls-mbed.c
+++ b/ext/tls/tls-mbed.c
@@ -93,7 +93,13 @@ static inline ScmObj inject_cert(ScmMbedTLS *t)
 		     CERT_STORE_MAXIMUM_ALLOWED_FLAG |
 		     CERT_SYSTEM_STORE_LOCAL_MACHINE),
 		    CERT_PHYSICAL_STORE_AUTH_ROOT_NAME);
-  CertControlStore(h, 0, CERT_STORE_CTRL_AUTO_RESYNC, NULL);
+  if (h == NULL) { return SCM_FALSE; }
+
+  if(!CertControlStore(h, 0, CERT_STORE_CTRL_AUTO_RESYNC, NULL)) {
+    CertCloseStore(h, 0);
+    return SCM_FALSE;
+  }
+
 
   PCCERT_CONTEXT ctx = NULL;
   while(1) {
@@ -106,6 +112,7 @@ static inline ScmObj inject_cert(ScmMbedTLS *t)
     mbedtls_x509_crt_parse_der(t->ca, ctx->pbCertEncoded, size);
   }
 
+  CertCloseStore(h, 0);
   return SCM_TRUE;
 #else
     (void)t;

--- a/ext/tls/tls-mbed.c
+++ b/ext/tls/tls-mbed.c
@@ -163,7 +163,8 @@ static ScmObj mbed_connect(ScmTLS* tls, int fd)
     if (SCM_FALSEP(s_ca_file)) {
         Scm_Error("mbedTLS: tls-ca-bundle-path isn't set. It is required to"
                   " validate server certs.");
-    } else if (!SCM_STRINGP(s_ca_file)) {
+    }
+    if (!SCM_STRINGP(s_ca_file)) {
         Scm_Error("Parameter tls-ca-bundle-path must have a string value,"
                   " but got: %S", s_ca_file);
     }

--- a/ext/tls/tls-mbed.c
+++ b/ext/tls/tls-mbed.c
@@ -82,17 +82,15 @@ typedef struct ScmMbedTLSRec {
 static inline ScmObj load_system_cert(ScmMbedTLS *t)
 {
 #ifdef HAVE_WINCRYPT_H
-  HCERTSTORE h;
-
-  h = CertOpenStore(CERT_STORE_PROV_SYSTEM,
-		    X509_ASN_ENCODING,
-		    0,
-		    (CERT_STORE_SHARE_STORE_FLAG |
-		     CERT_STORE_SHARE_CONTEXT_FLAG |
-		     CERT_STORE_OPEN_EXISTING_FLAG |
-		     CERT_STORE_MAXIMUM_ALLOWED_FLAG |
-		     CERT_SYSTEM_STORE_LOCAL_MACHINE),
-		    TEXT("Root"));
+  const HCERTSTORE h = CertOpenStore(CERT_STORE_PROV_SYSTEM,
+				     X509_ASN_ENCODING,
+				     0,
+				     (CERT_STORE_SHARE_STORE_FLAG |
+				      CERT_STORE_SHARE_CONTEXT_FLAG |
+				      CERT_STORE_OPEN_EXISTING_FLAG |
+				      CERT_STORE_MAXIMUM_ALLOWED_FLAG |
+				      CERT_SYSTEM_STORE_LOCAL_MACHINE),
+				     TEXT("Root"));
   if (h == NULL) {
     Scm_Warn("Can't open certificate store");
     return SCM_FALSE;

--- a/ext/tls/tls-mbed.c
+++ b/ext/tls/tls-mbed.c
@@ -113,7 +113,6 @@ static inline ScmObj inject_cert(ScmMbedTLS *t)
 
     if(mbedtls_x509_crt_parse_der(&t->ca, ctx->pbCertEncoded, ctx->cbCertEncoded) != 0) {
       Scm_Warn("Certificate is not accepted");
-      break;
     }
   }
 

--- a/ext/tls/tls-mbed.c
+++ b/ext/tls/tls-mbed.c
@@ -35,6 +35,12 @@
 #include <gauche/extend.h>
 
 #if defined(GAUCHE_USE_MBEDTLS)
+
+#ifdef HAVE_WINCRYPT_H
+#include <wincrypt.h>
+#endif
+
+
 /*
  * Class
  */
@@ -73,6 +79,15 @@ typedef struct ScmMbedTLSRec {
 } ScmMbedTLS;
 
 
+static inline ScmObj inject_cert(void)
+{
+#if 0
+#else
+    return SCM_TRUE;
+#endif
+}
+
+
 static void mbed_context_check(ScmMbedTLS* t SCM_UNUSED,
                                const char* op SCM_UNUSED)
 {
@@ -83,7 +98,7 @@ static void mbed_close_check(ScmMbedTLS* t, const char *op)
 {
     if (t->conn.fd < 0) Scm_Error("attempt to %s closed TLS: %S", op, t);
 }
-    
+
 static ScmObj mbed_connect(ScmTLS* tls, int fd)
 {
     ScmMbedTLS* t = (ScmMbedTLS*)tls;
@@ -113,8 +128,10 @@ static ScmObj mbed_connect(ScmTLS* tls, int fd)
                   SCM_FIND_MODULE("rfc.tls", 0));
     ScmObj s_ca_file = Scm_ApplyRec0(ca_bundle_path);
     if (SCM_FALSEP(s_ca_file)) {
-        Scm_Error("mbedTLS: tls-ca-bundle-path isn't set. It is required to"
-                  " validate server certs.");
+        if (SCM_FALSEP(inject_cert())) {
+	    Scm_Error("mbedTLS: tls-ca-bundle-path isn't set. It is required to"
+		      " validate server certs.");
+        }
     } if (!SCM_STRINGP(s_ca_file)) {
         Scm_Error("Parameter tls-ca-bundle-path must have a string value,"
                   " but got: %S", s_ca_file);

--- a/ext/tls/tls-mbed.c
+++ b/ext/tls/tls-mbed.c
@@ -166,7 +166,7 @@ static ScmObj mbed_connect(ScmTLS* tls, int fd)
     if (SCM_FALSEP(s_ca_file)) {
         Scm_Error("mbedTLS: tls-ca-bundle-path isn't set. It is required to"
                   " validate server certs.");
-    } else if(SCM_SYMBOLP(SCM_SYMBOL(s_ca_file))) {
+    } else if(Scm_EqP(s_ca_file, Scm_MakeSymbol(SCM_MAKE_STR("system"), TRUE))) {
         if(SCM_FALSEP(load_system_cert(t))) {
             Scm_Error("Can't load certificates from system certificate store");
         }

--- a/ext/tls/tls-mbed.c
+++ b/ext/tls/tls-mbed.c
@@ -166,21 +166,20 @@ static ScmObj mbed_connect(ScmTLS* tls, int fd)
     if (SCM_FALSEP(s_ca_file)) {
         Scm_Error("mbedTLS: tls-ca-bundle-path isn't set. It is required to"
                   " validate server certs.");
-    }
-    if (!SCM_STRINGP(s_ca_file)) {
-        Scm_Error("Parameter tls-ca-bundle-path must have a string value,"
-                  " but got: %S", s_ca_file);
-    }
-    if(Scm_StringEqual(SCM_STRING(s_ca_file), SCM_STRING(SCM_MAKE_STR("@system")))) {
+    } else if(SCM_SYMBOLP(SCM_SYMBOL(s_ca_file))) {
         if(SCM_FALSEP(load_system_cert(t))) {
             Scm_SysError("Can't load certificates from system certificate store");
         }
-    } else {
+    } else if(SCM_STRINGP(s_ca_file)) {
         const char *ca_file = Scm_GetStringConst(SCM_STRING(s_ca_file));
         if(mbedtls_x509_crt_parse_file(&t->ca, ca_file) != 0) {
             Scm_SysError("mbedtls_x509_crt_parse_file() failed: file=%S", s_ca_file);
         }
+    } else {
+        Scm_Error("Parameter tls-ca-bundle-path must have a string value,"
+                  " but got: %S", s_ca_file);
     }
+
     mbedtls_ssl_conf_ca_chain(&t->conf, &t->ca, NULL);
     mbedtls_ssl_conf_authmode(&t->conf, MBEDTLS_SSL_VERIFY_REQUIRED);
 

--- a/ext/tls/tls-mbed.c
+++ b/ext/tls/tls-mbed.c
@@ -92,7 +92,7 @@ static inline ScmObj inject_cert(ScmMbedTLS *t)
 		     CERT_STORE_OPEN_EXISTING_FLAG |
 		     CERT_STORE_MAXIMUM_ALLOWED_FLAG |
 		     CERT_SYSTEM_STORE_LOCAL_MACHINE),
-		    CERT_PHYSICAL_STORE_AUTH_ROOT_NAME);
+		    TEXT("Root"));
   if (h == NULL) {
     Scm_Warn("Can't open certificate store");
     return SCM_FALSE;

--- a/ext/tls/tls-mbed.c
+++ b/ext/tls/tls-mbed.c
@@ -109,7 +109,9 @@ static inline ScmObj inject_cert(ScmMbedTLS *t)
 
     size_t size = ctx->cbCertEncoded;
 
-    mbedtls_x509_crt_parse_der(t->ca, ctx->pbCertEncoded, size);
+    if(mbedtls_x509_crt_parse_der(t->ca, ctx->pbCertEncoded, size) != 0) {
+      break;
+    }
   }
 
   CertCloseStore(h, 0);

--- a/ext/tls/tls-mbed.c
+++ b/ext/tls/tls-mbed.c
@@ -47,7 +47,7 @@
 
 static ScmObj mbed_allocate(ScmClass *klass, ScmObj initargs);
 
-static void mbedtls_print(ScmObj obj, ScmPort* port, 
+static void mbedtls_print(ScmObj obj, ScmPort* port,
                           ScmWriteContext* ctx SCM_UNUSED)
 {
     Scm_Printf(port, "#<%A", Scm_ShortClassName(SCM_CLASS_OF(obj)));
@@ -57,7 +57,7 @@ static void mbedtls_print(ScmObj obj, ScmPort* port,
 }
 
 /* NB: We avoid referring Scm_TLSClass statically, since it is in another
-   DSO module and some OS doesn't resolve inter-DSO static data.  We 
+   DSO module and some OS doesn't resolve inter-DSO static data.  We
    set the CPA field in init routine. */
 SCM_DEFINE_BUILTIN_CLASS(Scm_MbedTLSClass, mbedtls_print, NULL,
                          NULL, mbed_allocate, NULL);
@@ -82,41 +82,41 @@ typedef struct ScmMbedTLSRec {
 static inline ScmObj load_system_cert(ScmMbedTLS *t)
 {
 #ifdef HAVE_WINCRYPT_H
-  const HCERTSTORE h = CertOpenStore(CERT_STORE_PROV_SYSTEM,
-				     X509_ASN_ENCODING,
-				     0,
-				     (CERT_STORE_SHARE_STORE_FLAG |
-				      CERT_STORE_SHARE_CONTEXT_FLAG |
-				      CERT_STORE_OPEN_EXISTING_FLAG |
-				      CERT_STORE_READONLY_FLAG |
-				      CERT_SYSTEM_STORE_LOCAL_MACHINE),
-				     TEXT("Root"));
-  if (h == NULL) {
-    Scm_Warn("Can't open certificate store");
-    return SCM_FALSE;
-  }
-
-  if(!CertControlStore(h, 0, CERT_STORE_CTRL_AUTO_RESYNC, NULL)) {
-    Scm_Warn("Can't resync certificate store");
-    CertCloseStore(h, 0);
-    return SCM_FALSE;
-  }
-
-
-  PCCERT_CONTEXT ctx = NULL;
-  while(1) {
-    ctx = CertEnumCertificatesInStore(h, ctx);
-
-    if (ctx == NULL) { break; }
-
-    int st = mbedtls_x509_crt_parse_der(&t->ca, ctx->pbCertEncoded, ctx->cbCertEncoded);
-    if(st != 0) {
-      Scm_Warn("Certificate is not accepted: %d", st);
+    const HCERTSTORE h = CertOpenStore(CERT_STORE_PROV_SYSTEM,
+                                       X509_ASN_ENCODING,
+                                       0,
+                                       (CERT_STORE_SHARE_STORE_FLAG |
+                                        CERT_STORE_SHARE_CONTEXT_FLAG |
+                                        CERT_STORE_OPEN_EXISTING_FLAG |
+                                        CERT_STORE_READONLY_FLAG |
+                                        CERT_SYSTEM_STORE_LOCAL_MACHINE),
+                                       TEXT("Root"));
+    if (h == NULL) {
+        Scm_Warn("Can't open certificate store");
+        return SCM_FALSE;
     }
-  }
 
-  CertCloseStore(h, 0);
-  return SCM_TRUE;
+    if(!CertControlStore(h, 0, CERT_STORE_CTRL_AUTO_RESYNC, NULL)) {
+        Scm_Warn("Can't resync certificate store");
+        CertCloseStore(h, 0);
+        return SCM_FALSE;
+    }
+
+
+    PCCERT_CONTEXT ctx = NULL;
+    while(1) {
+        ctx = CertEnumCertificatesInStore(h, ctx);
+
+        if (ctx == NULL) { break; }
+
+        int st = mbedtls_x509_crt_parse_der(&t->ca, ctx->pbCertEncoded, ctx->cbCertEncoded);
+        if(st != 0) {
+            Scm_Warn("Certificate is not accepted: %d", st);
+        }
+    }
+
+    CertCloseStore(h, 0);
+    return SCM_TRUE;
 #else
     (void)t;
     return SCM_FALSE;
@@ -138,7 +138,7 @@ static void mbed_close_check(ScmMbedTLS* t, const char *op)
 static ScmObj mbed_connect(ScmTLS* tls, int fd)
 {
     ScmMbedTLS* t = (ScmMbedTLS*)tls;
-    
+
     mbed_context_check(t, "connect");
     const char* pers = "Gauche";
     if(mbedtls_ctr_drbg_seed(&t->ctr_drbg, mbedtls_entropy_func, &t->entropy,
@@ -258,7 +258,7 @@ static ScmObj mbed_read(ScmTLS* tls)
 
     if (r < 0) { Scm_SysError("mbedtls_ssl_read() failed"); }
 
-    return Scm_MakeString((char *)buf, r, r, 
+    return Scm_MakeString((char *)buf, r, r,
                           SCM_STRING_INCOMPLETE | SCM_STRING_COPYING);
 }
 
@@ -270,7 +270,7 @@ static ScmObj mbed_write(ScmTLS* tls, ScmObj msg)
 
     ScmSize size;
     const uint8_t* cmsg = Scm_GetBytes(msg, &size);
-    
+
     if (cmsg == NULL) {
         Scm_TypeError("TLS message", "uniform vector or string", msg);
     }
@@ -362,4 +362,3 @@ void Scm_Init_rfc__tls__mbed()
     SCM_DEFINE(mod, "<mbed-tls>", SCM_FALSE);
 #endif /* defined(GAUCHE_USE_MBEDTLS) */
 }
-

--- a/ext/tls/tls-mbed.c
+++ b/ext/tls/tls-mbed.c
@@ -107,9 +107,7 @@ static inline ScmObj inject_cert(ScmMbedTLS *t)
 
     if (ctx == NULL) { break; }
 
-    size_t size = ctx->cbCertEncoded;
-
-    if(mbedtls_x509_crt_parse_der(&t->ca, ctx->pbCertEncoded, size) != 0) {
+    if(mbedtls_x509_crt_parse_der(&t->ca, ctx->pbCertEncoded, ctx->cbCertEncoded) != 0) {
       break;
     }
   }

--- a/ext/tls/tls.ac
+++ b/ext/tls/tls.ac
@@ -86,14 +86,19 @@ AS_IF([echo $TLSLIBS | tr "," "\012" | grep -q mbedtls], [
   LIBS=${LIBS_SAVE}
   EXT_LIBS="$EXT_LIBS $MBEDTLS_LIBS"
 
+  LIBS_SAVE=${LIBS}
+  SYSTEM_CERT_LIBS=""
   AC_CHECK_HEADERS([wincrypt.h], [], [], [@%:@include<windows.h>])
-  AC_SEARCH_LIBS([CertOpenStore], [crypt32], [EXT_LIBS="${EXT_LIBS} -lcrypt32"])
+  AC_SEARCH_LIBS([CertOpenStore], [crypt32], [SYSTEM_CERT_LIBS="-lcrypt32 ${SYSTEM_CERT_LIBS}"])
+  LIBS=${LIBS_SAVE}
+  EXT_LIBS="$EXT_LIBS $SYSTEM_CERT_LIBS"
 
   AS_IF([test "$mbedtls_unavailable" = yes], [
     AC_MSG_NOTICE([Can't find mbedtls headers and/or libraries.])
     ],[
       AC_DEFINE(GAUCHE_USE_MBEDTLS, 1, [Define if you use mbed TLS])
       AC_SUBST(MBEDTLS_LIBS)
+      AC_SUBST(SYSTEM_CERT_LIBS)
       GAUCHE_TLS_TYPES="mbedtls $GAUCHE_TLS_TYPES"
       GAUCHE_TLS_SWITCH_MBEDTLS=
       GAUCHE_TLS_SWITCH_NONE="@%:@"

--- a/ext/tls/tls.ac
+++ b/ext/tls/tls.ac
@@ -117,9 +117,9 @@ AC_ARG_WITH([ca-bundle],
                   mbed TLS. If set "system", use system certificate store.]),
   [
     AS_CASE([$with_ca_bundle],
-	[no],     [AC_DEFINE([GAUCHE_CA_BUNDLE_NONE], 1, [Define if uses no CA])],
+	[no],     [AC_DEFINE([GAUCHE_CA_BUNDLE_NONE],   1, [Define if uses no CA])],
 	[system], [AC_DEFINE([GAUCHE_CA_BUNDLE_SYSTEM], 1, [Define if uses system CA])],
-                  [AC_DEFINE([GAUCHE_CA_BUNDLE_FILE], 1, [Define if file CA])
+                  [AC_DEFINE([GAUCHE_CA_BUNDLE_FILE],   1, [Define if file CA])
 	           AC_DEFINE_UNQUOTED([GAUCHE_CA_BUNDLE], ["$with_ca_bundle"], [CA file path])]
      )
   ], [

--- a/ext/tls/tls.ac
+++ b/ext/tls/tls.ac
@@ -86,7 +86,7 @@ AS_IF([echo $TLSLIBS | tr "," "\012" | grep -q mbedtls], [
   LIBS=${LIBS_SAVE}
   EXT_LIBS="$EXT_LIBS $MBEDTLS_LIBS"
 
-  AC_CHECK_HEADERS([wincrypt.h])
+  AC_CHECK_HEADERS([wincrypt.h], [], [], [@%:@include<windows.h>])
   AC_SEARCH_LIBS([CertOpenStore], [crypt32], [EXT_LIBS="${EXT_LIBS} -lcrypt32"])
 
   AS_IF([test "$mbedtls_unavailable" = yes], [

--- a/ext/tls/tls.ac
+++ b/ext/tls/tls.ac
@@ -114,7 +114,7 @@ AC_ARG_WITH([ca-bundle],
   AS_HELP_STRING([--with-ca-bundle=/path/to/ca-bundle.crt],
 		 [Specify the default CA certificate bundle file path for 
                   TLS certificate validation. This file is required to use 
-                  mbed TLS.]),
+                  mbed TLS. If set "system", use system certificate store.]),
   [
     AS_CASE([$with_ca_bundle],
 	[no],     [AC_DEFINE([GAUCHE_CA_BUNDLE_NONE], 1, [Define if uses no CA])],

--- a/ext/tls/tls.ac
+++ b/ext/tls/tls.ac
@@ -117,11 +117,13 @@ AC_ARG_WITH([ca-bundle],
                   mbed TLS.]),
   [
     AS_CASE([$with_ca_bundle],
-	[no], [AC_DEFINE([GAUCHE_CA_BUNDLE], [NULL])],
-              [AC_DEFINE_UNQUOTED([GAUCHE_CA_BUNDLE], ["$with_ca_bundle"], [CA file path])]
+	[no],     [AC_DEFINE([GAUCHE_CA_BUNDLE_NONE], 1, [Define if uses no CA])],
+	[system], [AC_DEFINE([GAUCHE_CA_BUNDLE_SYSTEM], 1, [Define if uses system CA])],
+                  [AC_DEFINE([GAUCHE_CA_BUNDLE_FILE], 1, [Define if file CA])
+	           AC_DEFINE_UNQUOTED([GAUCHE_CA_BUNDLE], ["$with_ca_bundle"], [CA file path])]
      )
   ], [
-    AC_DEFINE([GAUCHE_CA_BUNDLE], [NULL])
+    AC_DEFINE([GAUCHE_CA_BUNDLE_NONE], 1)
   ])
 
 dnl

--- a/ext/tls/tls.ac
+++ b/ext/tls/tls.ac
@@ -47,7 +47,7 @@ GAUCHE_TLS_SWITCH_MBEDTLS="@%:@"
 GAUCHE_TLS_SWITCH_NONE=
 
 dnl We bundle axTLS so it's always available.
-AS_IF([echo $TLSLIBS | tr "," "\012" | grep -q axtls], [
+AS_IF([echo $TLSLIBS | grep -F -w -q axtls], [
   AC_DEFINE(GAUCHE_USE_AXTLS, 1, [Define if you use axTLS])
   GAUCHE_TLS_SWITCH_AXTLS=
   GAUCHE_TLS_SWITCH_NONE="@%:@"
@@ -63,7 +63,7 @@ AS_IF([echo $TLSLIBS | tr "," "\012" | grep -q axtls], [
 ])
 
 dnl mbedtls
-AS_IF([echo $TLSLIBS | tr "," "\012" | grep -q mbedtls], [
+AS_IF([echo $TLSLIBS | grep -F -w -q mbedtls], [
   AC_CHECK_HEADER([mbedtls/net_sockets.h],
     [AC_DEFINE(HAVE_MBEDTLS_NET_SOCKETS_H, 1, 
                [Define to 1 if you have the <mbedtls/net_sockets.h> header file.])],

--- a/ext/tls/tls.ac
+++ b/ext/tls/tls.ac
@@ -86,6 +86,9 @@ AS_IF([echo $TLSLIBS | tr "," "\012" | grep -q mbedtls], [
   LIBS=${LIBS_SAVE}
   EXT_LIBS="$EXT_LIBS $MBEDTLS_LIBS"
 
+  AC_CHECK_HEADERS([wincrypt.h])
+  AC_SEARCH_LIBS([CertOpenStore], [crypt32], [EXT_LIBS="${EXT_LIBS} -lcrypt32"])
+
   AS_IF([test "$mbedtls_unavailable" = yes], [
     AC_MSG_NOTICE([Can't find mbedtls headers and/or libraries.])
     ],[

--- a/ext/tls/tls.ac
+++ b/ext/tls/tls.ac
@@ -117,13 +117,24 @@ AC_ARG_WITH([ca-bundle],
                   mbed TLS. If set "system", use system certificate store.]),
   [
     AS_CASE([$with_ca_bundle],
-	[no],     [AC_DEFINE([GAUCHE_CA_BUNDLE_NONE],   1, [Define if uses no CA])],
-	[system], [AC_DEFINE([GAUCHE_CA_BUNDLE_SYSTEM], 1, [Define if uses system CA])],
+        [no],     [AC_DEFINE([GAUCHE_CA_BUNDLE_NONE],   1, [Define if uses no CA])
+                   TLS_CA_TYPE=none
+                   TLS_CA_PATH=
+                  ],
+        [system], [AC_DEFINE([GAUCHE_CA_BUNDLE_SYSTEM], 1, [Define if uses system CA])
+                   TLS_CA_TYPE=system
+                   TLS_CA_PATH=
+                  ],
                   [AC_DEFINE([GAUCHE_CA_BUNDLE_FILE],   1, [Define if file CA])
-	           AC_DEFINE_UNQUOTED([GAUCHE_CA_BUNDLE], ["$with_ca_bundle"], [CA file path])]
+                   AC_DEFINE_UNQUOTED([GAUCHE_CA_BUNDLE], ["$with_ca_bundle"], [CA file path])
+                   TLS_CA_TYPE=file
+                   TLS_CA_PATH=$with_ca_bundle
+                  ]
      )
   ], [
     AC_DEFINE([GAUCHE_CA_BUNDLE_NONE], 1)
+    TLS_CA_TYPE=none
+    TLS_CA_PATH=
   ])
 
 dnl

--- a/ext/tls/tls.c
+++ b/ext/tls/tls.c
@@ -172,7 +172,15 @@ ScmObj Scm_TLSSocket(ScmTLS* t)
 
 static inline ScmObj default_ca_bundle(void)
 {
-    return GAUCHE_CA_BUNDLE ? SCM_MAKE_STR(GAUCHE_CA_BUNDLE) : SCM_FALSE;
+#if   defined GAUCHE_CA_BUNDLE_NONE
+    return SCM_FALSE;
+#elif defined GAUCHE_CA_BUNDLE_SYSTEM
+    return Scm_MakeSymbol(SCM_MAKE_STR("system"), TRUE);
+#elif defined GAUCHE_CA_BUNDLE_FILE
+    return SCM_MAKE_STR(GAUCHE_CA_BUNDLE);
+#else
+#error Unknown CA bundle
+#endif
 }
 
 void Scm_Init_tls(ScmModule *mod)

--- a/ext/tls/tls.c
+++ b/ext/tls/tls.c
@@ -170,6 +170,11 @@ ScmObj Scm_TLSSocket(ScmTLS* t)
     return t->sock;
 }
 
+static inline ScmObj default_ca_bundle(void)
+{
+    return GAUCHE_CA_BUNDLE ? SCM_MAKE_STR(GAUCHE_CA_BUNDLE) : SCM_FALSE;
+}
+
 void Scm_Init_tls(ScmModule *mod)
 {
     Scm_InitStaticClass(&Scm_TLSClass, "<tls>", mod, NULL, 0);
@@ -184,9 +189,7 @@ void Scm_Init_tls(ScmModule *mod)
 #endif
                                  &default_tls_class);
     Scm_DefinePrimitiveParameter(mod, "tls-ca-bundle-path",
-                                 (GAUCHE_CA_BUNDLE
-                                  ? SCM_MAKE_STR(GAUCHE_CA_BUNDLE)
-                                  : SCM_FALSE),
+                                 default_ca_bundle(),
                                  &ca_bundle_path);
     k_options = SCM_MAKE_KEYWORD("options");
     k_num_sessions = SCM_MAKE_KEYWORD("num-sessions");

--- a/ext/tls/tls.c
+++ b/ext/tls/tls.c
@@ -175,7 +175,7 @@ static inline ScmObj default_ca_bundle(void)
 #if   defined GAUCHE_CA_BUNDLE_NONE
     return SCM_FALSE;
 #elif defined GAUCHE_CA_BUNDLE_SYSTEM
-    return Scm_MakeSymbol(SCM_MAKE_STR("system"), TRUE);
+    return Scm_MakeSymbol(SCM_STRING(SCM_MAKE_STR("system")), TRUE);
 #elif defined GAUCHE_CA_BUNDLE_FILE
     return SCM_MAKE_STR(GAUCHE_CA_BUNDLE);
 #else

--- a/ext/tls/tls.c
+++ b/ext/tls/tls.c
@@ -172,11 +172,11 @@ ScmObj Scm_TLSSocket(ScmTLS* t)
 
 static inline ScmObj default_ca_bundle(void)
 {
-#if   defined GAUCHE_CA_BUNDLE_NONE
+#if   defined(GAUCHE_CA_BUNDLE_NONE)
     return SCM_FALSE;
-#elif defined GAUCHE_CA_BUNDLE_SYSTEM
+#elif defined(GAUCHE_CA_BUNDLE_SYSTEM)
     return Scm_MakeSymbol(SCM_STRING(SCM_MAKE_STR("system")), TRUE);
-#elif defined GAUCHE_CA_BUNDLE_FILE
+#elif defined(GAUCHE_CA_BUNDLE_FILE)
     return SCM_MAKE_STR(GAUCHE_CA_BUNDLE);
 #else
 #error Unknown CA bundle

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -106,7 +106,7 @@ PRECOMP_DEPENDENCY = precomp vminsn.scm ../lib/gauche/vm/insn.scm \
 
 # for cross build
 BUILD_CC     = @BUILD_CC@
-BUILD_CFLAGS = -O2 -I$(top_builddir)/src
+BUILD_CFLAGS = -O2 -I$(top_builddir)/src -I$(top_srcdir)/src
 
 # BUILD_GOSH is the gosh command used to generate some of the source files.
 # We need to 'preload' some libraries from the host's environment, for

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -106,7 +106,7 @@ PRECOMP_DEPENDENCY = precomp vminsn.scm ../lib/gauche/vm/insn.scm \
 
 # for cross build
 BUILD_CC     = @BUILD_CC@
-BUILD_CFLAGS = -O2
+BUILD_CFLAGS = -O2 -I$(top_srcdir)/src
 
 # BUILD_GOSH is the gosh command used to generate some of the source files.
 # We need to 'preload' some libraries from the host's environment, for

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -106,7 +106,7 @@ PRECOMP_DEPENDENCY = precomp vminsn.scm ../lib/gauche/vm/insn.scm \
 
 # for cross build
 BUILD_CC     = @BUILD_CC@
-BUILD_CFLAGS = -O2 -I$(top_srcdir)/src
+BUILD_CFLAGS = -O2 -I$(top_builddir)/src
 
 # BUILD_GOSH is the gosh command used to generate some of the source files.
 # We need to 'preload' some libraries from the host's environment, for

--- a/src/gauche/config.h.in
+++ b/src/gauche/config.h.in
@@ -20,6 +20,15 @@
 /* CA file path */
 #undef GAUCHE_CA_BUNDLE
 
+/* Define if file CA */
+#undef GAUCHE_CA_BUNDLE_FILE
+
+/* Define if uses no CA */
+#undef GAUCHE_CA_BUNDLE_NONE
+
+/* Define if uses system CA */
+#undef GAUCHE_CA_BUNDLE_SYSTEM
+
 /* Define if Gauche handles multi-byte character as EUC-JP */
 #undef GAUCHE_CHAR_ENCODING_EUC_JP
 

--- a/src/gauche/config.h.in
+++ b/src/gauche/config.h.in
@@ -17,6 +17,9 @@
 /* Gauche ABI version string */
 #undef GAUCHE_ABI_VERSION
 
+/* CA file path */
+#undef GAUCHE_CA_BUNDLE
+
 /* Define if Gauche handles multi-byte character as EUC-JP */
 #undef GAUCHE_CHAR_ENCODING_EUC_JP
 
@@ -438,6 +441,9 @@
 /* Define to 1 if you have the <util.h> header file. */
 #undef HAVE_UTIL_H
 
+/* Define to 1 if you have the <wincrypt.h> header file. */
+#undef HAVE_WINCRYPT_H
+
 /* Define if you have zlib.h and want to use it */
 #undef HAVE_ZLIB_H
 
@@ -502,9 +508,6 @@
 #  undef WORDS_BIGENDIAN
 # endif
 #endif
-
-/* CA bundle file path */
-#undef GAUCHE_CA_BUNDLE
 
 /* Enable large inode numbers on Mac OS X 10.5.  */
 #ifndef _DARWIN_USE_64_BIT_INODE

--- a/src/genconfig.in
+++ b/src/genconfig.in
@@ -236,6 +236,7 @@ static struct cmd_rec {
     { NULL, NULL }
 };
 
+#define GAUCHE_CONFIG_C
 #if (defined(__MINGW32__) || defined(_MSC_VER)) && defined(UNICODE)
 /* mbs <-> wcs stuff */
 #include "win-compat.c"

--- a/src/genconfig.in
+++ b/src/genconfig.in
@@ -255,6 +255,7 @@ static void errfn(const char *fmt, ...)
     exit(1);
 }
 
+#define GAUCHE_CONFIG_C
 #define PATH_ALLOC(n) malloc(n)
 #include "paths.c"
 
@@ -275,6 +276,7 @@ int main(int argc, char **argv)
 {
 #if (defined(__MINGW32__) || defined(_MSC_VER)) && defined(UNICODE)
     (void)&mbs2wcs; /* suppress unused function warning */
+    (void)&wcs2mbs;
 #endif /* (defined(__MINGW32__) || defined(_MSC_VER)) && defined(UNICODE) */
 
     if (argc < 2) usage();

--- a/src/genconfig.in
+++ b/src/genconfig.in
@@ -236,7 +236,6 @@ static struct cmd_rec {
     { NULL, NULL }
 };
 
-#define GAUCHE_CONFIG_C
 #if (defined(__MINGW32__) || defined(_MSC_VER)) && defined(UNICODE)
 /* mbs <-> wcs stuff */
 #include "win-compat.c"

--- a/src/getdir_win.c
+++ b/src/getdir_win.c
@@ -8,6 +8,21 @@
 
 #include <string.h>
 
+#ifndef GAUCHE_CONFIG_C
+static inline const char *__wcs2mbs(const WCHAR *s)
+{
+  return SCM_WCS2MBS(s);
+}
+#else
+static void errfn(const char *fmt, ...);
+static const char *wcs2mbs(const WCHAR *s, int use_gc,
+                           void (*errfn)(const char*, ...));
+static inline const char *__wcs2mbs(const WCHAR *s)
+{
+  return wcs2mbs(s, FALSE, errfn);
+}
+#endif
+
 static const char *get_install_dir(void (*errfn)(const char *msg, ...))
 {
     HMODULE mod;
@@ -26,11 +41,11 @@ static const char *get_install_dir(void (*errfn)(const char *msg, ...))
     }
     /* remove \libgauche.dll */
     if (!PathRemoveFileSpec(path)) {
-        errfn("PathRemoveFileSpec failed on %s", SCM_WCS2MBS(path));
+        errfn("PathRemoveFileSpec failed on %s", __wcs2mbs(path));
     }
     /* remove \bin */
     if (!PathRemoveFileSpec(path)) {
-        errfn("PathRemoveFileSpec failed on %s", SCM_WCS2MBS(path));
+        errfn("PathRemoveFileSpec failed on %s", __wcs2mbs(path));
     }
-    return SCM_WCS2MBS(path);
+    return __wcs2mbs(path);
 }

--- a/src/getdir_win.c
+++ b/src/getdir_win.c
@@ -8,21 +8,6 @@
 
 #include <string.h>
 
-#ifndef GAUCHE_CONFIG_C
-static inline const char *__wcs2mbs(const WCHAR *s)
-{
-  return SCM_WCS2MBS(s);
-}
-#else
-static void errfn(const char *fmt, ...);
-static const char *wcs2mbs(const WCHAR *s, int use_gc,
-                           void (*errfn)(const char*, ...));
-static inline const char *__wcs2mbs(const WCHAR *s)
-{
-  return wcs2mbs(s, FALSE, errfn);
-}
-#endif
-
 static const char *get_install_dir(void (*errfn)(const char *msg, ...))
 {
     HMODULE mod;
@@ -41,11 +26,11 @@ static const char *get_install_dir(void (*errfn)(const char *msg, ...))
     }
     /* remove \libgauche.dll */
     if (!PathRemoveFileSpec(path)) {
-        errfn("PathRemoveFileSpec failed on %s", __wcs2mbs(path));
+        errfn("PathRemoveFileSpec failed on %s", SCM_WCS2MBS(path));
     }
     /* remove \bin */
     if (!PathRemoveFileSpec(path)) {
-        errfn("PathRemoveFileSpec failed on %s", __wcs2mbs(path));
+        errfn("PathRemoveFileSpec failed on %s", SCM_WCS2MBS(path));
     }
-    return __wcs2mbs(path);
+    return SCM_WCS2MBS(path);
 }

--- a/src/paths.c
+++ b/src/paths.c
@@ -39,7 +39,9 @@
  */
 
 #define LIBGAUCHE_BODY
+#ifndef GAUCHE_CONFIG_C
 #include "gauche.h"
+#endif
 
 #if !defined(PATH_ALLOC)
 #define PATH_ALLOC(n)  SCM_MALLOC_ATOMIC(n)

--- a/src/paths.c
+++ b/src/paths.c
@@ -39,9 +39,7 @@
  */
 
 #define LIBGAUCHE_BODY
-#ifndef GAUCHE_CONFIG_C
 #include "gauche.h"
-#endif
 
 #if !defined(PATH_ALLOC)
 #define PATH_ALLOC(n)  SCM_MALLOC_ATOMIC(n)


### PR DESCRIPTION
Load CA certificates from system certificate store. See also #365 .
It works on Windows with mbed TLS.

Usage:
```sh
# Use configure script
./configure --with-ca-bundle=system
```
or
```scheme
;; Runtime configuration
(use rfc.tls)
(default-tls-class <mbed-tls>)
(tls-ca-bundle-path 'system)
```
