### PR TITLE
cise: support return 4+ values in stub environment, #498

### DIFF
--- a/lib/gauche/cgen/stub.scm
+++ b/lib/gauche/cgen/stub.scm
@@ -619,7 +619,12 @@
                                  (set! SCM_RESULT1 ,e1)
                                  (set! SCM_RESULT2 ,e2)
                                  (goto SCM_STUB_RETURN))]
-           [_ (error "Too many values to return")]))
+           [(_ xs ...) `(begin (set!
+                                ,@(concatenate
+                                   (map-with-index
+                                    (^[i x] `(,(string->symbol #"SCM_RESULT~i") ,x))
+                                    xs)))
+                               (goto SCM_STUB_RETURN))]))
        ctx)))
 
 (define-syntax with-cise-ambient

--- a/test/cgen.scm
+++ b/test/cgen.scm
@@ -498,6 +498,17 @@ some_trick();
 (use gauche.cgen.stub)
 (test-module 'gauche.cgen.stub)
 
+(let ([c (lambda (form exp)
+           (test* (format "cise transform: ~a" form) exp
+                  (cise-render-to-string form 'stmt)))])
+  (parameterize ([cise-emit-source-line #f]
+                 [cise-ambient (cgen-stub-cise-ambient (cise-ambient))])
+    (c '(return) "goto SCM_STUB_RETURN;")
+    (c '(return e) "{SCM_RESULT=(e);goto SCM_STUB_RETURN;}")
+    (c '(return e0 e1) "{SCM_RESULT0=(e0);SCM_RESULT1=(e1);goto SCM_STUB_RETURN;}")
+    (c '(return e0 e1 e2) "{SCM_RESULT0=(e0);SCM_RESULT1=(e1);SCM_RESULT2=(e2);goto SCM_STUB_RETURN;}")
+    (c '(return e0 e1 e2 e3) "{SCM_RESULT0=(e0),SCM_RESULT1=(e1),SCM_RESULT2=(e2),SCM_RESULT3=(e3);goto SCM_STUB_RETURN;}")))
+
 ;;====================================================================
 (test-section "gauche.cgen.precomp")
 (use gauche.cgen.precomp)


### PR DESCRIPTION
Note that we have a hard limit SCM_VM_MAX_VALUES (20) but it's not
checked here. It will be checked when Scm_Values() is actually run. So
the user will notice anyway, even if at runtime instead of compile time.