### PR TITLE
Add AppVeyor setting for MSYS2/MinGW-w64

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ environment:
   matrix:
     - TARGET: MINGW64
     - TARGET: MINGW32
+  GAUCHE_INFO_URL: https://practical-scheme.net/gauche/releases
 
 for:
   -
@@ -15,8 +16,8 @@ for:
     environment:
       MSYSTEM: MINGW64
       PATH: C:\msys64\mingw64\bin;C:\msys64\usr\local\bin;C:\msys64\usr\bin;C:\msys64\bin;%PATH%
-      GAUCHE_INSTALLER: Gauche-mingw-0.9.7-64bit.msi
-      GAUCHE_INSTALLER_URL: http://prdownloads.sourceforge.net/gauche/
+      GAUCHE_INSTALLER_BIT: 64bit
+      GAUCHE_INSTALLER_URL: http://prdownloads.sourceforge.net/gauche
       GAUCHE_PATH: C:\Program Files\Gauche\bin
       RESULT_ZIP: Gauche-x86_64.zip
       RESULT_PATH: ..\Gauche-mingw-dist\Gauche-x86_64
@@ -27,8 +28,8 @@ for:
     environment:
       MSYSTEM: MINGW32
       PATH: C:\msys64\mingw32\bin;C:\msys64\usr\local\bin;C:\msys64\usr\bin;C:\msys64\bin;%PATH%
-      GAUCHE_INSTALLER: Gauche-mingw-0.9.7-32bit.msi
-      GAUCHE_INSTALLER_URL: http://prdownloads.sourceforge.net/gauche/
+      GAUCHE_INSTALLER_BIT: 32bit
+      GAUCHE_INSTALLER_URL: http://prdownloads.sourceforge.net/gauche
       GAUCHE_PATH: C:\Program Files (x86)\Gauche\bin
       RESULT_ZIP: Gauche-i686.zip
       RESULT_PATH: ..\Gauche-mingw-dist\Gauche-i686
@@ -39,7 +40,11 @@ install:
 #  - echo %PATH%
 #  - cd
 #  - dir
-  - curl -f -L --progress-bar -o %GAUCHE_INSTALLER% %GAUCHE_INSTALLER_URL%%GAUCHE_INSTALLER%
+  - for /f "usebackq delims=" %%i in (`curl -f %GAUCHE_INFO_URL%/latest.txt 2^>nul`) do set GAUCHE_INSTALLER_VERSION=%%i
+  - echo %GAUCHE_INSTALLER_VERSION%
+  - set GAUCHE_INSTALLER=Gauche-mingw-%GAUCHE_INSTALLER_VERSION%-%GAUCHE_INSTALLER_BIT%.msi
+  - echo %GAUCHE_INSTALLER%
+  - curl -f -L --progress-bar -o %GAUCHE_INSTALLER% %GAUCHE_INSTALLER_URL%/%GAUCHE_INSTALLER%
   - msiexec /i %GAUCHE_INSTALLER% /quiet /qn /norestart
   - set PATH=%PATH%;%GAUCHE_PATH%
 #  - echo %PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,62 @@
+#branches:
+#  only:
+#    - master
+
+environment:
+  matrix:
+    - TARGET: MINGW64
+    - TARGET: MINGW32
+
+for:
+  -
+    matrix:
+      only:
+        - TARGET: MINGW64
+    environment:
+      MSYSTEM: MINGW64
+      PATH: C:\msys64\mingw64\bin;C:\msys64\usr\local\bin;C:\msys64\usr\bin;C:\msys64\bin;%PATH%
+      GAUCHE_INSTALLER: Gauche-mingw-0.9.7-64bit.msi
+      GAUCHE_INSTALLER_URL: http://prdownloads.sourceforge.net/gauche/
+      GAUCHE_PATH: C:\Program Files\Gauche\bin
+      RESULT_ZIP: Gauche-x86_64.zip
+      RESULT_PATH: ..\Gauche-mingw-dist\Gauche-x86_64
+  -
+    matrix:
+      only:
+        - TARGET: MINGW32
+    environment:
+      MSYSTEM: MINGW32
+      PATH: C:\msys64\mingw32\bin;C:\msys64\usr\local\bin;C:\msys64\usr\bin;C:\msys64\bin;%PATH%
+      GAUCHE_INSTALLER: Gauche-mingw-0.9.7-32bit.msi
+      GAUCHE_INSTALLER_URL: http://prdownloads.sourceforge.net/gauche/
+      GAUCHE_PATH: C:\Program Files (x86)\Gauche\bin
+      RESULT_ZIP: Gauche-i686.zip
+      RESULT_PATH: ..\Gauche-mingw-dist\Gauche-i686
+
+install:
+#  - echo %TARGET%
+#  - echo %MSYSTEM%
+#  - echo %PATH%
+#  - cd
+#  - dir
+  - curl -f -L --progress-bar -o %GAUCHE_INSTALLER% %GAUCHE_INSTALLER_URL%%GAUCHE_INSTALLER%
+  - msiexec /i %GAUCHE_INSTALLER% /quiet /qn /norestart
+  - set PATH=%PATH%;%GAUCHE_PATH%
+#  - echo %PATH%
+  - gosh -V
+
+build_script:
+  - bash -lc "gcc -v"
+  - bash -lc "pwd"
+  - bash -lc "cd $APPVEYOR_BUILD_FOLDER && ./DIST gen"
+  - bash -lc "cd $APPVEYOR_BUILD_FOLDER && src/mingw-dist.sh"
+
+after_build:
+  - 7z a %RESULT_ZIP% %RESULT_PATH%
+
+test_script:
+  - bash -lc "cd $APPVEYOR_BUILD_FOLDER && make check"
+
+artifacts:
+  - path: Gauche-*.zip
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ environment:
     - TARGET: MINGW64
     - TARGET: MINGW32
   GAUCHE_INFO_URL: https://practical-scheme.net/gauche/releases
