### PR TITLE
Check winpty for ssltest on MinGW v2

### DIFF
--- a/ext/tls/test.scm
+++ b/ext/tls/test.scm
@@ -19,10 +19,12 @@
   ;; Some tests requires openssl command.  We've checked its availability
   ;; in toplevel configure.
   ;; NB: We assume we're running in $top_builddir/ext/tls.
-  (define openssl-cmd
-    (and-let1 m (any #/S\["OPENSSL"\]=\"(.+)\"/
-                     (file->string-list "../../config.status"))
-      (m 1)))
+  (define config-list (file->string-list "../../config.status"))
+  (define (get-config-var name)
+    (let1 r (string->regexp #"S\\[\"~|name|\"\\]=\"(.+)\"")
+      (and-let1 m (any (cut rxmatch r <>) config-list)
+        (m 1))))
+  (define openssl-cmd (get-config-var "OPENSSL"))
   (define (no-openssl msg)
     (warn #"~|msg|: some tests are skipped.\n")
     (set! openssl-cmd #f))
@@ -35,10 +37,11 @@
       (and-let1 msystem (sys-getenv "MSYSTEM")
         (boolean (#/MINGW(64|32)/ msystem)))]
      [else #f]))
+  (define openssl-path (get-config-var "OPENSSL_PATH"))
   (define winpty-needed
     (and mingw-detected
-         openssl-cmd
-         (boolean (#/\/mingw(64|32)/ openssl-cmd))))
+         openssl-path
+         (boolean (#/\/mingw(64|32)/ openssl-path))))
 
   (sys-unlink "axTLS/ssl/openssl.pid")
   (sys-unlink "kick_openssl.sh")
@@ -46,7 +49,7 @@
   (cond
    [(not openssl-cmd)
     (no-openssl "openssl command not available")]
-   [(and mingw-detected (not openssl-cmd))
+   [(and mingw-detected (not openssl-path))
     (no-openssl "couldn't get openssl command path")]
    [(and winpty-needed
          (not (find-file-in-paths "winpty" :extensions '("exe"))))

--- a/ext/tls/tls.ac
+++ b/ext/tls/tls.ac
@@ -147,7 +147,8 @@ dnl
 dnl Check openssl command; if available, we use it for axTLS tests.
 dnl This is needed even if we don't support libopenssl binding.
 dnl
-AC_PATH_PROGS(OPENSSL, openssl)
+AC_CHECK_PROGS(OPENSSL, openssl)
+AC_PATH_PROGS(OPENSSL_PATH, openssl)
 
 dnl Local variables:
 dnl mode: autoconf


### PR DESCRIPTION
https://github.com/shirok/Gauche/pull/480#issuecomment-500758620 の件で、
openssl コマンドのパスのチェックに、
`AC_PATH_PROGS(OPENSSL_PATH, openssl)` を使うようにしたものです。

ただ、動作チェックのために、./DIST gen からやり直しが必要になるので、
前の方が身軽だったような気もします。。。

＜テスト結果＞
https://ci.appveyor.com/project/Hamayama/gauche/builds/25195489
