### PR TITLE
Workaround for GC 7.6 and 8.0

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -77,8 +77,8 @@ GAUCHE_VERSION     = @GAUCHE_VERSION@
 GAUCHE_ABI_VERSION = @GAUCHE_ABI_VERSION@
 
 # Main definition of compilation commands
-ATOMIC_OPS_CFLAGS = `${srcdir}/get-atomic-ops-flags.sh ${top_builddir} --cflags`
-ATOMIC_OPS_LIBS = `${srcdir}/get-atomic-ops-flags.sh ${top_builddir} --libs`
+ATOMIC_OPS_CFLAGS = `${srcdir}/get-atomic-ops-flags.sh ${top_builddir} ${top_srcdir} --cflags`
+ATOMIC_OPS_LIBS = `${srcdir}/get-atomic-ops-flags.sh ${top_builddir} ${top_srcdir} --libs`
 COMPILE   = $(CC) $(DEFS) $(INCLUDES) $(CPPFLAGS) $(CFLAGS) $(OPTFLAGS)
 MKINSTDIR = $(top_srcdir)/mkinstalldirs
 CCLD      = $(LINK_HELPER) $(CC)
@@ -237,7 +237,7 @@ libgauche_OBJECTS = \
 libgauche_LDFLAGS = $(SONAME_FLAG) @SHLIB_DYLIB_LDFLAGS@
 
 libgc_pic_OBJECTS = $(wildcard $(top_builddir)/gc/.libs/*.$(OBJEXT)) \
-                    $(top_builddir)/gc/extra/.libs/gc.$(OBJEXT) \
+                    $(wildcard $(top_builddir)/gc/extra/.libs/gc.$(OBJEXT)) \
                     $(wildcard $(top_builddir)/gc/libatomic_ops/src/.libs/*.$(OBJEXT))
 libgc_pic_LIBRARY = libgc_pic.a
 

--- a/src/get-atomic-ops-flags.sh
+++ b/src/get-atomic-ops-flags.sh
@@ -15,12 +15,12 @@ fi
 case $option in
     --cflags)
         cflags=`sed -n -e 's@ATOMIC_OPS_CFLAGS =\(.*\)@\1@p' $gc_makefile`
-        sed_text1='s@$(top_builddir)@'
-        sed_text2="${top_builddir}/gc@"
-        cflags=`echo "$cflags" | sed -e "$sed_text1$sed_text2"`
-        sed_text1='s@$(top_srcdir)@'
-        sed_text2="${top_srcdir}/gc@"
-        cflags=`echo "$cflags" | sed -e "$sed_text1$sed_text2"`
+        sed_text1='$(top_builddir)'
+        sed_text2=`echo "${top_builddir}/gc" | sed -e 's/[\@&]/\\&/g'`
+        cflags=`echo "$cflags" | sed -e "s@$sed_text1@$sed_text2@"`
+        sed_text1='$(top_srcdir)'
+        sed_text2=`echo "${top_srcdir}/gc" | sed -e 's/[\@&]/\\&/g'`
+        cflags=`echo "$cflags" | sed -e "s@$sed_text1@$sed_text2@"`
         if grep 'define GC_BUILTIN_ATOMIC' $gc_config > /dev/null; then
             cflags="-DGC_BUILTIN_ATOMIC $cflags"
         fi

--- a/src/get-atomic-ops-flags.sh
+++ b/src/get-atomic-ops-flags.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
 top_builddir=$1
-option=$2
+top_srcdir=$2
+option=$3
 
 gc_makefile=${top_builddir}/gc/Makefile
 gc_config=${top_builddir}/gc/include/config.h
@@ -14,6 +15,12 @@ fi
 case $option in
     --cflags)
         cflags=`sed -n -e 's@ATOMIC_OPS_CFLAGS =\(.*\)@\1@p' $gc_makefile`
+        sed_text1='s@$(top_builddir)@'
+        sed_text2="${top_builddir}/gc@"
+        cflags=`echo "$cflags" | sed -e "$sed_text1$sed_text2"`
+        sed_text1='s@$(top_srcdir)@'
+        sed_text2="${top_srcdir}/gc@"
+        cflags=`echo "$cflags" | sed -e "$sed_text1$sed_text2"`
         if grep 'define GC_BUILTIN_ATOMIC' $gc_config > /dev/null; then
             cflags="-DGC_BUILTIN_ATOMIC $cflags"
         fi
@@ -23,7 +30,7 @@ case $option in
         sed -n -e 's@ATOMIC_OPS_LIBS =\(.*\)@\1@p' $gc_makefile
         ;;
     *)
-        echo "Usage: get-atomic-ops-flags.sh TOP_BUILDDIR --cflags|--libs"
+        echo "Usage: get-atomic-ops-flags.sh TOP_BUILDDIR TOP_SRCDIR --cflags|--libs"
         exit 1
         ;;
 esac


### PR DESCRIPTION
gc-7.6.10 + libatomic_ops-7.6.8 に差し替えたときにエラーになる部分を、
取り急ぎ対策しました。

- src/get-atomic-ops-flags.sh
  - cflags の文字列内の $(top_builddir) と $(top_srcdir) が Makefile 中で展開されず、
    エラーになったため対策。また 展開したディレクトリに /gc を追加
  - 引数に TOP_SRCDIR を追加

- src/Makefile.in
  - get-atomic-ops-flags.sh の引数に TOP_SRCDIR を追加
  - libgc_pic_OBJECTS の gc/extra の項目に wildcard 指定を追加

＜参考URL＞
http://practical-scheme.net/wiliki/wiliki.cgi?Gauche%3ABugs
(32bit版の Windows で GC 8.0 の動作が不安定 (0.9.7 リリースより後の HEAD))

＜テスト結果＞
OS : Windows 8.1 (64bit)
Gauche : コミット 66344a6 + 変更

開発環境1 : MSYS2/MinGW-w64 (64bit) (gcc version 7.3.0 (Rev2, Built by MSYS2 project))
Total: 19554 tests, 19554 passed,     0 failed,     0 aborted.

開発環境2 : MSYS2/MinGW-w64 (32bit) (gcc version 7.3.0 (Rev2, Built by MSYS2 project))
ビルドエラー
Fatal error in GC「Unexpected mark stack overflow」
以下の箇所で発生することが多い
"../../src/gosh" -ftest -l./adaptor -E "import sxml.adaptor" -E 'provide "sxml/adaptor"' ../../src/precomp -e -i ssax.sci -o sxml--ssax sxml-ssax.scm

開発環境2 : MSYS2/MinGW-w64 (32bit) (gcc version 7.3.0 (Rev2, Built by MSYS2 project))
gc-7.6.10 + libatomic_ops-7.6.8 に差し替え
Total: 19554 tests, 19554 passed,     0 failed,     0 aborted.
