### PR TITLE
Make define-cfn accept :extern for forward decl generation

### DIFF
--- a/doc/modgauche.texi
+++ b/doc/modgauche.texi
@@ -1970,8 +1970,15 @@ Conditional expression.
 Useful to  place a type name, e.g. an argument of sizeof operator.
 @end defspec
 
-@defspec define-cfn NAME (ARG @dots{}) [RET-TYPE [QUALIFIER @dots{}]] STMT @dots{}
-Define a C function. Supported qualifiers are :static and :inline.
+@defspec define-cfn @var{name} (@var{arg} [:: @var{type}] @dots{}) [@var{ret-type} [@var{qualiter} @dots{}]] @var{stmt} @dots{}
+Defines a C function.
+
+If @var{type} or @var{ret-type} is omitted, the default type is
+@code{ScmObj}.
+
+Supported qualifiers are @code{:static}, @code{:inline} and
+@code{:extern}.  @code{:extern} is a special case for generating
+forward function declaration only and must have no @var{STMT}.
 @end defspec
 
 @defspec .static-decls

--- a/ext/bcrypt/bcrypt.scm
+++ b/ext/bcrypt/bcrypt.scm
@@ -13,11 +13,16 @@
 (select-module crypt.bcrypt)
 
 (inline-stub
- "extern char *crypt_ra(const char *key, const char *setting,
-                        void **data, int *size);
-  extern char *crypt_gensalt_ra(const char *prefix, unsigned long count,
-                                const char *input, int size);
-  "
+ (define-cfn crypt_ra (key::(const char *)
+                       setting::(const char *)
+                       data::void**
+                       size::int*)
+   ::char* :extern)
+ (define-cfn crypt_gensalt_ra (prefix::(const char *)
+                               count::(unsigned long)
+                               input::(const char *)
+                               size::int)
+   ::char* :extern)
 
  (define-cproc crypt-ra (pass::<const-cstring> setting::<const-cstring>)
    (let* ([data::void* NULL] [size::int 0]

--- a/ext/fcntl/fcntl.scm
+++ b/ext/fcntl/fcntl.scm
@@ -108,5 +108,5 @@
 
 (inline-stub
  (define-cproc sys-fcntl (port-or-fd op::<fixnum> :optional arg) Scm_SysFcntl)
- (declcode "extern void Scm_Init_fcntl(void);")
+ (define-cfn Scm_Init_fcntl () ::void :extern)
  (initcode (Scm_Init_fcntl)))

--- a/ext/net/netlib.scm
+++ b/ext/net/netlib.scm
@@ -413,9 +413,9 @@
 ;; IPv6 routines
 
 (inline-stub 
-(declcode "extern ScmObj addrinfo_allocate(ScmClass *klass, ScmObj initargs);")
+ (define-cfn addrinfo_allocate (klass::ScmClass* intargs) :extern)
 
-(if "defined HAVE_IPV6"
+ (if "defined HAVE_IPV6"
     (begin
       (define-type <sys-addrinfo> "ScmSysAddrinfo*" #f
         "SCM_SYS_ADDRINFO_P" "SCM_SYS_ADDRINFO")

--- a/ext/threads/threads.scm
+++ b/ext/threads/threads.scm
@@ -57,15 +57,15 @@
 (select-module gauche.threads)
 
 (inline-stub
- "#include \"threads.h\""
-
  (declcode
-  "extern void Scm_Init_mutex(ScmModule*);"
-  "extern void Scm_Init_threads(ScmModule*);")
+  (.include "threads.h"))
+
+ (define-cfn Scm_Init_mutex (mod::ScmModule*) ::void :extern)
+ (define-cfn Scm_Init_threads (mod::ScmModule*) ::void :extern)
 
  (initcode
-  "Scm_Init_threads(Scm_CurrentModule());"
-  "Scm_Init_mutex(Scm_CurrentModule());"))
+  (Scm_Init_threads (Scm_CurrentModule))
+  (Scm_Init_mutex (Scm_CurrentModule))))
 
 ;;===============================================================
 ;; System query

--- a/lib/gauche/cgen/cise.scm
+++ b/lib/gauche/cgen/cise.scm
@@ -454,7 +454,8 @@
     (intersperse " "
                  (map (^[qual] (ecase qual
                                  [(:static) "static"]
-                                 [(:inline) "inline"]))
+                                 [(:inline) "inline"]
+                                 [(:extern) "extern"]))
                       (reverse quals))))
 
   (define (gen-cfn name quals args rettype body)
@@ -486,12 +487,24 @@
        (check-quals name `(:static ,@quals) args ret-type body)]
       [(':inline . body)
        (check-quals name `(:inline ,@quals) args ret-type body)]
+      [(':extern . body)
+       (check-quals name `(:extern ,@quals) args ret-type body)]
       [((? keyword? z) . body)
        (errorf "Invalid qualifier in define-cfn ~s: ~s" name z)]
       [_
-       (when (memq :static quals)
-         (record-static name quals args ret-type))
-       (gen-cfn name quals args ret-type body)]))
+       (if (memq :extern quals)
+           (begin
+             (unless (null? body)
+               (errorf "extern define-cfn ~s must not have a body" name))
+             (when (or (memq :static quals) (memq :inline quals))
+               (errorf "define-cfn ~s cannot have both extern and static/inline" name))
+             (record-static name quals args ret-type)
+             ;; no function implementation
+             '())
+           (begin
+             (when (memq :static quals)
+               (record-static name quals args ret-type))
+             (gen-cfn name quals args ret-type body)))]))
 
   (ensure-toplevel-ctx form env)
   (match form

--- a/test/cgen.scm
+++ b/test/cgen.scm
@@ -94,6 +94,8 @@ some_trick();
   (c '(define-cfn a () :inline) "inline ScmObj a(){{}}")
   (c '(define-cfn a () :static :inline)
      "static inline ScmObj a(){{}}")
+  (c '(define-cfn a () :extern) "")
+  (c '(define-cfn a () :extern (return 0)) err)
   (c '(define-cfn a () :unknown) err)
   (c '(define-cfn a () ::foo) " foo a(){{}}")
   (c '(define-cfn a () ::(foo bar)) " foo bar a(){{}}")


### PR DESCRIPTION
There is no way currently to write a forward function declaration in sexp. One would have to fall back to write a C fragment, which is not as nice.

`define-cfn` seems like the best place to add support for this since it already knows how to generate forward declaration and we do not need to introduce another form just for this.

A few extensions are updated to take advantage of this change.