### PR TITLE
Fix the invalid reference to uvector-ref in gauche/cgen/literal.scm.

### DIFF
--- a/lib/gauche/cgen/literal.scm
+++ b/lib/gauche/cgen/literal.scm
@@ -720,7 +720,7 @@
       (print (uvector-class->c-type-name class)" "(~ self'elements)"[] = {")
       (dotimes [i (uvector-length value)]
         ($ uvector-class-emit-elt class
-           $ (with-module gauche.internal %uvector-ref)
+           $ (with-module gauche.internal uvector-ref)
              value (uvector-class->type-enum class) i))
       (print  "};"))]
   [static (self) #f]


### PR DESCRIPTION
The error like this happens when precomp gets code which contains uvector. 

```
*** ERROR: unbound variable: %uvector-ref
Stack Trace:
_______________________________________
  0  ((with-module gauche.internal %uvector-ref) value (uvector-cl ...
        [unknown location]
  1  ((with-module gauche.internal %uvector-ref) value (uvector-cl ...
        [unknown location]
  2  (uvector-class-emit-elt class ((with-module gauche.internal % ...
        expanded from ($ uvector-class-emit-elt class $ (with-module gauche.intern
        at "/home/naoki/.local/share/gauche-0.97/0.9.8_pre1/lib/gauche/cgen/literal.scm":722
  3  (do ((limit (uvector-length value)) (i 0 (+ i 1))) ((>= i lim ...
        expanded from (dotimes (i (uvector-length value)) ($ uvector-class-emit-el
        at "/home/naoki/.local/share/gauche-0.97/0.9.8_pre1/lib/gauche/cgen/literal.scm":721
  4  (gf node)
        at "/home/naoki/.local/share/gauche-0.97/0.9.8_pre1/lib/gauche/cgen/unit.scm":226
  5  (cgen-emit-part unit 'decl)
        at "/home/naoki/.local/share/gauche-0.97/0.9.8_pre1/lib/gauche/cgen/unit.scm":133
  6  (with-output-to-port port thunk)
        at "/home/naoki/.local/share/gauche-0.97/0.9.8_pre1/lib/gauche/cgen/unit.scm":333
  7  (cgen-emit-c (cgen-current-unit))
        at "/home/naoki/.local/share/gauche-0.97/0.9.8_pre1/lib/gauche/cgen/precomp.scm":235
  8  (do-it)
        at "/home/naoki/.local/share/gauche-0.97/0.9.8_pre1/lib/gauche/cgen/precomp.scm":259
  9  (call-with-output-file out.sci (^p (display ";; generated aut ...
        at "/home/naoki/.local/share/gauche-0.97/0.9.8_pre1/lib/gauche/cgen/precomp.scm":255
 10  (apply %cgen-precompile src keys)
        at "/home/naoki/.local/share/gauche-0.97/0.9.8_pre1/lib/gauche/cgen/precomp.scm":158
 11  (cgen-precompile src :out.c out.c :out.sci (or out.sci ext-mo ...
        at "/home/naoki/.local/share/gauche-0.97/0.9.8_pre1/lib/precomp":73
```
This pull request fixes the invalid reference.
