### PR TITLE
Fix build failure on Mac

### DIFF
--- a/ext/tls/ssltest-mod.scm
+++ b/ext/tls/ssltest-mod.scm
@@ -63,7 +63,8 @@
                                            [else
                                             '(openssl version)]))
                              1)
-      (version>=? openssl-version "1.1")))
+      (and openssl-version
+           (version>=? openssl-version "1.1"))))
 
   (define add-seclevel-client
     (if openssl-1.1>=?


### PR DESCRIPTION
Build failed on my environment.

```sh
===snip===
"../../src/gosh" -ftest ./ssltest-mod.scm "/Users/admin/repos/lisp/Gauche/ext/tls" "/Users/admin/repos/lisp/Gauche/ext/tls" < ./axTLS/ssl/test/ssltest.c
*** ERROR: string required, but got #f
Stack Trace:
_______________________________________
  0  (rxmatch #/[\-._]/ ver)
        at "../../lib/gauche/version.scm":108
  1  (next-component a-ver)
        at "../../lib/gauche/version.scm":129
  2  (version-compare a b)
        at "../../lib/gauche/version.scm":141
  3  (version>=? openssl-version "1.1")
        at "././ssltest-mod.scm":67
```

It seems `openssl` is changed to LibreSSL on MacOS, so `rxmatch->string` returns `#f` in `openssl-1.1>=?`.

```sh
$ openssl version
LibreSSL 2.6.5
```

-- 
MacOS Mojave
version 10.14.5
