### PR TITLE
Add u8vector hash support

### DIFF
--- a/lib/gauche/computil.scm
+++ b/lib/gauche/computil.scm
@@ -122,7 +122,8 @@
 (define uvector-comparator
   (make-comparator/compare uvector? equal? compare hash 'uvector-comparator))
 (define bytevector-comparator
-  (make-comparator/compare (cut is-a? <> <u8vector>) equal? compare hash
+  ;; u8vector hash support
+  (make-comparator/compare (cut is-a? <> <u8vector>) equal? compare default-hash
                            'bytevector-comparator))
 
 (define (make-pair-comparator car-comparator cdr-comparator)

--- a/src/hash.c
+++ b/src/hash.c
@@ -230,6 +230,20 @@ static u_long internal_string_hash(ScmString *str, u_long salt, int portable)
     }
 }
 
+/* u8vector hash support */
+static u_long internal_u8vector_hash(ScmUVector *u, u_long salt, int portable)
+{
+    if (portable) {
+        return (u_long)Scm__DwSipPortableHash(SCM_U8VECTOR_ELEMENTS(u),
+                                              (uint32_t)SCM_U8VECTOR_SIZE(u),
+                                              salt, salt);
+    } else {
+        return Scm__DwSipDefaultHash(SCM_U8VECTOR_ELEMENTS(u),
+                                     (uint32_t)SCM_U8VECTOR_SIZE(u),
+                                     salt, salt);
+    }
+}
+
 /* equal-hash, which satisfies
      forall x, y: equal(x,y) => hash(x) = hash(y)
   
@@ -263,6 +277,10 @@ static u_long equal_hash_common(ScmObj obj, u_long salt, int portable)
             h = COMBINE(h, h2);
         }
         return h;
+    /* u8vector hash support */
+    } else if (SCM_UVECTORP(obj) &&
+               Scm_UVectorType(Scm_ClassOf(obj)) == SCM_UVECTOR_U8) {
+        return internal_u8vector_hash(SCM_UVECTOR(obj), salt, portable);
 #if GAUCHE_KEEP_DISJOINT_KEYWORD_OPTION
     } else if (SCM_KEYWORDP(obj)) {
         if (portable) {

--- a/test/hash.scm
+++ b/test/hash.scm
@@ -5,6 +5,7 @@
 (use gauche.test)
 (use srfi-1)
 (use srfi-13)
+(use gauche.uvector)
 
 ;; Note: test/object.scm contains extra tests of hashtables using
 ;; object-equal? and object-hash overload.
@@ -55,6 +56,15 @@
          (map (^p (list (car p)
                         (portable-hash (car p) 0)
                         (hash (car p))))
+              data)))
+
+;; u8vector hash support
+(let ([data '((#u8(0)     241632508)
+              (#u8(255)   1279917403)
+              (#u8(1 2 3) 3864380406))])
+  (test* "portable hash u8vector" data
+         (map (^p (list (car p)
+                        (portable-hash (car p) 0)))
               data)))
 
 ;;------------------------------------------------------------------
@@ -293,8 +303,15 @@
          (hash-table-put! h-equal (vector (cons 'a 'b) 3+3i) 61)
          (length (hash-table-keys h-equal))))
 
+;; u8vector hash support
+(test* "equal? test" 9
+       (begin
+         (hash-table-put! h-equal (u8vector (char->integer #\d)) 70)
+         (hash-table-put! h-equal (u8vector (char->integer #\d)) 71)
+         (length (hash-table-keys h-equal))))
+
 (test* "hash-table-values(3)" #t
-       (lset= equal? (hash-table-values h-equal) '(8 "b" #\c -1 "E" 5 7 61)))
+       (lset= equal? (hash-table-values h-equal) '(8 "b" #\c -1 "E" 5 7 61 71)))
 
 (test* "delete!" #f
        (begin


### PR DESCRIPTION
u8vector を、ハッシュテーブル (make-hash-table 'equal?) の
キーに使えるようにしてみました。

また、bytevector-comparator もハッシュテーブルの比較器として使えるようにしました。

正直、comparator のことが、よく分かっていない気がしますが。。。

(vector-comparator 等が default-hash ではなく hash を使っているのは、
過去との互換性のためでしょうか?)


＜テスト結果＞
https://ci.appveyor.com/project/Hamayama/gauche/builds/21905540