+  GAUCHE_INSTALLER_URL: https://prdownloads.sourceforge.net/gauche
 
 for:
   -
@@ -17,7 +18,6 @@ for:
       MSYSTEM: MINGW64
       PATH: C:\msys64\mingw64\bin;C:\msys64\usr\local\bin;C:\msys64\usr\bin;C:\msys64\bin;%PATH%
       GAUCHE_INSTALLER_BIT: 64bit
-      GAUCHE_INSTALLER_URL: http://prdownloads.sourceforge.net/gauche
       GAUCHE_PATH: C:\Program Files\Gauche\bin
       RESULT_ZIP: Gauche-x86_64.zip
       RESULT_PATH: ..\Gauche-mingw-dist\Gauche-x86_64
@@ -29,7 +29,6 @@ for:
       MSYSTEM: MINGW32
       PATH: C:\msys64\mingw32\bin;C:\msys64\usr\local\bin;C:\msys64\usr\bin;C:\msys64\bin;%PATH%
       GAUCHE_INSTALLER_BIT: 32bit
-      GAUCHE_INSTALLER_URL: http://prdownloads.sourceforge.net/gauche
       GAUCHE_PATH: C:\Program Files (x86)\Gauche\bin
       RESULT_ZIP: Gauche-i686.zip
       RESULT_PATH: ..\Gauche-mingw-dist\Gauche-i686


### PR DESCRIPTION
AppVeyor の設定を追加してみました。
MSYS2/MinGW-w64 (64bit/32bit) 環境でビルドとテストを行い、
成果物として Gauche-x86_64.zip と Gauche-i686.zip を生成します。
(ただ、現状、Gauche-i686.zip の生成には失敗しています)

実行状況は以下で確認できます。
https://ci.appveyor.com/project/Hamayama/gauche

状態表示の URL は以下になります。
https://ci.appveyor.com/api/projects/status/github/Hamayama/Gauche?branch=appveyor&svg=true

最新の成果物の URL は以下になります。
＜64bit＞
https://ci.appveyor.com/api/projects/Hamayama/gauche/artifacts/Gauche-x86_64.zip?branch=appveyor&job=Environment%3A%20TARGET%3DMINGW64&all=true
＜32bit＞
https://ci.appveyor.com/api/projects/Hamayama/gauche/artifacts/Gauche-i686.zip?branch=appveyor&job=Environment%3A%20TARGET%3DMINGW32&all=true
(ただ、現状、Gauche-i686.zip の生成には失敗しています)

appveyor.yml についてですが、現状、2個の job を設定しています。

job が 2個以上ある場合、最新の成果物の URL にアクセスするには、
「job name」をパラメータとして渡す必要があります。
その「job name」を短くするために、for を使って設定を分けています。
(こうしないと、job name が `Environment: TARGET=MINGW32, MSYSTEM=MINGW32, ...`
のように すごく長くなって、はまりました)

元リポジトリの方でも AppVeyor に登録していただけるとうれしいですが、
保守の手間等が発生するかもしれないので、判断はおまかせします。
(基本的には、必要なユーザが fork して登録すれば、使えると思います)
