### PR TITLE
Change dynamic-wind and reset/shift behavior v2

### DIFF
--- a/lib/gauche/partcont.scm
+++ b/lib/gauche/partcont.scm
@@ -2,7 +2,7 @@
   (export reset shift call/pc))
 (select-module gauche.partcont)
 
-(define %reset (with-module gauche.internal %apply-rec0))
+(define %reset (with-module gauche.internal %reset))
 (define %call/pc (with-module gauche.internal %call/pc))
 
 (define-syntax reset

--- a/src/gauche.h
+++ b/src/gauche.h
@@ -640,6 +640,7 @@ SCM_EXTERN ScmObj Scm_VMCall(ScmObj *args, int argcnt, void *data);
 
 SCM_EXTERN ScmObj Scm_VMCallCC(ScmObj proc);
 SCM_EXTERN ScmObj Scm_VMCallPC(ScmObj proc);
+SCM_EXTERN ScmObj Scm_VMReset(ScmObj proc);
 SCM_EXTERN ScmObj Scm_VMDynamicWind(ScmObj pre, ScmObj body, ScmObj post);
 SCM_EXTERN ScmObj Scm_VMDynamicWindC(ScmSubrProc *before,
                                      ScmSubrProc *body,

--- a/src/gauche/vm.h
+++ b/src/gauche/vm.h
@@ -276,6 +276,7 @@ typedef struct ScmEscapePointRec {
                                    for they can be executed on anywhere
                                    w.r.t. cstack. */
     ScmObj xhandler;            /* saved exception handler */
+    ScmObj resetChain;          /* for reset/shift */
     int errorReporting;         /* state of SCM_VM_ERROR_REPORTING flag
                                    when this ep is captured.  The flag status
                                    should be restored when the control
@@ -512,6 +513,9 @@ struct ScmVMRec {
                                    Alter this only if you want to customize
                                    it per thread.
                                  */
+
+    /* for reset/shift */
+    ScmObj resetChain;          /* list of pointer to dynamic handler chain */
 
     /* Program information */
     int    evalSituation;       /* eval situation (related to eval-when) */

--- a/src/libproc.scm
+++ b/src/libproc.scm
@@ -73,6 +73,7 @@
 (select-module gauche.internal)
 ;; for partial continuation.  See lib/gauche/partcont.scm
 (define-cproc %call/pc (proc) (return (Scm_VMCallPC proc)))
+(define-cproc %reset (proc) (return (Scm_VMReset proc)))
 
 ;;;
 ;;; Extended argument parsing

--- a/src/vm.c
+++ b/src/vm.c
@@ -2569,7 +2569,8 @@ ScmObj Scm_VMCallPC(ScmObj proc)
 
     /* 'proc' is executed on the outside of 'reset' */
     ScmObj reset_chain = vm->resetChain;
-    vm->resetChain = SCM_CDR(vm->resetChain);
+    vm->resetChain = (SCM_NULLP(vm->resetChain)?
+                      SCM_NIL : SCM_CDR(vm->resetChain));
     ScmObj ret = Scm_VMApply1(proc, contproc);
     vm->resetChain = reset_chain;
     return ret;

--- a/src/vm.c
+++ b/src/vm.c
@@ -2566,14 +2566,7 @@ ScmObj Scm_VMCallPC(ScmObj proc)
        It's ok, for a continuation pointed by cstack will be restored
        in user_eval_inner. */
     vm->cont = c;
-
-    /* 'proc' is executed on the outside of 'reset' */
-    ScmObj reset_chain = vm->resetChain;
-    vm->resetChain = (SCM_NULLP(vm->resetChain)?
-                      SCM_NIL : SCM_CDR(vm->resetChain));
-    ScmObj ret = Scm_VMApply1(proc, contproc);
-    vm->resetChain = reset_chain;
-    return ret;
+    return Scm_VMApply1(proc, contproc);
 }
 
 ScmObj Scm_VMReset(ScmObj proc)

--- a/src/vm.c
+++ b/src/vm.c
@@ -2483,6 +2483,14 @@ static ScmObj partcont_wrapper(ScmObj *argframe,
                                    SCM_MAKE_STR("partial continuation"));
     ScmObj ret = Scm_ApplyRec(contproc, args);
 
+    /* save return values */
+    int nvals = vm->numVals;
+    ScmObj *vals;
+    if (nvals > 1) {
+        vals = SCM_NEW_ARRAY(ScmObj, nvals-1);
+        memcpy(vals, vm->vals, sizeof(ScmObj)*(nvals-1));
+    }
+
     /* call dynamic handlers for reset/shift */
     ScmObj handlers_to_call = throw_cont_calculate_handlers(k_handlers,
                                                             vm->handlers);
@@ -2493,7 +2501,13 @@ static ScmObj partcont_wrapper(ScmObj *argframe,
         Scm_ApplyRec(proc, SCM_NIL);
     }
 
-   return ret;
+    /* restore return values */
+    vm->numVals = nvals;
+    if (nvals > 1) {
+        memcpy(vm->vals, vals, sizeof(ScmObj)*(nvals-1));
+    }
+
+    return ret;
 }
 
 ScmObj Scm_VMCallCC(ScmObj proc)

--- a/test/dynwind.scm
+++ b/test/dynwind.scm
@@ -636,6 +636,29 @@
            (k2)
            (k2))))
 
