### PR TITLE
doc: use @code{} for #t and #f

### DIFF
--- a/doc/corelib.texi
+++ b/doc/corelib.texi
@@ -1407,7 +1407,7 @@ used for ordering.
 @c EN
 The @var{hash} argument must be either @code{#f}, or
 a procedure taking one argument and returning nonnegative exact
-integer.  If @var{#f} is given, it indicates the comparator
+integer.  If @code{#f} is given, it indicates the comparator
 can't hash objects; the predefined procedure just throws an error.
 @c JP
 @var{hash}引数は@code{#f}か、一つの引数を取り非負の正確な整数をハッシュ値と
@@ -3882,7 +3882,7 @@ Returns bitwise not of an integer @var{n}.
 [SRFI-60]
 @c EN
 Returns @code{#t} if @var{index}-th bit of integer @var{n} is 1,
-@var{#f} otherwise.
+@code{#f} otherwise.
 @c JP
 整数@var{n}の@var{index}目のビットが1ならば@code{#t}を、0ならば@code{#f}を
 返します。
@@ -4423,7 +4423,7 @@ Returns @code{#t} if @var{obj} is an empty list, @code{#f} otherwise.
 [SRFI-1]
 @c EN
 Returns @code{#t} if @var{obj} is an empty list,
-@var{#f} if @code{obj} is a pair.  If @var{obj} is neither
+@code{#f} if @var{obj} is a pair.  If @var{obj} is neither
 a pair nor an empty list, an error is signaled.
 
 This can be used instead of @code{null?} to check the end-of-list
@@ -4447,7 +4447,7 @@ See also @code{proper-list?}, @code{circular-list?} and
 @code{dotted-list?} below.
 @c JP
 @var{obj}が正しいリストなら@code{#t}を、そうでなければ@code{#f}を返します。
-この手続きは@var{obj}がドットリストや循環リストなら@var{#f}を返します。
+この手続きは@var{obj}がドットリストや循環リストなら@code{#f}を返します。
 
 下に説明する、
 @code{proper-list?}、@code{circular-list?}、@code{dotted-list?}
@@ -10957,7 +10957,7 @@ R7RSはバイトベクタを定義しています。Gaucheではそれは単に
 @c EN
 Returns @code{#t} if @var{obj} is a vector, @code{#f} otherwise.
 @c JP
-@var{obj}がベクタなら@code{#t}を、そうでなければ@var{#f}を返します。
+@var{obj}がベクタなら@code{#t}を、そうでなければ@code{#f}を返します。
 @c COMMON
 @end defun
 
@@ -23054,7 +23054,7 @@ Creates a hard link named @var{new} to the existing file @var{existing}.
 @c EN
 Removes @var{pathname}.  It can't be a directory.
 Returns @code{#t} if it is successfully removed, or
-@var{#f} if @var{pathname} doesn't exist.
+@code{#f} if @var{pathname} doesn't exist.
 An error is signaled otherwise.
 @c JP
 @var{pathname}で示されるファイルを消去します。

--- a/doc/modgauche.texi
+++ b/doc/modgauche.texi
@@ -242,10 +242,10 @@ and content, so it is @code{equal?} to the original array.
 [SRFI-25]
 @c MOD gauche.array
 @c EN
-Returns @code{#t} if @var{obj} is an array, @var{#f} otherwise.
+Returns @code{#t} if @var{obj} is an array, @code{#f} otherwise.
 It is equivalent to @code{(is-a? obj <array-base>)}.
 @c JP
-@var{obj}が配列であれば@var{#t}が、そうでなければ@var{#f}が返されます。
+@var{obj}が配列であれば@code{#t}が、そうでなければ@code{#f}が返されます。
 @code{(is-a? obj <array-base>)}と等価です。
 @c COMMON
 @end defun
@@ -2690,7 +2690,7 @@ It is upper-compatible to any CES, and any CES is upper-compatible to
 @c JP
 CES @var{ces-b}でエンコードされた文字列が、システムの知る限りで
 変換無しに@var{ces-a}でエンコードされたものと見倣せる場合に@code{#t}を
-返します。見倣せない場合は@var{#f}を返します。
+返します。見倣せない場合は@code{#f}を返します。
 システムが判断できない場合は@var{unknown-value}に与えられた
 値を返します。そのデフォルトは@code{#f}です。
 
@@ -3776,7 +3776,7 @@ applied in order.  Otherwise the order of application is undefined.
 @example
 (find char-upper-case? "abcDe") @result{} #\D
 (find even? '#(1 3 4 6)) @result{} 4
-(find even? '(1 3 5 7))  @result{} #F
+(find even? '(1 3 5 7))  @result{} #f
 @end example
 @end deffn
 
@@ -22573,7 +22573,7 @@ if they are given.
 @c MOD gauche.uvector
 @c EN
 Both arguments must be a @var{TAG}vector.  Returns @code{#t} if
-@var{vec1} and @var{vec2} are equal to each other, @var{#f} otherwise.
+@var{vec1} and @var{vec2} are equal to each other, @code{#f} otherwise.
 
 Note that you can compare uvectors with @code{equal?} in Gauche.
 These are provided because SRFI-66 defines @code{u8vector=?}.
@@ -23886,7 +23886,7 @@ that is out of range is returned.
 @var{min}が@code{#f}の場合、最小値はマイナス無限大と考えられます。
 @var{max}が@code{#f}の場合、最大値はプラス無限大と考えられます。
 
-@var{vec}の全ての要素が範囲内であった場合は@var{#f}が返されます。
+@var{vec}の全ての要素が範囲内であった場合は@code{#f}が返されます。
 そうでなければ、範囲を外れた要素のうちもっとも左のものの@var{vec}内での
 インデックスが返されます。
 @c COMMON

--- a/doc/modr7rs.texi
+++ b/doc/modr7rs.texi
@@ -8473,7 +8473,7 @@ a NaN.
 [R7RS flonum]
 @c MOD scheme.flonum
 Returns @code{#t} if @var{x} is an integral flonum,
-@var{#f} otherwise.
+@code{#f} otherwise.
 @end defun
 
 @defun flzero? x

--- a/doc/modsrfi.texi
+++ b/doc/modsrfi.texi
@@ -5977,7 +5977,7 @@ Like @code{string-contains}, looks for a needle @var{string2} from
 a haystack @var{string1}, but if it is found, returns the start index
 of the @emph{last} match, instead of the first match.  The returned index
 is in @var{string1}.  The optional arguments limit the range of a needle
-and a haystack.  If a needle isn't found, @var{#f} is returned.
+and a haystack.  If a needle isn't found, @code{#f} is returned.
 
 An edge case: If a needle is empty (e.g. @var{string2} is empty,
 or @var{start2} = @var{end2}), it always matches right after the haystack,
@@ -5988,7 +5988,7 @@ so @var{end1} is returned.
 見つかった場合は最初ではなく最後のマッチの開始インデックスを返します。
 開始インデックスは@var{string1}に対するものです。
 省略可能引数は@var{string1}、@var{string2}それぞれの対象とする文字列を制限します。
-探索文字列@var{string2}が見つからなかった場合は@var{#f}が返されます。
+探索文字列@var{string2}が見つからなかった場合は@code{#f}が返されます。
 
 エッジケースとして、探索文字列が空文字列の場合 (@var{string2}が空であるとか、
 @var{start2} = @var{end2}である場合)は、

--- a/doc/modutil.texi
+++ b/doc/modutil.texi
@@ -5372,7 +5372,7 @@ passing a seed value, whose initial value is @var{seed}.
 That is, @var{proc} has a type of @code{(index, node, seed) -> seed}.
 Should return the last result of @var{proc}.
 @item tab-empty? @var{tab}
-Returns @code{#t} if @var{tab} is empty, @var{#f} otherwise.
+Returns @code{#t} if @var{tab} is empty, @code{#f} otherwise.
 You can omit or pass @code{#f} to this procedure; then we use
 @code{tab-fold} to check if @var{tab} is empty, which can be expensive.
 @end table
@@ -5543,7 +5543,7 @@ not equal to @var{seq} but @var{seq} matches its prefix.   Note that
 @var{seq} may or may not a key of @var{trie}; see the example below.
 @c JP
 @var{trie}の中に少なくともひとつ、@var{seq}と同じではないが@var{seq}を
-プリフィクスとするようなキーがあれば@var{#t}を返します。
+プリフィクスとするようなキーがあれば@code{#t}を返します。
 @var{seq}と一致するキーが他にあるかないかは結果には影響を及ぼしません。
 下の例を見てください。
 @c COMMON
@@ -8667,7 +8667,7 @@ whose content is @var{path}.
 @c MOD file.util
 @c EN
 Checks if a directory hierarchy according to @var{spec} exists
-under @var{dir}.  Returns @code{#t} if it exists, or @var{#f} otherwise.
+under @var{dir}.  Returns @code{#t} if it exists, or @code{#f} otherwise.
 
 The format of @var{spec} is the same
 as @code{create-directory-tree} described above.
@@ -15512,11 +15512,11 @@ uris with different stages.
 @c EN
 @code{uri-scheme&specific} takes a URI @var{uri}, and
 returns two values, its scheme part and its scheme-specific part.
-If @var{uri} doesn't have a scheme part, @var{#f} is returned for it.
+If @var{uri} doesn't have a scheme part, @code{#f} is returned for it.
 @c JP
 @code{uri-scheme&specific} は URI @var{uri} を引数に取り、
 スキーム部分と、そのスキーム特有の部分を表す2つの値を返します。
-@var{uri} がスキーム部分を持たない場合、@var{#f} を返します。
+@var{uri} がスキーム部分を持たない場合、@code{#f} を返します。
 @c COMMON
 @example
 (uri-scheme&specific "mailto:sclaus@@north.pole")
@@ -18300,10 +18300,10 @@ If @var{x} is a nodeset - returns it as is, otherwise wrap it in a list.
 @defun sxml:element? obj
 @c MOD sxml.sxpath
 @c EN
-Predicate which returns @var{#t}
-if @var{obj} is SXML element, otherwise returns @var{#f}.
+Predicate which returns @code{#t}
+if @var{obj} is SXML element, otherwise returns @code{#f}.
 @c JP
-@var{obj}がSXMLの要素であれば@var{#t}を返し、そうでなければ@var{#f}を
+@var{obj}がSXMLの要素であれば@code{#t}を返し、そうでなければ@code{#f}を
 返す述語です。
 @c COMMON
 @end defun
@@ -18510,7 +18510,7 @@ or nil result meaning failure.
 @c EN
 Given a converter-predicate and a nodeset, apply the predicate to
 each element of the nodeset, until the predicate yields anything but
-@var{#f} or nil. Return the elements of the input nodeset that have
+@code{#f} or nil. Return the elements of the input nodeset that have
 been processed
 till that moment (that is, which fail the predicate).
 @code{take-until} is a variation of the filter above:
@@ -18523,7 +18523,7 @@ to be more precise, a prefix -- of the nodeset returned by
 @c JP
 述語としてのコンバータとノードセットが与えられると、
 ノードセットの各要素に述語を適用し、
-述語が@var{#f}あるいはnil以外を返すと、
+述語が@code{#f}あるいはnil以外を返すと、
 (その述語が失敗した)その時点までに処理された要素を返します。
 @code{take-until}は、上のフィルタのバリエーションの1つです。
 @code{take-until}は、その述語を満足する最初の要素(それ自体は含まない)まで、
@@ -19318,13 +19318,13 @@ source code.
 @defun sxml:empty-element? obj
 @c MOD sxml.tools
 @c EN
-A predicate which returns @var{#t} if given element @var{obj} is empty.
+A predicate which returns @code{#t} if given element @var{obj} is empty.
 Empty element has no nested elements, text nodes, @code{PI}s,
 Comments or entities
 but it may contain attributes or namespace-id.
 It is a SXML counterpart of XML @code{empty-element}.
 @c JP
-与えられた要素@var{obj}が空なら@var{#t}を返す述語です。
+与えられた要素@var{obj}が空なら@code{#t}を返す述語です。
 空要素は、ネストした要素、テキストノード、@code{PI}、コメントや実体を
 持ちませんが、属性や名前空間IDは持つかもしれません。
 それは、XMLの@code{empty-element}のSXML版です。
@@ -19437,10 +19437,10 @@ SXMLの名前はシンボルですが、この関数は文字列を返すこと�
 @defun sxml:name->ns-id sxml-name
 @c MOD sxml.tools
 @c EN
-Returns namespace-id part of given name, or @var{#f} if it's LocalName
+Returns namespace-id part of given name, or @code{#f} if it's LocalName
 @c JP
 与えられた名前の名前空間ID部分を返します。与えられた名前がLocalNameの
-場合は@var{#f}を返します。
+場合は@code{#f}を返します。
 @c COMMON
 @end defun
 
@@ -19637,11 +19637,11 @@ Accessor for an attribute @var{attr-name} of
 given SXML element @var{obj}.
 It returns:
 the value of the attribute if the attribute is present, or
-@var{#f} if there is no such an attribute in the given element.
+@code{#f} if there is no such an attribute in the given element.
 @c JP
 与えられたSXML要素@var{obj}の@var{attr-name}という属性へのアクセッサです。
 戻り値は、その属性が存在すればその属性の値、与えられた要素に
-そのような属性がなければ@var{#f}です。
+そのような属性がなければ@code{#f}です。
 @c COMMON
 @end defun
 


### PR DESCRIPTION
`@var{}` is not the right macro for constant values like #t and #f. It also renders both as #T and #F, which looks weird. Use the right macro.

While at there, I also made a change #F -> #f and one `@code{obj}` to `@var{obj}`, but I didn't really go out of the way to find and correct all wrong `@code{var}`.