### PR TITLE
rfc: needs srfi

### DIFF
--- a/ext/Makefile.in
+++ b/ext/Makefile.in
@@ -54,7 +54,7 @@ bcrypt: mt-random
 
 dbm : threads
 
-rfc: gauche util
+rfc: gauche srfi util
 
 test : check
 


### PR DESCRIPTION
ext/rfc needs srfi-19 since version 0.9.5 and
https://github.com/shirok/Gauche/commit/bd22bc82361c5eeb5d3b58c3836236566746bb96

So add a dependency on srfi for rfc target in Makefile.in

Fixes:
 - http://autobuild.buildroot.org/results/f4935e29ce6aaebdaa47d46c56120b7e97145d1b

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>