### PR TITLE
Add more CiSE forms

### DIFF
--- a/doc/modgauche.texi
+++ b/doc/modgauche.texi
@@ -1830,9 +1830,13 @@ and also it keeps track of forward declarations.
 Code grouping with @{ and @}
 @end defspec
 
-@defspec let* ((VAR [:: TYPE] [INIT-EXPR]) @dots{}) STMT @dots{}
-Declare and optionally assign initial values to local variables. If
-TYPE is omitted, the default type is ScmObj.
+@defspec let* ((@var{name} [:: @var{type}] [@var{init-expr}]) @dots{}) @var{stmt} @dots{}
+Declare and optionally assign initial values to local variables.
+
+If @var{type} is omitted, the default type is
+@code{ScmObj}. @var{type} of an array is in the form @code{(.array
+@var{elem-type} (@var{size} @dots{}))}. Note that array initialization
+is not supported yet.
 @end defspec
 
 @defspec if TEST-EXPR THEN-STMT [ELSE-STMT]

--- a/lib/gauche/cgen/cise.scm
+++ b/lib/gauche/cgen/cise.scm
@@ -917,6 +917,24 @@
                      '("#endif\n" |#reset-line|)
                      condition stmts))]))
 
+;; [cise toplevel/stmt] .define NAME [EXPR]
+;; [cise toplevel/stmt] .define NAME (ARGS...) EXPR
+;;   c preprocessor define directive
+
+;; Note that "#define abc(a,b)" (i.e. no EXPR) cannot be generated
+;; because it's ambiguous with "#define abc a(b)".
+(define-cise-macro (.define form env)
+  (ensure-stmt-or-toplevel-ctx form env)
+  (match form
+    [(_ name) `("#define " ,(x->string name) "\n" |#reset-line|)]
+    [(_ name (args ...) expr) `("#define " ,(x->string name)
+                                "(" ,(intersperse "," (map x->string args)) ")"
+                                " (" ,(render-rec expr (expr-env env)) ")"
+                                "\n" |#reset-line|)]
+    [(_ name expr) `("#define " ,(x->string name)
+                     " (" ,(render-rec expr (expr-env env)) ")"
+                     "\n" |#reset-line|)]))
+
 ;; [cise toplevel/stmt] .undef NAME
 ;;   c preprocessor undefine directive
 (define-cise-macro (.undef form env)

--- a/lib/gauche/cgen/cise.scm
+++ b/lib/gauche/cgen/cise.scm
@@ -883,7 +883,7 @@
 ;; Preprocessor directives
 ;;
 
-;; [cise stmt] .if STRING STMT [STMT]
+;; [cise toplevel/stmt] .if STRING STMT [STMT]
 ;;   c preprocessor directive
 (define-cise-macro (.if form env)
   (ensure-stmt-or-toplevel-ctx form env)
@@ -901,7 +901,7 @@
        ,(render-rec stmt2 env) "\n"
        "#endif /* " ,(x->string condition) " */\n" |#reset-line|)]))
 
-;; [cise stmt] .cond CLAUSE [CLAUSE]
+;; [cise toplevel/stmt] .cond CLAUSE [CLAUSE]
 ;;   c preprocessor if/elif/endif chain directive
 (define-cise-macro (.cond form env)
   (ensure-stmt-or-toplevel-ctx form env)
@@ -917,14 +917,14 @@
                      '("#endif\n" |#reset-line|)
                      condition stmts))]))
 
-;; [cise stmt] .undef NAME
+;; [cise toplevel/stmt] .undef NAME
 ;;   c preprocessor undefine directive
 (define-cise-macro (.undef form env)
   (ensure-stmt-or-toplevel-ctx form env)
   (match form
     [(_ name) `("#undef " ,(x->string name) "\n" |#reset-line|)]))
 
-;; [cise stmt] .include PATH
+;; [cise toplevel/stmt] .include PATH
 ;;   c preprocessor include directive
 (define-cise-macro (.include form env)
   (ensure-stmt-or-toplevel-ctx form env)

--- a/lib/gauche/cgen/cise.scm
+++ b/lib/gauche/cgen/cise.scm
@@ -503,6 +503,57 @@
      (check-quals name '() (canonicalize-argdecl args) 'ScmObj body)]))
 
 ;;------------------------------------------------------------
+;; Global variable definition
+;;
+
+;; (define-cvar <name> [::<type>] [<qualifiers>...] [<init>])
+
+(define-cise-macro (define-cvar form env)
+  (define (gen-qualifiers quals)
+    (intersperse " "
+                 (map (^[qual] (ecase qual
+                                      [(:static) "static"]
+                                      [(:extern) "extern"]))
+                      (reverse quals))))
+
+  (define (gen-cvar var type quals has-init? init)
+    `(,@(gen-qualifiers quals) " "
+      ,(cise-render-typed-var type var env)
+      ,@(cond-list [has-init? `(" = ",(render-rec init (expr-env env)))])
+      ";"))
+
+  (define (check-quals var type quals init-and-quals)
+    (match init-and-quals
+      [(':static . init-and-quals)
+       (check-quals var type `(:static ,@quals) init-and-quals)]
+      [(':extern . init-and-quals)
+       (check-quals var type `(:extern ,@quals) init-and-quals)]
+      [((? keyword? z) . body)
+       (errorf "Invalid qualifier in define-cvar ~s: ~s" var z)]
+      [()
+       (gen-cvar var type quals #f #f)]
+      [(init)
+       (gen-cvar var type quals #t init)]
+      [else
+       (errorf "Invalid syntax in define-cvar ~s: ~s" var init-and-quals)]))
+
+  ;; Note, technically an extern declaration can appear in stmt scope
+  ;; too. But it's not worth supporting.
+  (ensure-toplevel-ctx form env)
+
+  (let* ([canon (car (canonicalize-vardecl (list (cdr form))))]
+         [var (car canon)]
+         [spec (cdr canon)])
+    (receive (type init-and-quals)
+        (match spec
+          [()         (values 'ScmObj '())]
+          [('::)      (errorf "invalid variable decl in let* form: (~s ~s)" var spec)]
+          [(':: type) (values type '())]
+          [(':: type . init-and-quals) (values type init-and-quals)]
+          [else (values 'ScmObj spec)])
+      (check-quals var type '() init-and-quals))))
+
+;;------------------------------------------------------------
 ;; CPS transformation
 ;;
 ;;  (define-cproc ...

--- a/test/cgen.scm
+++ b/test/cgen.scm
@@ -123,6 +123,17 @@ some_trick();
   (c '(define-cvar foo :extern) "extern ScmObj foo;")
   (c '(define-cvar foo :static 10) "static ScmObj foo = 10;"))
 
+;; .define
+(parameterize ([cise-emit-source-line #f])
+  (define (c form exp)
+    (test* (format "cise transform: ~a" form) exp
+           (cise-render-to-string form 'toplevel)))
+
+  (c '(.define foo) "#define foo\n")
+  (c '(.define foo (+ 2 3)) "#define foo ((2)+(3))\n")
+  (c '(.define foo (bar) (+ 2 3)) "#define foo(bar) ((2)+(3))\n")
+  (c '(.define foo (a b) (+ a b)) "#define foo(a,b) ((a)+(b))\n"))
+
 ;; statement-level tests
 (parameterize ([cise-emit-source-line #f])
   (define (c form exp)

--- a/test/cgen.scm
+++ b/test/cgen.scm
@@ -100,6 +100,29 @@ some_trick();
   (c '(define-cfn a (b c::int))
      " ScmObj a(ScmObj b,int c){{}}"))
 
+;; define-cvar
+(parameterize ([cise-emit-source-line #f])
+  (define (c form exp)
+    (test* (format "cise transform: ~a" form) exp
+           (cise-render-to-string form 'toplevel)))
+
+  (c '(define-cvar foo) " ScmObj foo;")
+  (c '(define-cvar foo::int) " int foo;")
+  (c '(define-cvar foo:: int) " int foo;")
+  (c '(define-cvar foo :: int) " int foo;")
+  (c '(define-cvar foo::(const char *)) " const char * foo;")
+  (c '(define-cvar foo:: (.array int (10))) " int foo[10];")
+
+  (c '(define-cvar foo 10) " ScmObj foo = 10;")
+  (c '(define-cvar foo::int 10) " int foo = 10;")
+  (c '(define-cvar foo:: int 10) " int foo = 10;")
+  (c '(define-cvar foo :: int 10) " int foo = 10;")
+  (c '(define-cvar foo::(const char *) NULL) " const char * foo = NULL;")
+  (c '(define-cvar foo::int (+ 2 3)) " int foo = (2)+(3);")
+
+  (c '(define-cvar foo :extern) "extern ScmObj foo;")
+  (c '(define-cvar foo :static 10) "static ScmObj foo = 10;"))
+
 ;; statement-level tests
 (parameterize ([cise-emit-source-line #f])
   (define (c form exp)

--- a/test/cgen.scm
+++ b/test/cgen.scm
@@ -123,6 +123,35 @@ some_trick();
   (c '(define-cvar foo :extern) "extern ScmObj foo;")
   (c '(define-cvar foo :static 10) "static ScmObj foo = 10;"))
 
+;; define-crec
+(parameterize ([cise-emit-source-line #f])
+  (define (c form exp)
+    (test* (format "cise transform: ~a" form)
+           (apply string-append
+                  (map (cut string-append <> "\n") exp))
+           (cise-render-to-string form 'toplevel)))
+
+  (c '(define-crec foo (abc def) :: struct)
+     '("struct foo {" "ScmObj abc;" "ScmObj def;" "};"))
+  (c '(define-crec foo (abc::int def::char) ::struct)
+     '("struct foo {" "int abc;" "char def;" "};"))
+  (c '(define-crec foo (abc def) :: union)
+     '("union foo {" "ScmObj abc;" "ScmObj def;" "};"))
+  (c '(define-crec foo (abc::(.array int (10)) def) ::union)
+     '("union foo {" "int abc[10];" "ScmObj def;" "};"))
+  (c '(define-crec foo (abc def))
+     '("struct foo {" "ScmObj abc;" "ScmObj def;" "};"))
+  (c '(define-crec foo (abc def) :typedef :: struct)
+     '("typedef struct {" "ScmObj abc;" "ScmObj def;" "} foo;"))
+  (c '(define-crec foo (abc def) :typedef ::struct)
+     '("typedef struct {" "ScmObj abc;" "ScmObj def;" "} foo;"))
+  (c '(define-crec foo (abc def) :typedef :: union)
+     '("typedef union {" "ScmObj abc;" "ScmObj def;" "} foo;"))
+  (c '(define-crec foo (abc def) :typedef ::union)
+     '("typedef union {" "ScmObj abc;" "ScmObj def;" "} foo;"))
+  (c '(define-crec foo (abc def) :typedef)
+     '("typedef struct {" "ScmObj abc;" "ScmObj def;" "} foo;")))
+
 ;; .define
 (parameterize ([cise-emit-source-line #f])
   (define (c form exp)


### PR DESCRIPTION
CiSE is great! But still there are areas where you have to write in C fragments. This PR adds three more forms to cover `#define`, struct/union and global var definitions. I think the only missing piece to comfortably live inside CiSE is array/struct initialization.

Three three forms are

```
(define-cvar <name>[::<type>] [<qualifiers>..] [<init-expr>])
(define-crec <name> (<field-spec>...) [:typedef] [::struct | ::union]
(.define <name> [(<args>..)] [<init-expr>])
```

I did not update the document yet because I think these forms may change. This is just a suggestion. Once they are settled, I'll update docs too. So what do you think?

PS. With #430 introducing `declare-cfn`, we might want `declare-cvar` too (instead of reusing `define-cvar` with `:extern`).