### PR TITLE
Add missing Japanese paragraph in search paths doc

### DIFF
--- a/doc/corelib.texi
+++ b/doc/corelib.texi
@@ -21433,6 +21433,8 @@ You can also use glob-like metacharacters '@code{*}' and
 である場合にはモジュール名(たとえば、@code{foo.bar})を指定します。
 文字列である場合にはライブラリの部分パス(たとえば、@code{"foo/bar"})を
 指定します。これはライブラリサーチパス以下で検索されます。
+@var{pattern}にはグロブのメタ文字として '@code{*}' と '@code{?}' を
+使うことができます。
 @c COMMON
 
 @defun library-fold pattern proc seed :key paths strict? allow-duplicates?


### PR DESCRIPTION
I translated a missing part of `Operations on libraries`.