### PR TITLE
Allow to put define-ctype in non-toplevel.

### DIFF
--- a/lib/gauche/cgen/cise.scm
+++ b/lib/gauche/cgen/cise.scm
@@ -528,13 +528,13 @@
 ;; (define-ctype <name> [::<type>])
 
 (define-cise-macro (define-cvar form env)
-  (expand-cvar form env))
+  (expand-cvar form env #t))
 (define-cise-macro (declare-cvar form env)
-  (expand-cvar form env))
+  (expand-cvar form env #t))
 (define-cise-macro (define-ctype form env)
-  (expand-cvar form env))
+  (expand-cvar form env #f))
 
-(define (expand-cvar form env)
+(define (expand-cvar form env ensure-toplevel?)
   (define (gen-qualifiers quals)
     (intersperse " "
                  (map (^[qual] (ecase qual
@@ -576,7 +576,8 @@
 
   ;; Note, technically an extern declaration can appear in stmt scope
   ;; too. But it's not worth supporting.
-  (ensure-toplevel-ctx form env)
+  (when ensure-toplevel?
+    (ensure-toplevel-ctx form env))
 
   (let* ([canon (car (canonicalize-vardecl (list (cdr form))))]
          [var (car canon)]


### PR DESCRIPTION
"typedef" is one of declarations so that it can be in non-toplevel. However, ensure-toplevel-ctx in define-ctype doesn't allow to use it in non-toplevel. This ensure-toplevel-ctx also doesn't allow to use the defined type in args of define-cfn with \:static like this.

` 
;; define-ctype can't be put in declcode by ensure-toplevel-ctx.
(define-ctype Foo::int))

;; "static Foo foo_add(Foo a, Foo b)" will be placed before "typedef int Foo;".
(define-cfn foo_add (a::Foo b::Foo) ::Foo :static
    (return (+ a b))))
`

I think it is better not to check toplevel in define-ctype. WDYT?
