### PR TITLE
Fix srfi-144 (flonum) on MinGW 32bit

### DIFF
--- a/ext/srfi/srfi-144.scm
+++ b/ext/srfi/srfi-144.scm
@@ -157,7 +157,8 @@
 (define-inline (flexponent x) (logb x))
 (define-inline (flinteger-exponent x) (ilogb x))
 (define-inline (flnormalized-fraction-exponent x) (frexp x))
-(define-cproc flsign-bit (x::<real>) ::<int> :constant :fast-flonum signbit)
+(define-cproc flsign-bit (x::<real>) ::<int> :constant :fast-flonum
+  (return (?: (signbit x) 1 0)))
 
 ;;;
 ;;; predicates
@@ -186,9 +187,9 @@
 (define-inline (flnan? x) (nan? x))
 
 (define-cproc flnormalized? (x::<real>) ::<boolean> :constant :fast-flonum
-  (return (== (fpclassify x) FP_NORMAL)))
+  (return (== (Scm_FlonumClassify x) FP_NORMAL)))
 (define-cproc fldenormalized? (x::<real>) ::<boolean> :constant :fast-flonum
-  (return (== (fpclassify x) FP_SUBNORMAL)))
+  (return (== (Scm_FlonumClassify x) FP_SUBNORMAL)))
 
 ;;;
 ;;; Arithmetic

--- a/src/gauche/number.h
+++ b/src/gauche/number.h
@@ -249,6 +249,7 @@ SCM_EXTERN double Scm_GetDouble(ScmObj obj);
 SCM_EXTERN ScmObj Scm_DecodeFlonum(double d, int *exp, int *sign);
 SCM_EXTERN double Scm_EncodeFlonum(ScmObj mant, int exp, int sign);
 SCM_EXTERN int    Scm_FlonumSign(double d);
+SCM_EXTERN int    Scm_FlonumClassify(double d);
 SCM_EXTERN ScmObj Scm_MakeFlonumToNumber(double d, int exactp);
 SCM_EXTERN double       Scm_HalfToDouble(ScmHalfFloat v);
 SCM_EXTERN ScmHalfFloat Scm_DoubleToHalf(double v);

--- a/src/libnum.scm
+++ b/src/libnum.scm
@@ -84,7 +84,7 @@
 (define-cproc -zero?    (x::<number>) ::<boolean> :fast-flonum :constant
   (return (and (SCM_FLONUMP x)          ;only flonums have -0.0
                (== (SCM_FLONUM_VALUE x) 0.0)
-               (== (signbit (SCM_FLONUM_VALUE x)) 1))))
+               (!= (signbit (SCM_FLONUM_VALUE x)) 0))))
 
 (define-cproc exact-integer? (obj) ::<boolean> :fast-flonum :constant
   SCM_INTEGERP)

--- a/src/number.c
+++ b/src/number.c
@@ -430,6 +430,16 @@ int Scm_FlonumSign(double d)
     return signbit(d)? -1 : 1;
 }
 
+/* On MinGW 32bit, fpclassify function is broken. */
+int Scm_FlonumClassify(double d)
+{
+#if defined(__MINGW32__) && !defined(__MINGW64__)
+    return __builtin_fpclassify(FP_INFINITE, FP_NAN, FP_NORMAL, FP_SUBNORMAL, FP_ZERO, d);
+#else
+    return fpclassify(d);
+#endif
+}
+
 /* Half float support */
 
 double Scm_HalfToDouble(ScmHalfFloat v)


### PR DESCRIPTION
MinGW の 32bit環境で、srfi-144 (flonum) のテストが 5件 エラーになっていたため修正しました。

```
Testing extension srfi modules ...                               failed.
discrepancies found.  Errors are:
test (flsign-bit negzero): expects 1 => got 512
test (flsign-bit (flonum -2)): expects 1 => got 512
test (flsign-bit neginf): expects 1 => got 512
test (flnormalized? fl-least): expects #f => got #t
test (fldenormalized? fl-least): expects #t => got #f
```

- signbit 関数で、引数が負のときの戻り値が 1 でなく 非0 だったため修正

- MinGW の 32bit環境で、fpclassify 関数がバグっていたため、
  `__builtin_fpclassify` 関数を使うようにした。

＜参考URL＞
http://practical-scheme.net/wiliki/wiliki.cgi?Gauche%3ABugs
(MinGW-w64 (32bit) 環境で srfi-144 (flonum) のテストエラー (0.9.8_pre1))

＜テスト結果＞
https://ci.appveyor.com/project/Hamayama/gauche/builds/23894118
