### PR TITLE
configure.ac: fix so suffix

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -641,7 +641,7 @@ AS_CASE([$host],
     SHLIB_MAIN_LDFLAGS=""
     SHLIB_OK=ok
     ],
-  [*-linux-gnu*|*-*-gnu*|*freebsd*|*dragonfly*], [
+  [*-linux-*|*-*-gnu*|*freebsd*|*dragonfly*], [
     SHLIB_SO_CFLAGS="-fPIC"
     SHLIB_SO_LDFLAGS="$rpath -shared -o"
     SHLIB_SO_SUFFIX="so"


### PR DESCRIPTION
With uclibc or musl configuration, $host does not match to '*-linux-gnu*'.

Signed-off-by: Hiroshi Kawashima <kei-k@ca2.so-net.ne.jp>
[Retrieved (and slightly updated) from:
https://git.buildroot.net/buildroot/tree/package/gauche/0001-fix-so-suffix.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>