### PR TITLE
Enable IPv6 support by default on Windows

### DIFF
--- a/src/mingw-dist.sh
+++ b/src/mingw-dist.sh
@@ -101,7 +101,7 @@ fi
 if [ "$SKIP_CONFIG" != yes ]; then
   rm -rf $distdir
   ./configure --prefix=$distdir --enable-threads=win32 \
-              --enable-multibyte=utf8 --enable-ipv6=no \
+              --enable-multibyte=utf8 --enable-ipv6=yes \
 	      --with-tls=axtls \
               --with-dbm=ndbm,odbm $buildopt
 fi


### PR DESCRIPTION
src/mingw-dist.sh で IPv6 のサポートを有効にしました。

また、過去との互換性を考えて、Windows の場合には、
make-sockaddrs が ipv4 アドレス を ipv6 アドレス より先に返すようにしました。
(ext/net/netaux.scm)

関連URL
https://practical-scheme.net/wiliki/wiliki.cgi?Gauche%3ABugs


＜テスト結果＞
OS : Windows 8.1 (64bit)
Gauche : コミット 36c0abb + 変更

開発環境1 : MSYS2/MinGW-w64 (64bit) (gcc version 7.3.0 (Rev2, Built by MSYS2 project))
Total: 19513 tests, 19513 passed,     0 failed,     0 aborted.
