### PR TITLE
Fix utility scripts test on Windows

### DIFF
--- a/lib/gauche/process.scm
+++ b/lib/gauche/process.scm
@@ -392,12 +392,12 @@
       (case dir
         [(< > >>)
          (cond [(string? arg) (do-file dir fd arg)]
+               [(eq? arg :null) (do-file dir fd *nulldev*)]
                [(symbol? arg)
                 (receive (in out) (sys-pipe)
                   (if (eq? dir '<)
                     (do-pipe fd arg #t in out)
                     (do-pipe fd arg #f out in)))]
-               [(eq? arg :null) (do-file dir fd *nulldev*)]
                [(or (port? arg) (integer? arg)) (push! iomap `(,fd . ,arg))]
                [else (error "invalid entry in process redirection" r)])]
         [(<< <<<)


### PR DESCRIPTION
utility scripts のテストを修正/変更しました。

- precomp の compile and dynload のテストでエラーになっていたため修正
  - fix-path を追加
  - メインプロセスで foo.dll を load すると、foo.dll が消せなくなったため、
    サブプロセスを run-process で起動して、そちらで load するようにした

- configure のテストを Windows でも実行できるようにした
  - env を使わずに sys-setenv で PATH の追加と復帰を行うようにした
  - run-process の :null の判定処理が symbol? より後なので、
    GAUCHE_KEYWORD_IS_SYMBOL が有効だと、判定できなくなっていたため、
    symbol? より前に移動した (lib/gauche/process.scm)
  - wrap-with-test-directory にディレクトリの指定の引数を追加した


＜テスト結果＞
https://ci.appveyor.com/project/Hamayama/gauche/builds/23490206
