### PR TITLE
Scm_CharSetAdd - do not clear 'large' flag when adding more

### DIFF
--- a/src/char.c
+++ b/src/char.c
@@ -808,7 +808,9 @@ ScmObj Scm_CharSetAdd(ScmCharSet *dst, ScmCharSet *src)
 
     if (dst == src) return SCM_OBJ(dst);  /* precaution */
 
-    set_large(dst, SCM_CHAR_SET_LARGE_P(src));
+    if (SCM_CHAR_SET_LARGE_P(src)) {
+        set_large(dst, TRUE);
+    }
     
     ScmTreeIter iter;
     ScmDictEntry *e;


### PR DESCRIPTION
Adding more chars to a charset can't possibly make it fit the small
range. This set_large() call may clear the large flag if the input
second charset's large flag is zero, which is not wanted. This makes

    (char-set-union char-set:letter+digit #[_])

return wrong when perform more algebra operations on it. Printing it out
is fine, but if you use the low level function

    ((with-module gauche.internal %char-set-dump)
        (char-set-union char-set:letter+digit #[_]))

then you'll see that it does not dump outside the small char range
correctly anymore. This should fix issue #497