### PR TITLE
Fix utility scripts test error on Windows

### DIFF
--- a/test/scripts.scm
+++ b/test/scripts.scm
@@ -642,20 +642,16 @@
                                       "-e(begin \
                                            (add-load-path \".\") \
                                            (load \"foo\") \
-                                           (write ((global-variable-ref 'foo 'foo-literals))) \
-                                           (write ((global-variable-ref 'foo 'foo-begin1))) \
-                                           (write ((global-variable-ref 'foo 'foo-begin2))) \
-                                           (write ((global-variable-ref 'foo 'foo-include1))) \
-                                           (write ((global-variable-ref 'foo 'foo-include2))) \
+                                           (write (list ((global-variable-ref 'foo 'foo-literals)) \
+                                                        ((global-variable-ref 'foo 'foo-begin1)) \
+                                                        ((global-variable-ref 'foo 'foo-begin2)) \
+                                                        ((global-variable-ref 'foo 'foo-include1)) \
+                                                        ((global-variable-ref 'foo 'foo-include2)))) \
                                            (exit 0))")
                                     :output :pipe :directory "test.o")]
-                    [ret1 (read (process-output p))]
-                    [ret2 (read (process-output p))]
-                    [ret3 (read (process-output p))]
-                    [ret4 (read (process-output p))]
-                    [ret5 (read (process-output p))])
+                    [ret (read (process-output p))])
                (process-wait p)
-               (list ret1 ret2 ret3))]
+               ret)]
             [else
              (load "foo" :paths '("./test.o"))
              (list ((global-variable-ref 'foo 'foo-literals))


### PR DESCRIPTION
テストでエラーが出ていたので修正しました。

```
Testing utility scripts ...                                      failed.
discrepancies found.  Errors are:
test compile and dynload: expects ((1 1.0 +inf.0 -inf.0 +nan.0 10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 22/7 5.0+3.0i #\a "abcde?" a :a #(a b c d e) #u8(1 2 3 4 5) #s8(1 2 3 4 5) #u16(1 2 3 4 5) #s16(1 2 3 4 5) #u32(1 2 3 4 5) #s32(1 2 3 4 5) #u64(1 2 3 4 5) #s64(1 2 3 4 5) #f16(0.0 -0.0 1.0 2.0 3.0 +inf.0 -inf.0 +nan.0) #f32(0.0 -0.0 1.0 2.0 3.0 +inf.0 -inf.0 +nan.0) #f64(0.0 -0.0 1.0 2.0 3.0 +inf.0 -inf.0 +nan.0)) begin1 begin2 include1 include2) => got ((1 1.0 +inf.0 -inf.0 +nan.0 10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 22/7 5.0+3.0i #\a "abcde?" a :a #(a b c d e) #u8(1 2 3 4 5) #s8(1 2 3 4 5) #u16(1 2 3 4 5) #s16(1 2 3 4 5) #u32(1 2 3 4 5) #s32(1 2 3 4 5) #u64(1 2 3 4 5) #s64(1 2 3 4 5) #f16(0.0 -0.0 1.0 2.0 3.0 +inf.0 -inf.0 +nan.0) #f32(0.0 -0.0 1.0 2.0 3.0 +inf.0 -inf.0 +nan.0) #f64(0.0 -0.0 1.0 2.0 3.0 +inf.0 -inf.0 +nan.0)) begin1begin2include1include2 #<eof>)
```

write の出力がつながってうまく read できなかったようです。
