### PR TITLE
Fix s/u64vector test error on Windows

### DIFF
--- a/src/gauche/int64.h
+++ b/src/gauche/int64.h
@@ -48,12 +48,12 @@ typedef uint32_t ScmUInt32;
 typedef int64_t  ScmInt64;
 typedef uint64_t ScmUInt64;
 
-#define SCM_SET_INT64_MAX(v64)    ((v64) = LONG_MAX)
-#define SCM_SET_INT64_MIN(v64)    ((v64) = LONG_MIN)
-#define SCM_SET_UINT64_MAX(v64)   ((v64) = ULONG_MAX)
+#define SCM_SET_INT64_MAX(v64)    ((v64) = INT64_MAX)
+#define SCM_SET_INT64_MIN(v64)    ((v64) = INT64_MIN)
+#define SCM_SET_UINT64_MAX(v64)   ((v64) = UINT64_MAX)
 #define SCM_SET_INT64_ZERO(v64)   ((v64) = 0)
 #define SCM_SET_INT64_BY_LONG(v64, val)   ((v64) = (val))
-#define SCM_SET_INT64_BY_DOUBLE(v64, val) ((v64) = (long)(val))
+#define SCM_SET_INT64_BY_DOUBLE(v64, val) ((v64) = (int64_t)(val))
 
 #define SCM_INT64_EQV(a64, b64)     ((a64) == (b64))
 #define SCM_INT64_CMP(op, a64, b64)     ((a64) op (b64))


### PR DESCRIPTION
テストでエラーが出ていたので修正しました。

