### PR TITLE
Out-of-tree build fix for features list generator

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -913,8 +913,8 @@ AC_CONFIG_FILES([
           gc/configure.gnu-gauche:tools/gc-configure.gnu-gauche.in
          ])
 AC_CONFIG_COMMANDS([VERSION],
-	[echo "${GAUCHE_VERSION}" > VERSION],
-	[GAUCHE_VERSION="${GAUCHE_VERSION}"])
+                   [echo "${GAUCHE_VERSION}" > VERSION],
+                   [GAUCHE_VERSION="${GAUCHE_VERSION}"])
 AC_CONFIG_COMMANDS([src/features],
                    [${srcdir}/src/gen-features.sh ${ac_srcdir} ${ac_builddir}])
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -875,11 +875,6 @@ AC_CONFIG_SUBDIRS(gc)
 
 dnl ===========================================================
 dnl Create output files
-AC_CONFIG_COMMANDS([VERSION],
-	[echo "${GAUCHE_VERSION}" > VERSION],
-	[GAUCHE_VERSION="${GAUCHE_VERSION}"])
-AC_CONFIG_COMMANDS([src/features],
-                   [${srcdir}/src/gen-features.sh ${ac_srcdir} ${ac_builddir}])
 AC_CONFIG_FILES([
           Makefile
           src/Makefile src/genconfig src/makeverslink
@@ -917,6 +912,11 @@ AC_CONFIG_FILES([
           examples/standalone/Makefile
           gc/configure.gnu-gauche:tools/gc-configure.gnu-gauche.in
          ])
+AC_CONFIG_COMMANDS([VERSION],
+	[echo "${GAUCHE_VERSION}" > VERSION],
+	[GAUCHE_VERSION="${GAUCHE_VERSION}"])
+AC_CONFIG_COMMANDS([src/features],
+                   [${srcdir}/src/gen-features.sh ${ac_srcdir} ${ac_builddir}])
 AC_OUTPUT
 
 dnl ===========================================================

--- a/configure.ac
+++ b/configure.ac
@@ -879,7 +879,7 @@ AC_CONFIG_COMMANDS([VERSION],
 	[echo "${GAUCHE_VERSION}" > VERSION],
 	[GAUCHE_VERSION="${GAUCHE_VERSION}"])
 AC_CONFIG_COMMANDS([src/features],
-                   [src/gen-features.sh ${ac_srcdir} ${ac_builddir}])
+                   [${srcdir}/src/gen-features.sh ${ac_srcdir} ${ac_builddir}])
 AC_CONFIG_FILES([
           Makefile
           src/Makefile src/genconfig src/makeverslink


### PR DESCRIPTION
This fix enables out-of-tree build when generate features list.
