### PR TITLE
Add setter to port-name for windows console standard ports

### DIFF
--- a/doc/corelib.texi
+++ b/doc/corelib.texi
@@ -17801,6 +17801,7 @@ Returns the type of @var{port} in one of the symbols @code{file},
 @end defun
 
 @defun port-name port
+@defunx {(setter port-name)} port name
 @c EN
 Returns the name of @var{port}.  If the port is associated to a file,
 it is the name of the file.   Otherwise, it is some description of the port.

--- a/ext/windows/windows/console/codepage.scm
+++ b/ext/windows/windows/console/codepage.scm
@@ -1,7 +1,7 @@
 ;;;
 ;;; os.windows.console.codepage - windows console code page support
 ;;;
-;;;   Copyright (c) 2017  Hamayama  https://github.com/Hamayama
+;;;   Copyright (c) 2017-2019  Hamayama  https://github.com/Hamayama
 ;;;
 ;;;   Redistribution and use in source and binary forms, with or without
 ;;;   modification, are permitted provided that the following conditions
@@ -40,6 +40,9 @@
   (export wrap-windows-console-standard-ports
           auto-wrap-windows-console-standard-ports))
 (select-module os.windows.console.codepage)
+
+;; a character indicating conversion error
+(define *conv-err-char* #\?)
 
 ;; check a standard handle redirection
 (define (redirected-handle? hdl)
@@ -80,7 +83,7 @@
                        ;; a character is incomplete
                        (if (< i2 maxbytes)
                          (loop i2 (+ i2 readbytes))
-                         #\null)])
+                         *conv-err-char*)])
               ;; a character is complete
               (let1 chr (string-ref str 0)
                 (cond
@@ -102,7 +105,7 @@
                        ;; a character is incomplete
                        (if (< i2 maxbytes)
                          (loop i2 (+ i2 readbytes))
-                         #\null)])
+                         *conv-err-char*)])
               ;; a character is complete
               (string-ref str 0))))))))
 
