### PR TITLE
Implement SRFI-115 regexp-replace and regexp-replace-all

### DIFF
--- a/lib/srfi-115.scm
+++ b/lib/srfi-115.scm
@@ -176,8 +176,22 @@
                   start
                   end))))
 
-(define regexp-replace #f)
-(define regexp-replace-all #f)
+(define (regexp-replace rx str sub :optional
+                        (start 0)
+                        (end #f)
+                        (count 0))
+  ((with-module gauche.internal %regexp-replace)
+   (regexp rx)
+   str start end
+   (if (string? sub) (list sub) sub) count 1))
+
+(define (regexp-replace-all rx str sub :optional
+                            (start 0)
+                            (end #f))
+  ((with-module gauche.internal %regexp-replace)
+   (regexp rx)
+   str start end
+   (if (string? sub) (list sub) sub) 0 #f))
 
 (define regexp-match? regmatch?)
 (define regexp-match-count rxmatch-num-matches)

--- a/test/srfi.scm
+++ b/test/srfi.scm
@@ -1956,6 +1956,38 @@
        '("abc" "123" "def" "456" "ghi" "789")
        (regexp-partition '(* numeric) "abc123def456ghi789"))
 
+(test* "regexp-replace"
+       "abc def"
+       (regexp-replace '(+ space) "abc \t\n def" " "))
+(test* "regexp-replace"
+       "  abc-abc"
+       (regexp-replace '(: ($ (+ alpha)) ":" (* space)) "  abc: " '(1 "-" 1)))
+(test* "regexp-replace"
+       "  abc-  abc"
+       (regexp-replace '(: ($ (+ alpha)) ":" (* space)) "  abc: " '(1 "-" pre 1)))
+
+(test* "regexp-replace"
+       "-abc \t\n d ef  "
+       (regexp-replace '(+ space) "  abc \t\n d ef  " "-" 0))
+(test* "regexp-replace"
+       "-abc \t\n d ef  "
+       (regexp-replace '(+ space) "  abc \t\n d ef  " "-" 0 #f 0))
+(test* "regexp-replace"
+       "  abc-d ef  "
+       (regexp-replace '(+ space) "  abc \t\n d ef  " "-" 0 #f 1))
+(test* "regexp-replace"
+       "  abc \t\n d-ef  "
+       (regexp-replace '(+ space) "  abc \t\n d ef  " "-" 0 #f 2))
+(test* "regexp-replace"
+       "  abc \t\n d ef-"
+       (regexp-replace '(+ space) "  abc \t\n d ef  " "-" 0 #f 3))
+(test* "regexp-replace"
+       "  abc \t\n d ef  "
+       (regexp-replace '(+ space) "  abc \t\n d ef  " "-" 0 #f 4))
+(test* "regexp-replace"
+       " abc d ef "
+       (regexp-replace-all '(+ space) "  abc \t\n d ef  " " "))
+
 ;;-----------------------------------------------------------------------
 (test-section "srfi-117")
 (use srfi-117)


### PR DESCRIPTION
This is the last piece that makes Gauche compatible with srfi-115 (mostly, without grapheme). I pulled Chibi's implementation for these procedures instead of extending Gauche's versions because:

- extending means pulling sre into the core. That's something that should wait until things are stablized and you have had a closer look at it.
- incompatible substitution semantics (srfi-115 subst string is literal, no backrefs)