### PR TITLE
Check winpty for ssltest on MinGW

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,6 +45,8 @@ install:
   - gosh -V
   - bash -lc "pacman -S --noconfirm msys/winpty"
   - bash -lc "winpty --version"
+  - bash -lc "where openssl"
+  - bash -lc "openssl version"
 
 build_script:
   - bash -lc "pwd"
@@ -61,5 +63,6 @@ test_script:
 
 artifacts:
   - path: Gauche-*.zip
+#  - path: ext/tls/kick_openssl.sh
 #  - path: ext/tls/ssltest.log
 


### PR DESCRIPTION
axTLS の ssltest で、MinGW の openssl.exe を使用する場合に、
winpty の存在をチェックするようにしました。

(関連プルリクエスト #468 #479)

＜参考URL＞
- https://practical-scheme.net/wiliki/wiliki.cgi?Gauche%3ABugs
  (tls のテストに失敗する (0.9.8_rc1))

＜テスト結果＞
https://ci.appveyor.com/project/Hamayama/gauche/builds/25172302