@@ -221,6 +224,7 @@
   (and (or (= (sys-get-console-cp) 0) ; for gosh-noconsole
            (not (redirected-handle? (sys-get-std-handle STD_INPUT_HANDLE))))
        (rlet1 vport (make <virtual-input-port>)
+         (set! (port-name vport) "(windows console standard input)")
          (port-attribute-set! vport 'windows-console-conversion #t)
          (let1 proc (make-conv-getc (standard-input-port)
                                     STD_INPUT_HANDLE ces use-api vport)
@@ -230,6 +234,7 @@
   (and (or (= (sys-get-console-cp) 0) ; for gosh-noconsole
            (not (redirected-handle? (sys-get-std-handle STD_OUTPUT_HANDLE))))
        (rlet1 vport (make <virtual-output-port>)
+         (set! (port-name vport) "(windows console standard output)")
          (port-attribute-set! vport 'windows-console-conversion #t)
          (let1 proc (make-conv-puts (standard-output-port)
                                     STD_OUTPUT_HANDLE ces use-api vport)
@@ -240,6 +245,7 @@
   (and (or (= (sys-get-console-cp) 0) ; for gosh-noconsole
            (not (redirected-handle? (sys-get-std-handle STD_ERROR_HANDLE))))
        (rlet1 vport (make <virtual-output-port>)
+         (set! (port-name vport) "(windows console standard error output)")
          (port-attribute-set! vport 'windows-console-conversion #t)
          (let1 proc (make-conv-puts (standard-error-port)
                                     STD_ERROR_HANDLE ces use-api vport)
@@ -247,7 +253,7 @@
            (set! (~ vport'puts) proc)))))
 
 ;; wrap windows console standard ports
-(define (wrap-windows-console-standard-ports :optional (ces '#f) (use-api #f))
+(define (wrap-windows-console-standard-ports :optional (ces #f) (use-api #f))
   (if-let1 port (make-stdin-conv-port  ces use-api) (current-input-port  port))
   (if-let1 port (make-stdout-conv-port ces use-api) (current-output-port port))
   (if-let1 port (make-stderr-conv-port ces use-api) (current-error-port  port))

--- a/src/gauche/port.h
+++ b/src/gauche/port.h
@@ -322,6 +322,7 @@ SCM_EXTERN void   Scm_SetPortReaderLexicalMode(ScmPort *port, ScmObj obj);
 SCM_EXTERN void   Scm_FlushAllPorts(int exitting);
 
 SCM_EXTERN ScmObj Scm_PortName(ScmPort *port);
+SCM_EXTERN void   Scm_SetPortName(ScmPort *port, ScmObj name);
 SCM_EXTERN int    Scm_PortLine(ScmPort *port);
 SCM_EXTERN ScmObj Scm_PortSeek(ScmPort *port, ScmObj off, int whence);
 SCM_EXTERN ScmObj Scm_PortSeekUnsafe(ScmPort *port, ScmObj off, int whence);

--- a/src/libio.scm
+++ b/src/libio.scm
@@ -103,7 +103,13 @@
 
 (select-module gauche)
 
-(define-cproc port-name (port::<port>) Scm_PortName)
+(define-cproc port-name (port::<port>)
+  (setter (port::<port> name) ::<void>
+          (unless (or (SCM_STRINGP name) (SCM_FALSEP name))
+            (Scm_TypeError "name" "string or #f" name))
+          (Scm_SetPortName port name))
+  (return (Scm_PortName port)))
+
 (define-cproc port-current-line (port::<port>) ::<fixnum> Scm_PortLine)
 
 (define-cproc port-file-number (port::<port>)

--- a/src/port.c
+++ b/src/port.c
@@ -74,6 +74,14 @@ static ScmObj get_port_name(ScmPort *port)
     return Scm_PortName(port);
 }
 
+static void set_port_name(ScmPort *port, ScmObj name)
+{
+    if (!SCM_STRINGP(name) && !SCM_FALSEP(name)) {
+        Scm_TypeError("name", "string or #f", name);
+    }
+    Scm_SetPortName(port, name);
+}
+
 static ScmObj get_port_current_line(ScmPort *port)
 {
     return SCM_MAKE_INT(Scm_PortLine(port));
@@ -103,7 +111,7 @@ static void set_port_sigpipe_sensitive(ScmPort *port, ScmObj val)
 }
 
 static ScmClassStaticSlotSpec port_slots[] = {
-    SCM_CLASS_SLOT_SPEC("name", get_port_name, NULL),
+    SCM_CLASS_SLOT_SPEC("name", get_port_name, set_port_name),
     SCM_CLASS_SLOT_SPEC("buffering", get_port_buffering,
                         set_port_buffering),
     SCM_CLASS_SLOT_SPEC("sigpipe-sensitive?", get_port_sigpipe_sensitive,
@@ -253,6 +261,11 @@ ScmObj Scm_VMWithPortLocking(ScmPort *port SCM_UNUSED, ScmObj closure)
 ScmObj Scm_PortName(ScmPort *port)
 {
     return port->name;
+}
+
+void Scm_SetPortName(ScmPort *port, ScmObj name)
+{
+    port->name = name;
 }
 
 int Scm_PortLine(ScmPort *port)

--- a/test/io.scm
+++ b/test/io.scm
@@ -104,6 +104,34 @@
            (call-with-input-file "tmp2.o" read)))
 
 ;;-------------------------------------------------------------------
+(test-section "common port operations")
+
+(let ([p-in  (open-input-string "abcde")]
+      [p-out (open-output-string)])
+  (unwind-protect
+      (begin
+        (test* "port? 1" #t (port? p-in))
+        (test* "port? 2" #f (port? 'not-port))
+        (test* "input-port? 1" #t (input-port? p-in))
+        (test* "input-port? 2" #f (input-port? p-out))
+        (test* "output-port? 1" #t (output-port? p-out))
+        (test* "output-port? 2" #f (output-port? p-in))
+        (test* "port-closed?" #f (port-closed? p-in))
+        (test* "port-type" 'string (port-type p-in))
+        (test* "port-name 1" "(input string port)"  (port-name p-in))
+        (test* "port-name 2" "(output string port)" (port-name p-out))
+        (test* "port-name 3" "12345" 
+               (begin (set! (port-name p-in) "12345") (port-name p-in)))
+        (test* "port-buffering 1" #f (port-buffering p-in))
+        (test* "port-buffering 2" (test-error)
+               (set! (port-buffering p-out) :line))
+        (test* "port-current-line" 1 (port-current-line p-in))
+        (test* "port-file-number" #f (port-file-number p-in))
+        )
+    (close-port p-in)
+    (close-port p-out)))
+
+;;-------------------------------------------------------------------
 (test-section "port-attributes")
 
 (let ([p (open-output-file "tmp.o" :if-exists :supersede)])


### PR DESCRIPTION
Windows コンソール上で、例えば `)` を入力すると、
```
*** READ-ERROR: Read error at "??":line 1: extra close parenthesis `)'
```
のようにポート名の表示が `??` になっていました。

それで、port-name に setter 手続きを追加して、ポート名を設定するようにしました。

以下のようにポート名が表示されるようになります。
```
*** READ-ERROR: Read error at "(windows console standard input)":line 1: extra close parenthesis `)'
```

また、ポートのテストを少し追加しました。
(ユーザリファレンスの「ポート共通の操作」からいくつか)

＜テスト結果＞
https://ci.appveyor.com/project/Hamayama/gauche/builds/24616752
