### PR TITLE
Workaround for GC on Windows WOW64

### DIFF
--- a/gc/misc.c
+++ b/gc/misc.c
@@ -817,9 +817,7 @@ GC_API int GC_CALL GC_is_init_called(void)
 #endif
 
 #if defined(MSWIN32) && !defined(MSWINRT_FLAVOR) && !defined(MSWIN_XBOX1) \
-    && (!defined(SMALL_CONFIG) \
-        || (!defined(_WIN64) && defined(GC_WIN32_THREADS) \
-            && defined(CHECK_NOT_WOW64)))
+    && !defined(SMALL_CONFIG)
   STATIC void GC_win32_MessageBoxA(const char *msg, const char *caption,
                                    unsigned flags)
   {
@@ -923,30 +921,6 @@ GC_API void GC_CALL GC_init(void)
       initial_heap_sz = GC_INITIAL_HEAP_SIZE;
 #   else
       initial_heap_sz = MINHINCR * HBLKSIZE;
-#   endif
-
-#   if defined(MSWIN32) && !defined(_WIN64) && defined(GC_WIN32_THREADS) \
-       && defined(CHECK_NOT_WOW64)
-      {
-        /* Windows: running 32-bit GC on 64-bit system is broken!       */
-        /* WoW64 bug affects SuspendThread, no workaround exists.       */
-        HMODULE hK32 = GetModuleHandle(TEXT("kernel32.dll"));
-        if (hK32) {
-          FARPROC pfn = GetProcAddress(hK32, "IsWow64Process");
-          BOOL bIsWow64 = FALSE;
-          if (pfn
-              && (*(BOOL (WINAPI*)(HANDLE, BOOL*))pfn)(GetCurrentProcess(),
-                                                       &bIsWow64)
-              && bIsWow64) {
-            GC_win32_MessageBoxA("This program uses BDWGC garbage collector"
-                " compiled for 32-bit but running on 64-bit Windows.\n"
-                "This is known to be broken due to a design flaw"
-                " in Windows itself! Expect erratic behavior...",
-                "32-bit program running on 64-bit system",
-                MB_ICONWARNING | MB_OK);
-          }
-        }
-      }
 #   endif
 
     DISABLE_CANCEL(cancel_state);

--- a/gc/win32_threads.c
+++ b/gc/win32_threads.c
@@ -1386,6 +1386,10 @@ static GC_bool may_be_in_stack(ptr_t s)
           && !(last_info.Protect & PAGE_GUARD);
 }
 
