### PR TITLE
Workaround for GC 8.0 on MSYS2/MinGW-w64 32bit

### DIFF
--- a/gc/mark.c
+++ b/gc/mark.c
@@ -1605,7 +1605,8 @@ GC_INNER void GC_push_all_stack(ptr_t bottom, ptr_t top)
 #         if defined(THREADS) && defined(MPROTECT_VDB)
             && !GC_auto_incremental
 #         endif
-         ) {
+          && (word)GC_mark_stack_top
+             < (word)(GC_mark_stack_limit - INITIAL_MARK_STACK_SIZE/8)) {
         GC_push_all(bottom, top);
       } else
 #   endif


### PR DESCRIPTION
GC 8.0 が MSYS2/MinGW-w64 32bit 環境で動作するようにするための修正になります。

以下の内容を反映しました。
https://github.com/ivmai/bdwgc/issues/260

ただ、テスト中に別の問題が見つかっていて、そちらは未解決です。
https://github.com/ivmai/bdwgc/issues/262
(Gauche の動作とは関係ないかもしれません)


＜テスト結果＞
https://ci.appveyor.com/project/Hamayama/gauche/builds/21798895

＜成果物＞
64bit: Gauche-x86_64.zip
https://ci.appveyor.com/project/Hamayama/gauche/builds/21798895/job/og8vc5qsnngdcmkd/artifacts
32bit: Gauche-i686.zip
https://ci.appveyor.com/project/Hamayama/gauche/builds/21798895/job/ubpc1q1ts3ebe301/artifacts
(ただし、6ヵ月で消えるとのこと。。。)
