### PR TITLE
Fix ssltest.exe hangs when MinGW's openssl.exe exists

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,3 @@
-#branches:
-#  only:
-#    - master
-
 environment:
   matrix:
     - TARGET: MINGW64
@@ -37,8 +33,7 @@ install:
 #  - echo %TARGET%
 #  - echo %MSYSTEM%
 #  - echo %PATH%
-#  - cd
-#  - dir
+  - cd
   - for /f "usebackq delims=" %%i in (`curl -f %GAUCHE_INFO_URL%/latest.txt 2^>nul`) do set GAUCHE_INSTALLER_VERSION=%%i
   - echo %GAUCHE_INSTALLER_VERSION%
   - set GAUCHE_INSTALLER=Gauche-mingw-%GAUCHE_INSTALLER_VERSION%-%GAUCHE_INSTALLER_BIT%.msi
@@ -48,10 +43,13 @@ install:
   - set PATH=%PATH%;%GAUCHE_PATH%
 #  - echo %PATH%
   - gosh -V
+  - bash -lc "pacman -S --noconfirm msys/winpty"
+  - bash -lc "winpty --version"
 
 build_script:
-  - bash -lc "gcc -v"
   - bash -lc "pwd"
+  - bash -lc "echo $APPVEYOR_BUILD_FOLDER"
+  - bash -lc "gcc -v"
   - bash -lc "cd $APPVEYOR_BUILD_FOLDER && ./DIST gen"
   - bash -lc "cd $APPVEYOR_BUILD_FOLDER && src/mingw-dist.sh"
 
@@ -63,4 +61,5 @@ test_script:
 
 artifacts:
   - path: Gauche-*.zip
+#  - path: ext/tls/ssltest.log
 

--- a/ext/tls/test.scm
+++ b/ext/tls/test.scm
@@ -82,7 +82,7 @@
                        :wait #t)))
 
   ;; On MSYS (mintty), winpty with '-Xallow-non-tty' option changes tty
-  ;; setting so that we should reset it.
+  ;; setting, so that we should reset it.
   (cond-expand
    [gauche.os.windows (sys-system "stty sane")]
    [else])

--- a/ext/tls/test.scm
+++ b/ext/tls/test.scm
@@ -53,7 +53,24 @@
         (print "#!/bin/sh")
         (print "set -e")
         (print #"echo \"$$\" \"~|openssl-cmd|\" >> openssl.pid")
-        (print #"exec \"~|openssl-cmd|\" \"$@\"")))
+        (cond-expand
+         [gauche.os.windows
+          ;; MinGW's openssl.exe needs winpty only when stdin is terminal.
+          ;; (MSYS's openssl.exe doesn't need this workaround.)
+          (print  "mingw_workaround=no")
+          (print  "case \"$MSYSTEM\" in")
+          (print  "    MINGW64|MINGW32)")
+          (print #"        if echo `/usr/bin/which \"~|openssl-cmd|\" || :` | grep -q -E \"/mingw(64|32)\"; then")
+          (print  "            mingw_workaround=yes")
+          (print  "        fi;;")
+          (print  "esac")
+          (print  "if [ \"$mingw_workaround\" = yes -a -t 0 ]; then")
+          (print #"    exec winpty -Xallow-non-tty -Xplain \"~|openssl-cmd|\" \"$@\"")
+          (print  "else")
+          (print #"    exec \"~|openssl-cmd|\" \"$@\"")
+          (print  "fi")]
+         [else
+          (print #"exec \"~|openssl-cmd|\" \"$@\"")])))
     (sys-chmod "kick_openssl.sh" #o755))
 
   (test* "ssltest" 0
@@ -63,6 +80,12 @@
                        :directory "axTLS/ssl"
                        :output "ssltest.log"
                        :wait #t)))
+
+  ;; On MSYS (mintty), winpty with '-Xallow-non-tty' option changes tty
+  ;; setting so that we should reset it.
+  (cond-expand
+   [gauche.os.windows (sys-system "stty sane")]
+   [else])
   ]
  [else])
 


### PR DESCRIPTION
MinGW の openssl.exe が存在すると、
axTLS の ssltest.exe のテストで固まる件に対応してみました。
(関連 https://github.com/shirok/Gauche/pull/467#issuecomment-487252768)

固まる openssl.exe は以下のものになります。
C:\msys64\mingw64\bin\openssl.exe
C:\msys64\mingw32\bin\openssl.exe
(バージョンを 1.0.2 から 1.1.1b に更新しても同じでした)

以下の openssl.exe は固まりません (MSYSのもの)。
C:\msys64\usr\bin\openssl.exe
(バージョンを 1.0.2 から 1.1.1b に更新しても同じでした)

また、AppVeyor 上のテストでは固まらないことから、
mintty 上でテストしているときにのみ固まると思われます。

それで、探したところ、以下の情報がありました。
1. https://stackoverflow.com/questions/9450120/openssl-hangs-and-does-not-exit
   (winpty をかませると固まらない)

2. https://github.com/rprichard/winpty/issues/103
   (winpty は、-Xallow-non-tty -Xplain オプションを付けると、
   標準出力のリダイレクトに対応できる)

3. https://github.com/rprichard/winpty/issues/101
   (winpty は、標準入力のリダイレクトには対応できないため、
   `if [ -t 0 ]; then` を使って判別して、
   リダイレクトがないときだけ winpty をかませるようにする)

以上のことから、試行錯誤でパッチを作成しました。
しかし、winpty に -Xallow-non-tty オプションを付けて実行すると、
実行後に mintty 上でキー入力がエコーされない状態になりました。
それで、テスト後に (sys-system "stty sane") を実行して、
端末をリセットするようにしました。

また、appveyor.yml に winpty のインストールを追加しました。

＜テスト結果＞
https://ci.appveyor.com/project/Hamayama/gauche/builds/24155999