+#if defined(I386)
+  static BOOL isWow64;  /* Is running 32-bit code on Win64?     */
+#endif
+
 STATIC word GC_push_stack_for(GC_thread thread, DWORD me)
 {
   ptr_t sp, stack_min;
@@ -1399,7 +1403,22 @@ STATIC word GC_push_stack_for(GC_thread thread, DWORD me)
               /* Use saved sp value for blocked threads. */
     /* For unblocked threads call GetThreadContext().   */
     CONTEXT context;
-    context.ContextFlags = CONTEXT_INTEGER|CONTEXT_CONTROL;
+#   if defined(I386)
+#     ifndef CONTEXT_EXCEPTION_ACTIVE
+#       define CONTEXT_EXCEPTION_ACTIVE    0x08000000
+#       define CONTEXT_EXCEPTION_REQUEST   0x40000000
+#       define CONTEXT_EXCEPTION_REPORTING 0x80000000
+#     endif
+
+      if (isWow64) {
+        context.ContextFlags = CONTEXT_INTEGER | CONTEXT_CONTROL
+                                | CONTEXT_EXCEPTION_REQUEST
+                                | CONTEXT_SEGMENTS;
+      } else
+#   endif
+    /* else */ {
+      context.ContextFlags = CONTEXT_INTEGER | CONTEXT_CONTROL;
+    }
     if (!GetThreadContext(THREAD_HANDLE(thread), &context))
       ABORT("GetThreadContext failed");
 
@@ -1411,7 +1430,45 @@ STATIC word GC_push_stack_for(GC_thread thread, DWORD me)
 #   define PUSH4(r1,r2,r3,r4) (PUSH2(r1,r2), PUSH2(r3,r4))
 #   if defined(I386)
       PUSH4(Edi,Esi,Ebx,Edx), PUSH2(Ecx,Eax), PUSH1(Ebp);
-      sp = (ptr_t)context.Esp;
+      /* WoW64 workaround. */
+      if (isWow64
+          && (context.ContextFlags & CONTEXT_EXCEPTION_REPORTING) != 0
+          && (context.ContextFlags & (CONTEXT_EXCEPTION_ACTIVE
+                                      /* | CONTEXT_SERVICE_ACTIVE */)) != 0) {
+        LDT_ENTRY selector;
+        PNT_TIB tib;
+
+        if (!GetThreadSelectorEntry(THREAD_HANDLE(thread), context.SegFs,
+                                    &selector))
+          ABORT("GetThreadSelectorEntry failed");
+        tib = (PNT_TIB)(selector.BaseLow
+                        | (selector.HighWord.Bits.BaseMid << 16)
+                        | (selector.HighWord.Bits.BaseHi << 24));
+        /* GetThreadContext() might return stale register values, so    */
+        /* we scan the entire stack region (down to the stack limit).   */
+        /* There is no 100% guarantee that all the registers are pushed */
+        /* but we do our best (the proper solution would be to fix it   */
+        /* inside Windows OS).                                          */
+        sp = (ptr_t)tib->StackLimit;
+#       ifdef DEBUG_THREADS
+          GC_log_printf("TIB stack limit/base: %p .. %p\n",
+                        (void *)tib->StackLimit, (void *)tib->StackBase);
+#       endif
+        GC_ASSERT(!((word)thread->stack_base
+                    COOLER_THAN (word)tib->StackBase));
+      } else {
+#       ifdef DEBUG_THREADS
+          {
+            static GC_bool logged;
+            if (isWow64 && !logged
+                && (context.ContextFlags & CONTEXT_EXCEPTION_REPORTING) == 0) {
+              GC_log_printf("CONTEXT_EXCEPTION_REQUEST not supported\n");
+              logged = TRUE;
+            }
+          }
+#       endif
+        sp = (ptr_t)context.Esp;
+      }
 #   elif defined(X86_64)
       PUSH4(Rax,Rcx,Rdx,Rbx); PUSH2(Rbp, Rsi); PUSH1(Rdi);
       PUSH4(R8, R9, R10, R11); PUSH4(R12, R13, R14, R15);
@@ -2444,6 +2501,20 @@ GC_INNER void GC_thr_init(void)
 #     endif
       /* else */ if (GC_handle_fork != -1)
         ABORT("pthread_atfork failed");
+    }
+# endif
+
+# if defined(I386)
+    /* Set isWow64 flag. */
+    {
+      HMODULE hK32 = GetModuleHandle(TEXT("kernel32.dll"));
+      if (hK32) {
+        FARPROC pfn = GetProcAddress(hK32, "IsWow64Process");
+        if (pfn
+            && !(*(BOOL (WINAPI*)(HANDLE, BOOL*))pfn)(GetCurrentProcess(),
+                                                      &isWow64))
+          isWow64 = FALSE; /* IsWow64Process failed */
+      }
     }
 # endif
 


### PR DESCRIPTION
GC の以下の件を反映しました。
https://github.com/ivmai/bdwgc/issues/262

関連プルリクエスト #438

＜説明＞
Windows の WOW64 (64bit の Windows で、32bit の exe を実行する仕組み) 上で、
Windows API の GetThreadContext が古いレジスタ値を返すことがあり、
そのために gctest で エラーが起きることがありました。
(必要なデータが GC に回収されてしまい、壊れたりするようです)

発生の頻度は、環境にもよりますが、gctest 100-1000 回に数回程度です。
(GC_suspend 100000-1000000 回に数回程度)

発生するのは、64bit の Windows で、32bit版 の Gauche を実行した場合のみです。
(GC の問題というよりは、Windows の WOW64 の問題になります。
かなり前から存在し、MS も把握はしているが、根本的な修正はされていないようです)

対策としては、GetThreadContext の結果が使えないときには、
スタック領域全体のスキャンを行うように変更しています。

＜テスト結果＞
https://ci.appveyor.com/project/Hamayama/gauche/builds/22239758
