### PR TITLE
Check winpty for ssltest on MinGW v3

### DIFF
--- a/ext/tls/test.scm
+++ b/ext/tls/test.scm
@@ -37,7 +37,8 @@
      [else #f]))
   (define openssl-path
     (and mingw-detected
-         (find-file-in-paths "openssl" :extensions '("exe"))))
+         openssl-cmd
+         (find-file-in-paths openssl-cmd :extensions '("exe"))))
   (define winpty-needed
     (and mingw-detected
          openssl-path

--- a/ext/tls/tls.ac
+++ b/ext/tls/tls.ac
@@ -148,7 +148,6 @@ dnl Check openssl command; if available, we use it for axTLS tests.
 dnl This is needed even if we don't support libopenssl binding.
 dnl
 AC_CHECK_PROGS(OPENSSL, openssl)
-AC_PATH_PROGS(OPENSSL_PATH, openssl)
 
 dnl Local variables:
 dnl mode: autoconf


### PR DESCRIPTION
find-file-in-paths を使うようにしてみました。
メンテと信頼性のバランスからみて、これでどうでしょうか。
(MinGW 以外には影響はないはず。。。)

＜テスト結果＞
https://ci.appveyor.com/project/Hamayama/gauche/builds/25216173
