### PR TITLE
Link examples/mqueue-cpp to gauche-dev.texi

### DIFF
--- a/doc/gauche-dev.texi
+++ b/doc/gauche-dev.texi
@@ -399,6 +399,8 @@ or
 @node Real-life examples, C API reference, Fundamental concepts, Top
 @chapter Real-life examples
 
+To be written. Meanwhile have a look at @file{examples/mqueue-cpp/README.adoc}
+in the Gauche source tree.
 
 @c ======================================================================
 @node C API reference, Creating new Scheme datatypes, Real-life examples, Top

--- a/examples/mqueue-cpp/README.adoc
+++ b/examples/mqueue-cpp/README.adoc
@@ -103,7 +103,7 @@ wrapped in `ScmForeignPointer.`  'Unboxing' is to retrieve the {cpp}
 [source,c++]
 ----
 #define MQUEUE_P(obj)      SCM_XTYPEP(obj, MQueueClass)
-#define MQUEUE_UNBOX(obj)  ((MQueue*)(SCM_FOREIGN_POINTER_REF(obj)))
+#define MQUEUE_UNBOX(obj)  SCM_FOREIGN_POINTER_REF(MQueue*, obj)
 #define MQUEUE_BOX(ptr)    Scm_MakeForeignPointer(MQueueClass, ptr)
 ----
 


### PR DESCRIPTION
The README file for mqueue-cpp is pretty good and could really help a
new extension writer. There are a couple deprecated parts in the
README. But let's leave them for now.

While at there, fix a code snippet (I did try it :)