### PR TITLE
Add datum->syntax for macro combination problem

### DIFF
--- a/src/compaux.c
+++ b/src/compaux.c
@@ -195,6 +195,7 @@ ScmObj Scm_MakeIdentifier(ScmObj name, ScmModule *mod, ScmObj env)
     id->name = name;
     id->module = mod? mod : SCM_CURRENT_MODULE();
     id->frames = Scm_Cons(SCM_FALSE, env); /* see the above comment */
+    id->renames = SCM_FALSE;
     return SCM_OBJ(id);
 }
 
@@ -248,7 +249,13 @@ ScmObj Scm_WrapIdentifier(ScmIdentifier *orig)
     id->name = SCM_OBJ(orig);
     id->module = orig->module;
     id->frames = orig->frames;
+    id->renames = orig->renames;
     return SCM_OBJ(id);
+}
+
+void Scm_IdentifierRenamesSet(ScmIdentifier *id, ScmObj renames)
+{
+    id->renames = renames;
 }
 
 static ScmObj identifier_name_get(ScmObj obj)
@@ -274,6 +281,11 @@ static ScmObj identifier_env_get(ScmObj obj)
     return Scm_IdentifierEnv(SCM_IDENTIFIER(obj));
 }
 
+static ScmObj identifier_renames_get(ScmObj obj)
+{
+    return SCM_OBJ(SCM_IDENTIFIER(obj)->renames);
+}
+
 /* Identifier name can be mutated during macro expansion to avoid
    conflicts on macro-inserted toplevel identifiers.  See
    %rename-toplevel-identifier! in compiler pass1.
@@ -282,6 +294,7 @@ static ScmClassStaticSlotSpec identifier_slots[] = {
     SCM_CLASS_SLOT_SPEC("name", identifier_name_get, identifier_name_set),
     SCM_CLASS_SLOT_SPEC("module", identifier_module_get, NULL),
     SCM_CLASS_SLOT_SPEC("env", identifier_env_get, NULL),
+    SCM_CLASS_SLOT_SPEC("renames", identifier_renames_get, NULL),
     SCM_CLASS_SLOT_SPEC_END()
 };
 

--- a/src/gauche/priv/identifierP.h
+++ b/src/gauche/priv/identifierP.h
@@ -41,6 +41,9 @@ struct ScmIdentifierRec {
     ScmObj name;          /* symbol or identifier */
     ScmModule *module;
     ScmObj frames;        /* opaque - see compaux.c for the details */
+    ScmObj renames;       /* EXPERIMENTAL: for datum->syntax */
+                          /*  list of alist (((var . identifier) ...)) */
+                          /*  or #f (default value) */
 };
 
 

--- a/src/gauche/vm.h
+++ b/src/gauche/vm.h
@@ -207,6 +207,7 @@ SCM_EXTERN ScmObj Scm_WrapIdentifier(ScmIdentifier *id);
 SCM_EXTERN int    Scm_IdentifierBindingEqv(ScmIdentifier *id,
                                            ScmSymbol *sym,
                                            ScmObj env);
+SCM_EXTERN void   Scm_IdentifierRenamesSet(ScmIdentifier *id, ScmObj renames);
 
 SCM_EXTERN ScmIdentifier *Scm_OutermostIdentifier(ScmIdentifier *id);
 SCM_EXTERN ScmSymbol     *Scm_UnwrapIdentifier(ScmIdentifier *id);

--- a/src/libsym.scm
+++ b/src/libsym.scm
@@ -154,6 +154,10 @@
   (return (SCM_OBJ (-> id name))))
 (define-cproc identifier-env (id::<identifier>)
   (return (Scm_IdentifierEnv id)))
+(define-cproc identifier-renames (id::<identifier>)
+  (return (SCM_OBJ (-> id renames))))
+(define-cproc identifier-renames-set! (id::<identifier> renames) ::<void>
+  (set! (-> id renames) renames))
 
 (select-module gauche.internal)
 ;; EXPERIMENTAL


### PR DESCRIPTION
datum->syntax を追加してみました。
これによって、er-macro と syntax-rules の組み合わせで
unbound variable が発生するケースを、
解決できるようになります。
(テストケース datum->syntax 1, datum->syntax 2)

実装については、identifier に リネームの辞書情報 を追加しました。
また、リネームの辞書情報については、alist をさらに list で囲うようにして、
alist に変更があっても、各 identifier 間で情報を共有できるようにしました。
また、これに伴い、er-rename も、(values id dict) ではなく id だけを返すようにしました。

これで方向性として正しいのかが、気になりますが。。。
R7RS large のマクロシステムとか、どこかで議論されているのでしょうか。。。

＜関連URL＞
https://practical-scheme.net/wiliki/wiliki.cgi?Scheme%3Aer-macro%E9%96%A2%E9%80%A3


＜テスト結果＞
OS : Windows 8.1 (64bit)
Gauche : コミット 1338ef6 + (src/paths.c 一部変更) + 変更

開発環境1 : MSYS2/MinGW-w64 (64bit) (gcc version 7.3.0 (Rev2, Built by MSYS2 project))
Total: 19433 tests, 19433 passed,     0 failed,     0 aborted.