+(test* "dynamic-wind + reset/shift 3-C"
+       ;"[d01][d02][d21][d01][d11][d12][d02][d01][d11][d12][d02][d01][d11][d12][d02][d22]"
+       "[d01][d02][d21][d22][d01][d11][d12][d02][d21][d22][d01][d11][d12][d02][d21][d22][d01][d11][d12][d02][d21][d22]"
+       (with-output-to-string
+         (^[]
+           (define k1 #f)
+           (define k2 #f)
+           (reset
+            (dynamic-wind
+             (^[] (display "[d01]"))
+             (^[] (shift k (set! k1 k))
+                  (dynamic-wind
+                   (^[] (display "[d11]"))
+                   (^[] (shift k (set! k2 k)))
+                   (^[] (display "[d12]"))))
+             (^[] (display "[d02]"))))
+           (dynamic-wind
+            (^[] (display "[d21]"))
+            (^[] (k1)
+                 (k2)
+                 (k2))
+            (^[] (display "[d22]"))))))
+
 (test* "dynamic-wind + reset/shift 4"
        ;"[d01][d11][d12][d02][d11][d12]"
        "[d01][d11][d12][d02][d01][d11][d12][d02]"

--- a/test/dynwind.scm
+++ b/test/dynwind.scm
@@ -547,6 +547,19 @@
          ;(k3)
          ))
 
+(test* "reset/shift + values 1"
+       '(1 2 3)
+       (values->list (reset (values 1 2 3))))
+
+(test* "reset/shift + values 2"
+       '(1 2 3)
+       (begin
+         (define k1 #f)
+         (reset
+          (shift k (set! k1 k))
+          (values 1 2 3))
+         (values->list (k1))))
+
 (test* "reset/shift + parameterize 1"
        "010"
        (with-output-to-string

--- a/test/dynwind.scm
+++ b/test/dynwind.scm
@@ -531,6 +531,22 @@
 ;;  - tests for interactions of dynamic handlers and partial continuaions.
 ;;  - tests for interactions of partial and full continuations.
 
+(test* "reset/shift combination 1"
+       1000
+       (begin
+         (define k1 #f)
+         (define k2 #f)
+         (define k3 #f)
+         (reset
+          (shift k (set! k1 k)
+                 (shift k (set! k2 k)
+                        (shift k (set! k3 k))))
+          1000)
+         (k1)
+         ;(k2)
+         ;(k3)
+         ))
+
 (test* "reset/shift + parameterize 1"
        "010"
        (with-output-to-string

--- a/test/dynwind.scm
+++ b/test/dynwind.scm
@@ -3,6 +3,7 @@
 ;;
 
 (use gauche.test)
+(use gauche.parameter)
 
 (test-start "dynamic-wind and call/cc")
 
@@ -529,5 +530,209 @@
 ;; To be written:
 ;;  - tests for interactions of dynamic handlers and partial continuaions.
 ;;  - tests for interactions of partial and full continuations.
+
+(test* "reset/shift + parameterize 1"
+       "010"
+       (with-output-to-string
+         (^[]
+           (define p (make-parameter 0))
+           (display (p))
+           (reset
+            (parameterize ([p 1])
+              (display (p))
+              ;; expr of 'shift' is executed on the outside of 'reset'
+              (shift k (display (p))))))))
+
+(test* "reset/shift + call/cc 1"
+       "[r01][r02][r02][r03]"
+       (with-output-to-string
+         (^[]
+           (define k1 #f)
+           (define done #f)
+           (call/cc
+            (^[k0]
+              (reset
+               (display "[r01]")
+               (shift k (set! k1 k))
+               (display "[r02]")
+               (unless done
+                 (set! done #t)
+                 (k0))
+               (display "[r03]"))))
+           (k1))))
+
+(test* "reset/shift + with-error-handler 1"
+       "[E01][E02]"
+       (with-output-to-string
+         (^[]
+           (with-error-handler
+            (^[e] (display (~ e 'message)))
+            (^[]
+              (display "[E01]")
+              (reset (error "[E02]"))
+              (display "[E03]"))))))
+
+(test* "dynamic-wind + reset/shift 1"
+       ;"[d01][d02][d03][d04]"
+       "[d01][d02][d04][d01][d03][d04]"
+       (with-output-to-string
+         (^[]
+           (reset
+            (shift
+             k
+             (dynamic-wind
+              (^[] (display "[d01]"))
+              (^[] (display "[d02]")
+                   (k)
+                   (display "[d03]"))
+              (^[] (display "[d04]"))))))))
+
+(test* "dynamic-wind + reset/shift 2"
+       "[d01][d02][d04][d01][d03][d04]"
+       (with-output-to-string
+         (^[]
+           (define k1 #f)
+           (reset
+            (dynamic-wind
+             (^[] (display "[d01]"))
+             (^[] (display "[d02]")
+                  (shift k (set! k1 k))
+                  (display "[d03]"))
+             (^[] (display "[d04]"))))
+           (k1))))
+
+(test* "dynamic-wind + reset/shift 3"
+       "[d01][d02][d01][d02][d01][d02][d01][d02]"
+       (with-output-to-string
+         (^[]
+           (define k1 #f)
+           (define k2 #f)
+           (reset
+            (dynamic-wind
+             (^[] (display "[d01]"))
+             (^[] (shift k (set! k1 k))
+                  (shift k (set! k2 k)))
+             (^[] (display "[d02]"))))
+           (k1)
+           (k2)
+           (k2))))
+
+(test* "dynamic-wind + reset/shift 3-B"
+       "[d01][d02][d01][d11][d12][d02][d01][d11][d12][d02][d01][d11][d12][d02]"
+       (with-output-to-string
+         (^[]
+           (define k1 #f)
+           (define k2 #f)
+           (reset
+            (dynamic-wind
+             (^[] (display "[d01]"))
+             (^[] (shift k (set! k1 k))
+                  (dynamic-wind
+                   (^[] (display "[d11]"))
+                   (^[] (shift k (set! k2 k)))
+                   (^[] (display "[d12]"))))
+             (^[] (display "[d02]"))))
+           (k1)
+           (k2)
+           (k2))))
+
+(test* "dynamic-wind + reset/shift 4"
+       ;"[d01][d11][d12][d02][d11][d12]"
+       "[d01][d11][d12][d02][d01][d11][d12][d02]"
+       (with-output-to-string
+         (^[]
+           (define k1 #f)
+           (reset
+            (dynamic-wind
+             (^[] (display "[d01]"))
+             (^[] (reset
+                   (dynamic-wind
+                    (^[] (display "[d11]"))
+                    (^[] (shift k (set! k1 k)))
+                    (^[] (display "[d12]")))))
+             (^[] (display "[d02]"))))
+           (k1))))
+
+(test* "dynamic-wind + reset/shift 5"
+       ;"[d01][d02][d01][d11][d12][d02][d11][d12][d11][d12]"
+       "[d01][d02][d01][d11][d12][d02][d01][d11][d12][d02][d01][d11][d12][d02]"
+       (with-output-to-string
+         (^[]
+           (define k1 #f)
+           (define k2 #f)
+           (define k3 #f)
+           (reset
+            (dynamic-wind
+             (^[] (display "[d01]"))
+             (^[] (shift k (set! k1 k))
+                  (reset
+                   (dynamic-wind
+                    (^[] (display "[d11]"))
+                    (^[] (shift k (set! k2 k))
+                         (shift k (set! k3 k)))
+                    (^[] (display "[d12]")))))
+             (^[] (display "[d02]"))))
+           (k1)
+           (k2)
+           (k3))))
+
+(test* "dynamic-wind + reset/shift 6"
+       ;"[d01][d02][d11][d12][d13][d14][d03][d04]"
+       "[d01][d02][d11][d12][d14][d04][d01][d11][d13][d14][d03][d04]"
+       (with-output-to-string
+         (^[]
+           (reset
+            (shift
+             k
+             (dynamic-wind
+              (^[] (display "[d01]"))
+              (^[] (display "[d02]")
+                   (dynamic-wind
+                    (^[] (display "[d11]"))
+                    (^[] (display "[d12]")
+                         (k)
+                         (display "[d13]"))
+                    (^[] (display "[d14]")))
+                   (display "[d03]"))
+              (^[] (display "[d04]"))))))))
+
+(test* "dynamic-wind + reset/shift 7"
+       "[d01][d02][d11][d12][d14][d04][d01][d11][d13][d14][d03][d04]"
+       (with-output-to-string
+         (^[]
+           (define k1 #f)
+           (reset
+            (dynamic-wind
+             (^[] (display "[d01]"))
+             (^[] (display "[d02]")
+                  (dynamic-wind
+                   (^[] (display "[d11]"))
+                   (^[] (display "[d12]")
+                        (shift k (set! k1 k))
+                        (display "[d13]"))
+                   (^[] (display "[d14]")))
+                  (display "[d03]"))
+             (^[] (display "[d04]"))))
+           (k1))))
+
+(test* "dynamic-wind + reset/shift 8"
+       ;"[d01][d02][d04][d11][d12][d01][d03][d04][d13][d14]"
+       "[d01][d02][d04][d11][d12][d14][d01][d03][d04][d11][d13][d14]"
+       (with-output-to-string
+         (^[]
+           (define k1 #f)
+           (reset
+            (dynamic-wind
+             (^[] (display "[d01]"))
+             (^[] (display "[d02]")
+                  (shift k (set! k1 k))
+                  (display "[d03]"))
+             (^[] (display "[d04]"))))
+           (dynamic-wind
+            (^[] (display "[d11]"))
+            (^[] (display "[d12]")
+                 (k1)
+                 (display "[d13]"))
+            (^[] (display "[d14]"))))))
 
 (test-end)


### PR DESCRIPTION
#507 の続きです (#477 の対応)。

前回からの変更点は、Scm_VMCallPC 関数内で、
proc を reset の外側で実行するために、
reset-chain を操作してつじつまを合わせるようにしたことです。
(コメント「'proc' is executed on the outside of 'reset'」のところ)

あと、テストに「dynamic-wind + reset/shift 3-B」を追加しました。
(このテストは、エミュレータの dynamic-test v3 で NG になりましたが、
本プルリクエストでは動的環境の切り出しをしていないため、問題ありませんでした)

＜テスト結果＞
https://ci.appveyor.com/project/Hamayama/gauche/builds/27045206

また、https://github.com/Hamayama/Gauche-effects で、
effects.scm 内の `*use-native-reset*` を #t にした場合も、
正常動作することを確認しています。