```
Testing uniform vector and array ...                             failed.
discrepancies found.  Errors are:
test s64vector-set! clamp: expects (error -9223372036854775808 error -9223372036854775808) => got (error -2147483648 error -2147483648)
test s64vector-set! clamp: expects (error error 9223372036854775807 9223372036854775807) => got (error error 2147483647 2147483647)
test u64vector-set! clamp: expects (error error 18446744073709551615 18446744073709551615) => got (error error 4294967295 4294967295)
test u64vector-add (v+v): expects (error #u64(18446744073709551613 18446744073709551614 18446744073709551615 18446744073709551615) error #u64(18446744073709551613 18446744073709551614 18446744073709551615 18446744073709551615)) => got (error #u64(18446744073709551613 18446744073709551614 18446744073709551615 4294967295) error #u64(18446744073709551613 18446744073709551614 18446744073709551615 4294967295))
test u64vector-add (v+s): expects (error #u64(18446744073709551613 18446744073709551614 18446744073709551615 18446744073709551615) error #u64(18446744073709551613 18446744073709551614 18446744073709551615 18446744073709551615)) => got (error #u64(18446744073709551613 18446744073709551614 18446744073709551615 4294967295) error #u64(18446744073709551613 18446744073709551614 18446744073709551615 4294967295))
test u64vector-add (v+b): expects (error #u64(18446744073709551615 18446744073709551615 18446744073709551615 18446744073709551615) error #u64(18446744073709551615 18446744073709551615 18446744073709551615 18446744073709551615)) => got (error #u64(18446744073709551615 4294967295 4294967295 4294967295) error #u64(18446744073709551615 4294967295 4294967295 4294967295))
test u64vector-sub (v-b): expects (error #u64(18446744073709551615 18446744073709551615 18446744073709551615 18446744073709551615) error #u64(18446744073709551615 18446744073709551615 18446744073709551615 18446744073709551615)) => got (error #u64(18446744073709551615 4294967295 4294967295 4294967295) error #u64(18446744073709551615 4294967295 4294967295 4294967295))
test u64vector-mul (v*v): expects (error #u64(0 18446744073709551613 18446744073709551615 18446744073709551615) error #u64(0 18446744073709551613 18446744073709551615 18446744073709551615)) => got (error #u64(0 18446744073709551613 4294967295 4294967295) error #u64(0 18446744073709551613 4294967295 4294967295))
test u64vector-mul (v*s): expects (error #u64(0 18446744073709551614 18446744073709551615 18446744073709551615) error #u64(0 18446744073709551614 18446744073709551615 18446744073709551615)) => got (error #u64(0 18446744073709551614 4294967295 4294967295) error #u64(0 18446744073709551614 4294967295 4294967295))
test s64vector-add (v+v): expects (error #s64(9223372036854775805 9223372036854775806 9223372036854775807 9223372036854775807) error #s64(9223372036854775805 9223372036854775806 9223372036854775807 9223372036854775807)) => got (error #s64(9223372036854775805 9223372036854775806 9223372036854775807 2147483647) error #s64(9223372036854775805 9223372036854775806 9223372036854775807 2147483647))
test s64vector-add (v+s): expects (error #s64(9223372036854775805 9223372036854775806 9223372036854775807 9223372036854775807) error #s64(9223372036854775805 9223372036854775806 9223372036854775807 9223372036854775807)) => got (error #s64(9223372036854775805 9223372036854775806 9223372036854775807 2147483647) error #s64(9223372036854775805 9223372036854775806 9223372036854775807 2147483647))
test s64vector-add (v+s): expects (error error #s64(-9223372036854775808 -9223372036854775808 -9223372036854775807 -9223372036854775806) #s64(-9223372036854775808 -9223372036854775808 -9223372036854775807 -9223372036854775806)) => got (error error #s64(-2147483648 -9223372036854775808 -9223372036854775807 -9223372036854775806) #s64(-2147483648 -9223372036854775808 -9223372036854775807 -9223372036854775806))
test s64vector-add (v+b): expects (error #s64(9223372036854775807 9223372036854775807 9223372036854775807 9223372036854775807) error #s64(9223372036854775807 9223372036854775807 9223372036854775807 9223372036854775807)) => got (error #s64(2147483647 2147483647 2147483647 2147483647) error #s64(2147483647 2147483647 2147483647 2147483647))
test s64vector-add (v+b): expects (error error #s64(-9223372036854775808 -9223372036854775808 -9223372036854775808 -9223372036854775808) #s64(-9223372036854775808 -9223372036854775808 -9223372036854775808 -9223372036854775808)) => got (error error #s64(-2147483648 -2147483648 -2147483648 -2147483648) #s64(-2147483648 -2147483648 -2147483648 -2147483648))
test s64vector-sub (v-v): expects (error error #s64(-9223372036854775806 -9223372036854775807 -9223372036854775808 -9223372036854775808) #s64(-9223372036854775806 -9223372036854775807 -9223372036854775808 -9223372036854775808)) => got (error error #s64(-9223372036854775806 -9223372036854775807 -9223372036854775808 -2147483648) #s64(-9223372036854775806 -9223372036854775807 -9223372036854775808 -2147483648))
test s64vector-sub (v-s): expects (error error #s64(-9223372036854775808 -9223372036854775808 -9223372036854775807 -9223372036854775806) #s64(-9223372036854775808 -9223372036854775808 -9223372036854775807 -9223372036854775806)) => got (error error #s64(-2147483648 -9223372036854775808 -9223372036854775807 -9223372036854775806) #s64(-2147483648 -9223372036854775808 -9223372036854775807 -9223372036854775806))
test s64vector-sub (v-b): expects (error error #s64(-9223372036854775808 -9223372036854775808 -9223372036854775808 -9223372036854775808) #s64(-9223372036854775808 -9223372036854775808 -9223372036854775808 -9223372036854775808)) => got (error error #s64(-2147483648 -2147483648 -2147483648 -2147483648) #s64(-2147483648 -2147483648 -2147483648 -2147483648))
test s64vector-sub (v-b): expects (error #s64(9223372036854775807 9223372036854775807 9223372036854775807 9223372036854775807) error #s64(9223372036854775807 9223372036854775807 9223372036854775807 9223372036854775807)) => got (error #s64(2147483647 2147483647 2147483647 2147483647) error #s64(2147483647 2147483647 2147483647 2147483647))
test s64vector-mul (v*v): expects (error #s64(0 9223372036854775805 9223372036854775807 9223372036854775807) error #s64(0 9223372036854775805 9223372036854775807 9223372036854775807)) => got (error #s64(0 9223372036854775805 2147483647 2147483647) error #s64(0 9223372036854775805 2147483647 2147483647))
test s64vector-mul (v*v): expects (error error #s64(0 -9223372036854775806 -9223372036854775808 -9223372036854775808) #s64(0 -9223372036854775806 -9223372036854775808 -9223372036854775808)) => got (error error #s64(0 -9223372036854775806 -2147483648 -2147483648) #s64(0 -9223372036854775806 -2147483648 -2147483648))
test s64vector-mul (v*s): expects (error #s64(0 9223372036854775806 9223372036854775807 9223372036854775807) error #s64(0 9223372036854775806 9223372036854775807 9223372036854775807)) => got (error #s64(0 9223372036854775806 2147483647 2147483647) error #s64(0 9223372036854775806 2147483647 2147483647))
test s64vector-mul (v*s): expects (error error #s64(0 -9223372036854775806 -9223372036854775808 -9223372036854775808) #s64(0 -9223372036854775806 -9223372036854775808 -9223372036854775808)) => got (error error #s64(0 -9223372036854775806 -2147483648 -2147483648) #s64(0 -9223372036854775806 -2147483648 -2147483648))
```

s/u64vector の clamp 処理で使われている
src/gauche/int64.h の long のところを int64 にしました。


＜テスト結果＞
https://ci.appveyor.com/project/Hamayama/gauche/builds/26714071
まだ utility scripts のテストでエラーが1個出ていますが。。。
