### PR TITLE
Change dynamic-wind and reset/shift behavior v3

### DIFF
--- a/lib/gauche/partcont.scm
+++ b/lib/gauche/partcont.scm
@@ -2,7 +2,7 @@
   (export reset shift call/pc))
 (select-module gauche.partcont)
 
-(define %reset (with-module gauche.internal %apply-rec0))
+(define %reset (with-module gauche.internal %reset))
 (define %call/pc (with-module gauche.internal %call/pc))
 
 (define-syntax reset

--- a/src/gauche.h
+++ b/src/gauche.h
@@ -640,6 +640,7 @@ SCM_EXTERN ScmObj Scm_VMCall(ScmObj *args, int argcnt, void *data);
 
 SCM_EXTERN ScmObj Scm_VMCallCC(ScmObj proc);
 SCM_EXTERN ScmObj Scm_VMCallPC(ScmObj proc);
+SCM_EXTERN ScmObj Scm_VMReset(ScmObj proc);
 SCM_EXTERN ScmObj Scm_VMDynamicWind(ScmObj pre, ScmObj body, ScmObj post);
 SCM_EXTERN ScmObj Scm_VMDynamicWindC(ScmSubrProc *before,
                                      ScmSubrProc *body,

--- a/src/gauche/vm.h
+++ b/src/gauche/vm.h
@@ -278,7 +278,6 @@ typedef struct ScmEscapePointRec {
     ScmObj xhandler;            /* saved exception handler */
     ScmObj resetChain;          /* for reset/shift */
     ScmObj partHandlers;        /* for reset/shift */
-    int partcontReadyState;     /* for reset/shift */
     int errorReporting;         /* state of SCM_VM_ERROR_REPORTING flag
                                    when this ep is captured.  The flag status
                                    should be restored when the control
@@ -517,15 +516,9 @@ struct ScmVMRec {
                                  */
 
     /* for reset/shift */
-    ScmObj resetChain;          /* list of pointer to dynamic handler chain */
-    int    partcontReadyState;  /* EXPERIMENTAL:
-                                   workaround for partial continuation error
-                                   (state of partial continuation availability
-                                     =0: initial state,
-                                     =1: inside of reset,
-                                     =2: inside of partial continuation,
-                                     =3: after executing full continuation,
-                                     =4: partial continuation error) */
+    ScmObj resetChain;          /* list of reset information,
+                                   where reset information is
+                                   (continuation . <dynamic handlers chain>) */
 
     /* Program information */
     int    evalSituation;       /* eval situation (related to eval-when) */

--- a/src/gauche/vm.h
+++ b/src/gauche/vm.h
@@ -278,6 +278,7 @@ typedef struct ScmEscapePointRec {
     ScmObj xhandler;            /* saved exception handler */
     ScmObj resetChain;          /* for reset/shift */
     ScmObj partHandlers;        /* for reset/shift */
+    int partcontReadyState;     /* for reset/shift */
     int errorReporting;         /* state of SCM_VM_ERROR_REPORTING flag
                                    when this ep is captured.  The flag status
                                    should be restored when the control

--- a/src/gauche/vm.h
+++ b/src/gauche/vm.h
@@ -517,6 +517,14 @@ struct ScmVMRec {
 
     /* for reset/shift */
     ScmObj resetChain;          /* list of pointer to dynamic handler chain */
+    int    partcontReadyState;  /* EXPERIMENTAL:
+                                   workaround for partial continuation error
+                                   (state of partial continuation availability
+                                     =0: initial state,
+                                     =1: inside of reset,
+                                     =2: inside of partial continuation,
+                                     =3: after executing full continuation,
+                                     =4: partial continuation error) */
 
     /* Program information */
     int    evalSituation;       /* eval situation (related to eval-when) */

--- a/src/gauche/vm.h
+++ b/src/gauche/vm.h
@@ -276,6 +276,8 @@ typedef struct ScmEscapePointRec {
                                    for they can be executed on anywhere
                                    w.r.t. cstack. */
     ScmObj xhandler;            /* saved exception handler */
+    ScmObj resetChain;          /* for reset/shift */
+    ScmObj partHandlers;        /* for reset/shift */
     int errorReporting;         /* state of SCM_VM_ERROR_REPORTING flag
                                    when this ep is captured.  The flag status
                                    should be restored when the control
@@ -512,6 +514,9 @@ struct ScmVMRec {
                                    Alter this only if you want to customize
                                    it per thread.
                                  */
+
+    /* for reset/shift */
+    ScmObj resetChain;          /* list of pointer to dynamic handler chain */
 
     /* Program information */
     int    evalSituation;       /* eval situation (related to eval-when) */

--- a/src/libproc.scm
+++ b/src/libproc.scm
@@ -73,6 +73,7 @@
 (select-module gauche.internal)
 ;; for partial continuation.  See lib/gauche/partcont.scm
 (define-cproc %call/pc (proc) (return (Scm_VMCallPC proc)))
+(define-cproc %reset (proc) (return (Scm_VMReset proc)))
 
 ;;;
 ;;; Extended argument parsing

--- a/src/vm.c
+++ b/src/vm.c
@@ -242,6 +242,7 @@ ScmVM *Scm_NewVM(ScmVM *proto, ScmObj name)
     v->customErrorReporter = (proto? proto->customErrorReporter : SCM_FALSE);
 
     v->resetChain = SCM_NIL;
+    v->partcontReadyState = 0;
 
     v->evalSituation = SCM_VM_EXECUTING;
 
@@ -1501,6 +1502,10 @@ static ScmObj user_eval_inner(ScmObj program, ScmWord *codevec)
             POP_CONT();
             PC = prev_pc;
         } else if (vm->cont == NULL) {
+            /* workaround for partial continuation error */
+            if (vm->partcontReadyState == 4) {
+                Scm_Error("partial continuation error.");
+            }
             /* we're finished with executing partial continuation.*/
             vm->cont = cstack.cont;
             POP_CONT();
@@ -1535,7 +1540,13 @@ static ScmObj user_eval_inner(ScmObj program, ScmWord *codevec)
                 vm->cont = ep->cont;
                 vm->pc = PC_TO_RETURN;
                 /* restore reset-chain for reset/shift */
-                if (ep->cstack != NULL) vm->resetChain = ep->resetChain;
+                if (ep->cstack != NULL) {
+                    vm->resetChain = ep->resetChain;
+                    /* workaround for partial continuation error */
+                    if (vm->partcontReadyState != 2) {
+                        vm->partcontReadyState = 3;
+                    }
+                }
                 goto restart;
             } else if (vm->cstack->prev == NULL) {
                 /* This loop is the outermost C stack, and nobody will
@@ -2113,7 +2124,13 @@ ScmObj Scm_VMDefaultExceptionHandler(ScmObj e)
             SCM_VM_RUNTIME_FLAG_SET(vm, SCM_ERROR_BEING_REPORTED);
         }
         /* restore reset-chain for reset/shift */
-        if (ep->cstack != NULL) vm->resetChain = ep->resetChain;
+        if (ep->cstack != NULL) {
+            vm->resetChain = ep->resetChain;
+            /* workaround for partial continuation error */
+            if (vm->partcontReadyState != 2) {
+                vm->partcontReadyState = 3;
+            }
+        }
     } else {
         /* We don't have an active error handler, so this is the fallback
            behavior.  Reports the error and rewind dynamic handlers and
@@ -2396,7 +2413,13 @@ static ScmObj throw_cont_body(ScmObj handlers,    /* after/before thunks
     vm->pc = PC_TO_RETURN;
     vm->cont = ep->cont;
     /* restore reset-chain for reset/shift */
-    if (ep->cstack != NULL) vm->resetChain = ep->resetChain;
+    if (ep->cstack != NULL) {
+        vm->resetChain = ep->resetChain;
+        /* workaround for partial continuation error */
+        if (vm->partcontReadyState != 2) {
+            vm->partcontReadyState = 3;
+        }
+    }
 
     nargs = Scm_Length(args);
     if (nargs == 1) {
@@ -2495,6 +2518,10 @@ static ScmObj partcont_wrapper(ScmObj *argframe,
     ScmObj args = argframe[0];
     ScmVM *vm = theVM;
 
+    /* workaround for partial continuation error */
+    int partcontReadyState = vm->partcontReadyState;
+    vm->partcontReadyState = 2;
+
     ScmObj k_handlers = vm->handlers;
 
     ScmObj contproc = Scm_MakeSubr(throw_continuation, ep, 0, 1,
@@ -2527,6 +2554,10 @@ static ScmObj partcont_wrapper(ScmObj *argframe,
     if (nvals > 1) {
         memcpy(vm->vals, vals, sizeof(ScmObj)*(nvals-1));
     }
+
+    /* workaround for partial continuation error */
+    /* (recover saved state) */
+    vm->partcontReadyState = partcontReadyState;
 
     return ret;
 }
@@ -2614,6 +2645,12 @@ ScmObj Scm_VMCallPC(ScmObj proc)
        It's ok, for a continuation pointed by cstack will be restored
        in user_eval_inner. */
     vm->cont = c;
+
+    /* workaround for partial continuation error */
+    if (vm->partcontReadyState == 3 && vm->cont == NULL) {
+        vm->partcontReadyState = 4;
+    }
+
     return Scm_VMApply1(proc, contproc);
 }
 
@@ -2621,11 +2658,20 @@ ScmObj Scm_VMReset(ScmObj proc)
 {
     ScmVM *vm = theVM;
 
+    /* workaround for partial continuation error */
+    int partcontReadyState = vm->partcontReadyState;
+    vm->partcontReadyState = 1;
+
     /* push/pop reset-chain for reset/shift */
     vm->resetChain = Scm_Cons(vm->handlers, vm->resetChain);
     ScmObj ret = Scm_ApplyRec(proc, SCM_NIL);
     SCM_ASSERT(SCM_PAIRP(vm->resetChain));
     vm->resetChain = SCM_CDR(vm->resetChain);
+
+    /* workaround for partial continuation error */
+    /* (recover saved state) */
+    vm->partcontReadyState = partcontReadyState;
+
     return ret;
 }
 

--- a/src/vm.c
+++ b/src/vm.c
@@ -136,7 +136,7 @@ static void save_stack(ScmVM *vm);
 
 static ScmSubr default_exception_handler_rec;
 #define DEFAULT_EXCEPTION_HANDLER  SCM_OBJ(&default_exception_handler_rec)
-static ScmObj throw_cont_calculate_handlers(ScmEscapePoint *, ScmVM *);
+static ScmObj throw_cont_calculate_handlers(ScmObj target, ScmObj current);
 static ScmObj throw_cont_body(ScmObj, ScmEscapePoint*, ScmObj);
 static void   process_queued_requests(ScmVM *vm);
 static void   vm_finalize(ScmObj vm, void *data);
@@ -240,6 +240,8 @@ ScmVM *Scm_NewVM(ScmVM *proto, ScmObj name)
     v->escapeData[0] = NULL;
     v->escapeData[1] = NULL;
     v->customErrorReporter = (proto? proto->customErrorReporter : SCM_FALSE);
+
+    v->resetChain = SCM_NIL;
 
     v->evalSituation = SCM_VM_EXECUTING;
 
@@ -1514,7 +1516,8 @@ static ScmObj user_eval_inner(ScmObj program, ScmWord *codevec)
         if (vm->escapeReason == SCM_VM_ESCAPE_CONT) {
             ScmEscapePoint *ep = (ScmEscapePoint*)vm->escapeData[0];
             if (ep->cstack == vm->cstack) {
-                ScmObj handlers = throw_cont_calculate_handlers(ep, vm);
+                ScmObj handlers = throw_cont_calculate_handlers(ep->handlers,
+                                                                vm->handlers);
                 /* force popping continuation when restarted */
                 vm->pc = PC_TO_RETURN;
                 vm->val0 = throw_cont_body(handlers, ep, vm->escapeData[1]);
@@ -1531,6 +1534,8 @@ static ScmObj user_eval_inner(ScmObj program, ScmWord *codevec)
             if (ep && ep->cstack == vm->cstack) {
                 vm->cont = ep->cont;
                 vm->pc = PC_TO_RETURN;
+                /* restore reset-chain for reset/shift */
+                if (ep->cstack != NULL) vm->resetChain = ep->resetChain;
                 goto restart;
             } else if (vm->cstack->prev == NULL) {
                 /* This loop is the outermost C stack, and nobody will
@@ -1846,25 +1851,23 @@ static ScmObj dynwind_before_cc(ScmObj result SCM_UNUSED, void **data)
     ScmObj before  = SCM_OBJ(data[0]);
     ScmObj body = SCM_OBJ(data[1]);
     ScmObj after = SCM_OBJ(data[2]);
-    void *d[2];
+    void *d[1];
     ScmVM *vm = theVM;
-    ScmObj prev = vm->handlers;
 
     d[0] = (void*)after;
-    d[1] = (void*)prev;
-    vm->handlers = Scm_Cons(Scm_Cons(before, after), prev);
-    Scm_VMPushCC(dynwind_body_cc, d, 2);
+    vm->handlers = Scm_Cons(Scm_Cons(before, after), vm->handlers);
+    Scm_VMPushCC(dynwind_body_cc, d, 1);
     return Scm_VMApply0(body);
 }
 
 static ScmObj dynwind_body_cc(ScmObj result, void **data)
 {
     ScmObj after = SCM_OBJ(data[0]);
-    ScmObj prev  = SCM_OBJ(data[1]);
     void *d[3];
     ScmVM *vm = theVM;
 
-    vm->handlers = prev;
+    SCM_ASSERT(SCM_PAIRP(vm->handlers));
+    vm->handlers = SCM_CDR(vm->handlers);
     d[0] = (void*)result;
     d[1] = (void*)(intptr_t)vm->numVals;
     if (vm->numVals > 1) {
@@ -2024,9 +2027,9 @@ ScmObj Scm_VMDefaultExceptionHandler(ScmObj e)
             current = vm->handlers;
             for (ScmObj hp=current; SCM_PAIRP(hp) && (hp!=target);
                  hp=SCM_CDR(hp)) {
-                ScmObj proc = SCM_CDAR(hp);
+                ScmObj handler = SCM_CDAR(hp);
                 vm->handlers = SCM_CDR(hp);
-                Scm_ApplyRec(proc, SCM_NIL);
+                Scm_ApplyRec(handler, SCM_NIL);
             }
         }
 
@@ -2051,9 +2054,9 @@ ScmObj Scm_VMDefaultExceptionHandler(ScmObj e)
                 current = vm->handlers;
                 for (ScmObj hp=current; SCM_PAIRP(hp) && (hp!=target);
                      hp=SCM_CDR(hp)) {
-                    ScmObj proc = SCM_CDAR(hp);
+                    ScmObj handler = SCM_CDAR(hp);
                     vm->handlers = SCM_CDR(hp);
-                    Scm_ApplyRec(proc, SCM_NIL);
+                    Scm_ApplyRec(handler, SCM_NIL);
                 }
             }
         }
@@ -2073,20 +2076,20 @@ ScmObj Scm_VMDefaultExceptionHandler(ScmObj e)
             /* recover escape point */
             vm->escapePoint = ep;
             SCM_VM_FLOATING_EP_SET(vm, ep->floating);
-            vm->handlers = vmhandlers;
 
             /* reenter dynamic-winds */
-            target = ep->handlers;
-            current = vm->handlers;
+            target = vmhandlers;
+            current = ep->handlers;
             ScmObj hrev = SCM_NIL;
-            for (ScmObj hp=current; SCM_PAIRP(hp) && (hp!=target);
+            for (ScmObj hp=target; SCM_PAIRP(hp) && (hp!=current);
                  hp=SCM_CDR(hp)) {
                 hrev = Scm_Cons(hp, hrev);
             }
             ScmObj p;
             SCM_FOR_EACH(p, hrev) {
-                ScmObj proc = SCM_CAAR(SCM_CAR(p));
-                Scm_ApplyRec(proc, SCM_NIL);
+                ScmObj handler = SCM_CAAR(SCM_CAR(p));
+                Scm_ApplyRec(handler, SCM_NIL);
+                vm->handlers = SCM_CAR(p);
             }
 
             /* reraise and return */
@@ -2109,6 +2112,8 @@ ScmObj Scm_VMDefaultExceptionHandler(ScmObj e)
         if (ep->errorReporting) {
             SCM_VM_RUNTIME_FLAG_SET(vm, SCM_ERROR_BEING_REPORTED);
         }
+        /* restore reset-chain for reset/shift */
+        if (ep->cstack != NULL) vm->resetChain = ep->resetChain;
     } else {
         /* We don't have an active error handler, so this is the fallback
            behavior.  Reports the error and rewind dynamic handlers and
@@ -2117,9 +2122,9 @@ ScmObj Scm_VMDefaultExceptionHandler(ScmObj e)
         /* unwind the dynamic handlers */
         ScmObj hp;
         SCM_FOR_EACH(hp, vm->handlers) {
-            ScmObj proc = SCM_CDAR(hp);
+            ScmObj handler = SCM_CDAR(hp);
             vm->handlers = SCM_CDR(hp);
-            Scm_ApplyRec(proc, SCM_NIL);
+            Scm_ApplyRec(handler, SCM_NIL);
         }
     }
 
@@ -2256,10 +2261,12 @@ static ScmObj with_error_handler(ScmVM *vm, ScmObj handler,
     ep->prev = vm->escapePoint;
     ep->floating = SCM_VM_FLOATING_EP(vm);
     ep->ehandler = handler;
+    ep->cont = vm->cont;
     ep->handlers = vm->handlers;
     ep->cstack = vm->cstack;
     ep->xhandler = vm->exceptionHandler;
-    ep->cont = vm->cont;
+    ep->resetChain = vm->resetChain;
+    ep->partHandlers = SCM_NIL;
     ep->errorReporting =
         SCM_VM_RUNTIME_FLAG_IS_SET(vm, SCM_ERROR_BEING_REPORTED);
     ep->rewindBefore = rewindBefore;
@@ -2318,29 +2325,27 @@ ScmObj Scm_VMWithExceptionHandler(ScmObj handler, ScmObj thunk)
  */
 
 /* Figure out which before and after thunk should be called.
-   Returns a list of (<handler> . <handler-chain>), where the <handler-chain>
-   is the state of handlers on which <handler> should be executed. */
-static ScmObj throw_cont_calculate_handlers(ScmEscapePoint *ep, /*target*/
-                                            ScmVM *vm)
+   Returns a list of (before-flag <handler> . <handler-chain>),
+   where the <handler-chain> is the state of handlers on which
+   <handler> should be executed. */
+static ScmObj throw_cont_calculate_handlers(ScmObj target, ScmObj current)
 {
-    ScmObj target  = Scm_Reverse(ep->handlers);
-    ScmObj current = vm->handlers;
     ScmObj h = SCM_NIL, t = SCM_NIL, p;
+    ScmObj h2 = SCM_NIL;
 
     SCM_FOR_EACH(p, current) {
         SCM_ASSERT(SCM_PAIRP(SCM_CAR(p)));
         if (!SCM_FALSEP(Scm_Memq(SCM_CAR(p), target))) break;
         /* push 'after' handlers to be called */
-        SCM_APPEND1(h, t, Scm_Cons(SCM_CDAR(p), SCM_CDR(p)));
+        SCM_APPEND1(h, t, Scm_Cons(SCM_FALSE, Scm_Cons(SCM_CDAR(p), SCM_CDR(p))));
     }
     SCM_FOR_EACH(p, target) {
         SCM_ASSERT(SCM_PAIRP(SCM_CAR(p)));
-        if (!SCM_FALSEP(Scm_Memq(SCM_CAR(p), current))) continue;
-        ScmObj chain = Scm_Memq(SCM_CAR(p), ep->handlers);
-        SCM_ASSERT(SCM_PAIRP(chain));
+        if (!SCM_FALSEP(Scm_Memq(SCM_CAR(p), current))) break;
         /* push 'before' handlers to be called */
-        SCM_APPEND1(h, t, Scm_Cons(SCM_CAAR(p), SCM_CDR(chain)));
+        h2 = Scm_Cons(Scm_Cons(SCM_TRUE, Scm_Cons(SCM_CAAR(p), p)), h2);
     }
+    SCM_APPEND(h, t, h2);
     return h;
 }
 
@@ -2352,7 +2357,7 @@ static ScmObj throw_cont_body(ScmObj handlers,    /* after/before thunks
                               ScmObj args)        /* args to pass to the
                                                      target continuation */
 {
-    void *data[3];
+    void *data[4];
     int nargs;
     ScmObj ap;
     ScmVM *vm = theVM;
@@ -2362,14 +2367,16 @@ static ScmObj throw_cont_body(ScmObj handlers,    /* after/before thunks
      */
     if (SCM_PAIRP(handlers)) {
         SCM_ASSERT(SCM_PAIRP(SCM_CAR(handlers)));
-        ScmObj handler = SCM_CAAR(handlers);
-        ScmObj chain   = SCM_CDAR(handlers);
+        ScmObj before_flag = SCM_CAAR(handlers);
+        ScmObj handler     = SCM_CADR(SCM_CAR(handlers));
+        ScmObj chain       = SCM_CDDR(SCM_CAR(handlers));
 
         data[0] = (void*)SCM_CDR(handlers);
         data[1] = (void*)ep;
         data[2] = (void*)args;
-        Scm_VMPushCC(throw_cont_cc, data, 3);
-        vm->handlers = chain;
+        data[3] = (void*)(SCM_FALSEP(before_flag)? NULL : chain);
+        Scm_VMPushCC(throw_cont_cc, data, 4);
+        if (SCM_FALSEP(before_flag)) vm->handlers = chain;
         return Scm_VMApply0(handler);
     }
 
@@ -2388,7 +2395,8 @@ static ScmObj throw_cont_body(ScmObj handlers,    /* after/before thunks
      */
     vm->pc = PC_TO_RETURN;
     vm->cont = ep->cont;
-    vm->handlers = ep->handlers;
+    /* restore reset-chain for reset/shift */
+    if (ep->cstack != NULL) vm->resetChain = ep->resetChain;
 
     nargs = Scm_Length(args);
     if (nargs == 1) {
@@ -2410,9 +2418,15 @@ static ScmObj throw_cont_body(ScmObj handlers,    /* after/before thunks
 
 static ScmObj throw_cont_cc(ScmObj result SCM_UNUSED, void **data)
 {
+    ScmVM *vm = theVM;
+
     ScmObj handlers = SCM_OBJ(data[0]);
     ScmEscapePoint *ep = (ScmEscapePoint *)data[1];
     ScmObj args = SCM_OBJ(data[2]);
+    if (data[3]) {
+        ScmObj chain = SCM_OBJ(data[3]);
+        vm->handlers = chain;
+    }
     return throw_cont_body(handlers, ep, args);
 }
 
@@ -2458,8 +2472,63 @@ static ScmObj throw_continuation(ScmObj *argframe,
         save_cont(vm);
     }
 
-    ScmObj handlers_to_call = throw_cont_calculate_handlers(ep, vm);
+    ScmObj handlers_to_call;
+    if (ep->cstack != NULL) {
+        /* for full continuation */
+        handlers_to_call = throw_cont_calculate_handlers(ep->handlers,
+                                                         vm->handlers);
+    } else {
+        /* for partial continuation */
+        handlers_to_call
+            = throw_cont_calculate_handlers(Scm_Append2(ep->partHandlers,
+                                                        vm->handlers),
+                                            vm->handlers);
+    }
+
     return throw_cont_body(handlers_to_call, ep, args);
+}
+
+static ScmObj partcont_wrapper(ScmObj *argframe,
+                               int nargs SCM_UNUSED, void *data)
+{
+    ScmEscapePoint *ep = (ScmEscapePoint*)data;
+    ScmObj args = argframe[0];
+    ScmVM *vm = theVM;
+
+    ScmObj k_handlers = vm->handlers;
+
+    ScmObj contproc = Scm_MakeSubr(throw_continuation, ep, 0, 1,
+                                   SCM_MAKE_STR("partial continuation"));
+    ScmObj ret = Scm_ApplyRec(contproc, args);
+
+    /* save return values */
+    int nvals = vm->numVals;
+    ScmObj *vals;
+    if (nvals > 1) {
+        vals = SCM_NEW_ARRAY(ScmObj, nvals-1);
+        memcpy(vals, vm->vals, sizeof(ScmObj)*(nvals-1));
+    }
+
+    /* call dynamic handlers for reset/shift */
+    ScmObj handlers_to_call = throw_cont_calculate_handlers(k_handlers,
+                                                            vm->handlers);
+    ScmObj p;
+    SCM_FOR_EACH(p, handlers_to_call) {
+        ScmObj before_flag = SCM_CAAR(p);
+        ScmObj handler =     SCM_CADR(SCM_CAR(p));
+        ScmObj chain =       SCM_CDDR(SCM_CAR(p));
+        if (SCM_FALSEP(before_flag))  vm->handlers = chain;
+        Scm_ApplyRec(handler, SCM_NIL);
+        if (!SCM_FALSEP(before_flag)) vm->handlers = chain;
+    }
+
+    /* restore return values */
+    vm->numVals = nvals;
+    if (nvals > 1) {
+        memcpy(vm->vals, vals, sizeof(ScmObj)*(nvals-1));
+    }
+
+    return ret;
 }
 
 ScmObj Scm_VMCallCC(ScmObj proc)
@@ -2473,6 +2542,8 @@ ScmObj Scm_VMCallCC(ScmObj proc)
     ep->cont = vm->cont;
     ep->handlers = vm->handlers;
     ep->cstack = vm->cstack;
+    ep->resetChain = vm->resetChain;
+    ep->partHandlers = SCM_NIL;
 
     ScmObj contproc = Scm_MakeSubr(throw_continuation, ep, 0, 1,
                                    SCM_MAKE_STR("continuation"));
@@ -2509,14 +2580,53 @@ ScmObj Scm_VMCallPC(ScmObj proc)
     ep->handlers = vm->handlers;
     ep->cstack = NULL; /* so that the partial continuation can be run
                           on any cstack state. */
-    ScmObj contproc = Scm_MakeSubr(throw_continuation, ep, 0, 1,
-                                   SCM_MAKE_STR("partial continuation"));
+    ep->resetChain = vm->resetChain;
+    ep->partHandlers = SCM_NIL;
+
+    ScmObj reset_handlers = (SCM_NULLP(vm->resetChain)?
+                             SCM_NIL : SCM_CAR(vm->resetChain));
+
+    /* cut dynamic handler chain for reset/shift */
+    ScmObj h = SCM_NIL, t = SCM_NIL, p;
+    SCM_FOR_EACH(p, ep->handlers) {
+        if (p == reset_handlers) break;
+        SCM_APPEND1(h, t, SCM_CAR(p));
+    }
+    ep->partHandlers = h;
+
+    /* call dynamic handlers for reset/shift */
+    ScmObj handlers_to_call = throw_cont_calculate_handlers(reset_handlers,
+                                                            ep->handlers);
+    ScmObj p2;
+    SCM_FOR_EACH(p2, handlers_to_call) {
+        ScmObj before_flag = SCM_CAAR(p2);
+        ScmObj handler =     SCM_CADR(SCM_CAR(p2));
+        ScmObj chain =       SCM_CDDR(SCM_CAR(p2));
+        if (SCM_FALSEP(before_flag))  vm->handlers = chain;
+        Scm_ApplyRec(handler, SCM_NIL);
+        if (!SCM_FALSEP(before_flag)) vm->handlers = chain;
+    }
+
+    ScmObj contproc = Scm_MakeSubr(partcont_wrapper, ep, 0, 1,
+                                   SCM_MAKE_STR("partial continuation wrapper"));
     /* Remove the saved continuation chain.
        NB: c can be NULL if we've been executing a partial continuation.
        It's ok, for a continuation pointed by cstack will be restored
        in user_eval_inner. */
     vm->cont = c;
     return Scm_VMApply1(proc, contproc);
+}
+
+ScmObj Scm_VMReset(ScmObj proc)
+{
+    ScmVM *vm = theVM;
+
+    /* push/pop reset-chain for reset/shift */
+    vm->resetChain = Scm_Cons(vm->handlers, vm->resetChain);
+    ScmObj ret = Scm_ApplyRec(proc, SCM_NIL);
+    SCM_ASSERT(SCM_PAIRP(vm->resetChain));
+    vm->resetChain = SCM_CDR(vm->resetChain);
+    return ret;
 }
 
 /*==============================================================
@@ -2986,6 +3096,7 @@ void Scm_VMDump(ScmVM *vm)
         ep = ep->prev;
     }
     Scm_Printf(out, "dynenv: %S\n", vm->handlers);
+    Scm_Printf(out, "reset-chain: %S\n", vm->resetChain);
     if (vm->base) {
         Scm_Printf(out, "Code:\n");
         Scm_CompiledCodeDump(vm->base);

--- a/src/vm.c
+++ b/src/vm.c
@@ -1543,6 +1543,7 @@ static ScmObj user_eval_inner(ScmObj program, ScmWord *codevec)
                 if (ep->cstack != NULL) {
                     vm->resetChain = ep->resetChain;
                     /* workaround for partial continuation error */
+                    vm->partcontReadyState = ep->partcontReadyState;
                     if (vm->partcontReadyState != 2) {
                         vm->partcontReadyState = 3;
                     }
@@ -2127,6 +2128,7 @@ ScmObj Scm_VMDefaultExceptionHandler(ScmObj e)
         if (ep->cstack != NULL) {
             vm->resetChain = ep->resetChain;
             /* workaround for partial continuation error */
+            vm->partcontReadyState = ep->partcontReadyState;
             if (vm->partcontReadyState != 2) {
                 vm->partcontReadyState = 3;
             }
@@ -2284,6 +2286,7 @@ static ScmObj with_error_handler(ScmVM *vm, ScmObj handler,
     ep->xhandler = vm->exceptionHandler;
     ep->resetChain = vm->resetChain;
     ep->partHandlers = SCM_NIL;
+    ep->partcontReadyState = vm->partcontReadyState;
     ep->errorReporting =
         SCM_VM_RUNTIME_FLAG_IS_SET(vm, SCM_ERROR_BEING_REPORTED);
     ep->rewindBefore = rewindBefore;
@@ -2416,6 +2419,7 @@ static ScmObj throw_cont_body(ScmObj handlers,    /* after/before thunks
     if (ep->cstack != NULL) {
         vm->resetChain = ep->resetChain;
         /* workaround for partial continuation error */
+        vm->partcontReadyState = ep->partcontReadyState;
         if (vm->partcontReadyState != 2) {
             vm->partcontReadyState = 3;
         }
@@ -2575,6 +2579,7 @@ ScmObj Scm_VMCallCC(ScmObj proc)
     ep->cstack = vm->cstack;
     ep->resetChain = vm->resetChain;
     ep->partHandlers = SCM_NIL;
+    ep->partcontReadyState = vm->partcontReadyState;
 
     ScmObj contproc = Scm_MakeSubr(throw_continuation, ep, 0, 1,
                                    SCM_MAKE_STR("continuation"));
@@ -2613,6 +2618,7 @@ ScmObj Scm_VMCallPC(ScmObj proc)
                           on any cstack state. */
     ep->resetChain = vm->resetChain;
     ep->partHandlers = SCM_NIL;
+    ep->partcontReadyState = vm->partcontReadyState;
 
     ScmObj reset_handlers = (SCM_NULLP(vm->resetChain)?
                              SCM_NIL : SCM_CAR(vm->resetChain));

--- a/test/dynwind.scm
+++ b/test/dynwind.scm
@@ -590,7 +590,7 @@
                (display "[r03]"))))
            (k1))))
 
-(test* "reset/shift + call/cc 2"
+(test* "reset/shift + call/cc error 1"
        (test-error)
        (with-output-to-string
          (^[]
@@ -602,6 +602,21 @@
            (define (f2) (display "[f02]"))
            (reset (f1) (f2))
            (reset (k1)))))
+
+(test* "reset/shift + call/cc error 2"
+       (test-error)
+       (with-output-to-string
+         (^[]
+           (define k1 #f)
+           (define k2 #f)
+           (define k3 #f)
+           (define (f1) (call/cc (^[k] (set! k1 k)))
+                        (shift k (set! k2 k))
+                        (display "[f01]"))
+           (define (f2) (display "[f02]"))
+           (reset (f1) (f2))
+           (reset (shift k (set! k3 k)) (k1))
+           (k3))))
 
 (test* "reset/shift + with-error-handler 1"
        "[E01][E02]"

--- a/test/dynwind.scm
+++ b/test/dynwind.scm
@@ -3,6 +3,7 @@
 ;;
 
 (use gauche.test)
+(use gauche.parameter)
 
 (test-start "dynamic-wind and call/cc")
 
@@ -529,5 +530,261 @@
 ;; To be written:
 ;;  - tests for interactions of dynamic handlers and partial continuaions.
 ;;  - tests for interactions of partial and full continuations.
+
+(test* "reset/shift combination 1"
+       1000
+       (begin
+         (define k1 #f)
+         (define k2 #f)
+         (define k3 #f)
+         (reset
+          (shift k (set! k1 k)
+                 (shift k (set! k2 k)
+                        (shift k (set! k3 k))))
+          1000)
+         (k1)
+         ;(k2)
+         ;(k3)
+         ))
+
+(test* "reset/shift + values 1"
+       '(1 2 3)
+       (values->list (reset (values 1 2 3))))
+
+(test* "reset/shift + values 2"
+       '(1 2 3)
+       (begin
+         (define k1 #f)
+         (reset
+          (shift k (set! k1 k))
+          (values 1 2 3))
+         (values->list (k1))))
+
+(test* "reset/shift + parameterize 1"
+       "010"
+       (with-output-to-string
+         (^[]
+           (define p (make-parameter 0))
+           (display (p))
+           (reset
+            (parameterize ([p 1])
+              (display (p))
+              ;; expr of 'shift' is executed on the outside of 'reset'
+              (shift k (display (p))))))))
+
+(test* "reset/shift + call/cc 1"
+       "[r01][r02][r02][r03]"
+       (with-output-to-string
+         (^[]
+           (define k1 #f)
+           (define done #f)
+           (call/cc
+            (^[k0]
+              (reset
+               (display "[r01]")
+               (shift k (set! k1 k))
+               (display "[r02]")
+               (unless done
+                 (set! done #t)
+                 (k0))
+               (display "[r03]"))))
+           (k1))))
+
+(test* "reset/shift + with-error-handler 1"
+       "[E01][E02]"
+       (with-output-to-string
+         (^[]
+           (with-error-handler
+            (^[e] (display (~ e 'message)))
+            (^[]
+              (display "[E01]")
+              (reset (error "[E02]"))
+              (display "[E03]"))))))
+
+(test* "dynamic-wind + reset/shift 1"
+       "[d01][d02][d03][d04]"
+       ;"[d01][d02][d04][d01][d03][d04]"
+       (with-output-to-string
+         (^[]
+           (reset
+            (shift
+             k
+             (dynamic-wind
+              (^[] (display "[d01]"))
+              (^[] (display "[d02]")
+                   (k)
+                   (display "[d03]"))
+              (^[] (display "[d04]"))))))))
+
+(test* "dynamic-wind + reset/shift 2"
+       "[d01][d02][d04][d01][d03][d04]"
+       (with-output-to-string
+         (^[]
+           (define k1 #f)
+           (reset
+            (dynamic-wind
+             (^[] (display "[d01]"))
+             (^[] (display "[d02]")
+                  (shift k (set! k1 k))
+                  (display "[d03]"))
+             (^[] (display "[d04]"))))
+           (k1))))
+
+(test* "dynamic-wind + reset/shift 3"
+       "[d01][d02][d01][d02][d01][d02][d01][d02]"
+       (with-output-to-string
+         (^[]
+           (define k1 #f)
+           (define k2 #f)
+           (reset
+            (dynamic-wind
+             (^[] (display "[d01]"))
+             (^[] (shift k (set! k1 k))
+                  (shift k (set! k2 k)))
+             (^[] (display "[d02]"))))
+           (k1)
+           (k2)
+           (k2))))
+
+(test* "dynamic-wind + reset/shift 3-B"
+       "[d01][d02][d01][d11][d12][d02][d01][d11][d12][d02][d01][d11][d12][d02]"
+       (with-output-to-string
+         (^[]
+           (define k1 #f)
+           (define k2 #f)
+           (reset
+            (dynamic-wind
+             (^[] (display "[d01]"))
+             (^[] (shift k (set! k1 k))
+                  (dynamic-wind
+                   (^[] (display "[d11]"))
+                   (^[] (shift k (set! k2 k)))
+                   (^[] (display "[d12]"))))
+             (^[] (display "[d02]"))))
+           (k1)
+           (k2)
+           (k2))))
+
+(test* "dynamic-wind + reset/shift 3-C"
+       "[d01][d02][d21][d01][d11][d12][d02][d01][d11][d12][d02][d01][d11][d12][d02][d22]"
+       ;"[d01][d02][d21][d22][d01][d11][d12][d02][d21][d22][d01][d11][d12][d02][d21][d22][d01][d11][d12][d02][d21][d22]"
+       (with-output-to-string
+         (^[]
+           (define k1 #f)
+           (define k2 #f)
+           (reset
+            (dynamic-wind
+             (^[] (display "[d01]"))
+             (^[] (shift k (set! k1 k))
+                  (dynamic-wind
+                   (^[] (display "[d11]"))
+                   (^[] (shift k (set! k2 k)))
+                   (^[] (display "[d12]"))))
+             (^[] (display "[d02]"))))
+           (dynamic-wind
+            (^[] (display "[d21]"))
+            (^[] (k1)
+                 (k2)
+                 (k2))
+            (^[] (display "[d22]"))))))
+
+(test* "dynamic-wind + reset/shift 4"
+       "[d01][d11][d12][d02][d11][d12]"
+       ;"[d01][d11][d12][d02][d01][d11][d12][d02]"
+       (with-output-to-string
+         (^[]
+           (define k1 #f)
+           (reset
+            (dynamic-wind
+             (^[] (display "[d01]"))
+             (^[] (reset
+                   (dynamic-wind
+                    (^[] (display "[d11]"))
+                    (^[] (shift k (set! k1 k)))
+                    (^[] (display "[d12]")))))
+             (^[] (display "[d02]"))))
+           (k1))))
+
+(test* "dynamic-wind + reset/shift 5"
+       "[d01][d02][d01][d11][d12][d02][d11][d12][d11][d12]"
+       ;"[d01][d02][d01][d11][d12][d02][d01][d11][d12][d02][d01][d11][d12][d02]"
+       (with-output-to-string
+         (^[]
+           (define k1 #f)
+           (define k2 #f)
+           (define k3 #f)
+           (reset
+            (dynamic-wind
+             (^[] (display "[d01]"))
+             (^[] (shift k (set! k1 k))
+                  (reset
+                   (dynamic-wind
+                    (^[] (display "[d11]"))
+                    (^[] (shift k (set! k2 k))
+                         (shift k (set! k3 k)))
+                    (^[] (display "[d12]")))))
+             (^[] (display "[d02]"))))
+           (k1)
+           (k2)
+           (k3))))
+
+(test* "dynamic-wind + reset/shift 6"
+       "[d01][d02][d11][d12][d13][d14][d03][d04]"
+       ;"[d01][d02][d11][d12][d14][d04][d01][d11][d13][d14][d03][d04]"
+       (with-output-to-string
+         (^[]
+           (reset
+            (shift
+             k
+             (dynamic-wind
+              (^[] (display "[d01]"))
+              (^[] (display "[d02]")
+                   (dynamic-wind
+                    (^[] (display "[d11]"))
+                    (^[] (display "[d12]")
+                         (k)
+                         (display "[d13]"))
+                    (^[] (display "[d14]")))
+                   (display "[d03]"))
+              (^[] (display "[d04]"))))))))
+
+(test* "dynamic-wind + reset/shift 7"
+       "[d01][d02][d11][d12][d14][d04][d01][d11][d13][d14][d03][d04]"
+       (with-output-to-string
+         (^[]
+           (define k1 #f)
+           (reset
+            (dynamic-wind
+             (^[] (display "[d01]"))
+             (^[] (display "[d02]")
+                  (dynamic-wind
+                   (^[] (display "[d11]"))
+                   (^[] (display "[d12]")
+                        (shift k (set! k1 k))
+                        (display "[d13]"))
+                   (^[] (display "[d14]")))
+                  (display "[d03]"))
+             (^[] (display "[d04]"))))
+           (k1))))
+
+(test* "dynamic-wind + reset/shift 8"
+       "[d01][d02][d04][d11][d12][d01][d03][d04][d13][d14]"
+       ;"[d01][d02][d04][d11][d12][d14][d01][d03][d04][d11][d13][d14]"
+       (with-output-to-string
+         (^[]
+           (define k1 #f)
+           (reset
+            (dynamic-wind
+             (^[] (display "[d01]"))
+             (^[] (display "[d02]")
+                  (shift k (set! k1 k))
+                  (display "[d03]"))
+             (^[] (display "[d04]"))))
+           (dynamic-wind
+            (^[] (display "[d11]"))
+            (^[] (display "[d12]")
+                 (k1)
+                 (display "[d13]"))
+            (^[] (display "[d14]"))))))
 
 (test-end)

--- a/test/dynwind.scm
+++ b/test/dynwind.scm
@@ -590,6 +590,19 @@
                (display "[r03]"))))
            (k1))))
 
+(test* "reset/shift + call/cc 2"
+       (test-error)
+       (with-output-to-string
+         (^[]
+           (define k1 #f)
+           (define k2 #f)
+           (define (f1) (call/cc (^[k] (set! k1 k)))
+                        (shift k (set! k2 k))
+                        (display "[f01]"))
+           (define (f2) (display "[f02]"))
+           (reset (f1) (f2))
+           (reset (k1)))))
+
 (test* "reset/shift + with-error-handler 1"
        "[E01][E02]"
        (with-output-to-string


### PR DESCRIPTION
#477 の件に対応したものです。
(関連プルリクエスト #507, #515)

内容としては、以下の記事の [dynamic-test v4] の動作を、Gauche の本体に反映したものになります。

https://practical-scheme.net/wiliki/wiliki.cgi?Gauche%3A%E9%83%A8%E5%88%86%E7%B6%99%E7%B6%9A%E3%81%A8%E5%8B%95%E7%9A%84%E7%92%B0%E5%A2%83%E3%81%AE%E5%AE%9F%E9%A8%93

ただ、実装の違いもあって、いろいろと気になる部分が出ています。
それらを、以下に挙げておきます。
(今、見返してみると、マージは厳しいかなという気もしますが。。。)

(1) reset-chain の追加
フル継続の起動時 (vm->cont = ep->cont となる箇所[L1] [L2] [L3]) に更新もれがないように
注意が必要 (dynamic-chain (vm->handlers) と同様)。
デバッグ用に Scm_VMDump の dynenv: の下に、reset-chain: として表示するようにした ([L4])。

(2) travel (= dynamic-chain の移動) の実行時、
before の実行**後**に dynamic-chain (vm->handlers) を更新するように統一した ([L5] [L6] [L7] [L8])。
(元は、before も after も、実行**前**に dynamic-chain (vm->handlers) を更新していた)
(他の実装 (Chez, Racket, Guile 等) では、大体以下の順となっている ([TSPL4 5.6] の do-wind 等)
before -> push-winder -> thunk -> pop-winder -> after )
実装としては、handlers_to_call の先頭に before_flag を追加して、
before か after かを判別できるようにした ([L9])。

(3) 部分継続起動時の、dynamic-chain の切り取り (ep->partHandlers に格納) を実装した ([L10])。
これによって、余分な before や after を実行しなくてすむようになった。
(ただ、これによって、dynamic-wind の after での dynamic-chain の復帰は、
前の値 prev に戻すのではだめで、pop が必要になった ([L11])。
このため、フェイルセーフとしては少し弱くなった)
(しかし、現状の parameterize の実装では、パラメータが1個だけのときは、
外側の値と内側の値を、格納場所を分けずに交換するようになっている (その方が省メモリ [L12])。
このため、before なしで after が 呼ばれたら、
内側と外側の値が逆転して、ややこしい不具合になる。
したがって、結局、before なしで after が呼ばれるようなケースは、
できるだけデバッグしてつぶさないといけない)

(4) 今回、travel の実行に Scm_ApplyRec を使用している ([L13] [L14]) ため、
before や after が実質 reset で囲われている意味になっている。
このため、before や after の中に shift を書くと、
Racket や Guile と挙動が異なるケースがある。
(正しくは、Scm_VMApply を使用するべきだが、
Scm_VMApply は 関数を return しないと起動できないので、
実装が大変になる (Scm_VMPushCC で次に呼ぶ関数を指定しないといけない) ため妥協した)
(基本的に before や after の中で継続を使うと、
before と after の対応が崩れるので、そのような運用はしないと思われるが。。。)
(reset を追加しない Scm_ApplyRec が欲しいが、それも難しそう)

(5) 現状、部分継続とフル継続を組み合わせると、
「*** ERROR: attempt to return from a ghost continuation.」
というエラーが出るケースがある (昔から)。
```
(use gauche.partcont)
(define k1 #f)
(reset (call/cc (lambda (k) (set! k1 k))) (display 1000))
(k1)
```
ただ、これは reset の中に戻ることはできない現状の仕様と思われる。

(6) 現状、部分継続を起動すると、
reset (Scm_ApplyRec) を抜けてから呼び出し元に戻るような動作になる (昔から)。
このため、prompt/control を実現することはできない。
(control は、部分継続の起動時に reset を追加しないため、
無関係の reset を探して脱出してしまう)

(7) 今回、部分継続の起動後の travel ([L7]) を実行するために、
partcont_wrapper ([L15]) という関数をかませて、Scm_ApplyRec (reset) を 1段増やしている。
これも、後々 prompt/control を実現しようとすると、問題になるかもしれない。

(8) 今回、部分継続の起動後の travel ([L7]) で、
実際に handler が実行されるようなテストケースが作れていない。
しかし、[Gauche-effects] の threads のサンプルを実行すると、
この travel で handler が実行されている。
(call/cc との組み合わせがポイントのようだが、ネストが複雑すぎて、
シンプルなテストケースに落とせていない。。。)
(結果として、何か変更したら [Gauche-effects] のサンプルを
(effects.scm 内の `*use-native-reset*` を #t に変更してから) すべて手動で実行して、
動作を確認しないといけなくなってしまっている。。。)

(9) 現状、SEGV になるケースがある (昔から)。
https://practical-scheme.net/wiliki/wiliki.cgi?Gauche%3ABugs
の方に記入しました。

[dynamic-test v4]:https://gist.github.com/Hamayama/c3a5424240a9eb69278dd4e6ad6d57c9

[L1]:https://github.com/shirok/Gauche/pull/518/commits/a342dedf9d944035abe54af7554ea28e1e7ccfdb#diff-86406329889f2c13524766839f0a96b3R1537
[L2]:https://github.com/shirok/Gauche/pull/518/commits/a342dedf9d944035abe54af7554ea28e1e7ccfdb#diff-86406329889f2c13524766839f0a96b3R2115
[L3]:https://github.com/shirok/Gauche/pull/518/commits/a342dedf9d944035abe54af7554ea28e1e7ccfdb#diff-86406329889f2c13524766839f0a96b3R2398
[L4]:https://github.com/shirok/Gauche/pull/518/commits/a342dedf9d944035abe54af7554ea28e1e7ccfdb#diff-86406329889f2c13524766839f0a96b3R3099

[L5]:https://github.com/shirok/Gauche/pull/518/commits/a342dedf9d944035abe54af7554ea28e1e7ccfdb#diff-86406329889f2c13524766839f0a96b3R2089
[L6]:https://github.com/shirok/Gauche/pull/518/commits/a342dedf9d944035abe54af7554ea28e1e7ccfdb#diff-86406329889f2c13524766839f0a96b3R2368
[L7]:https://github.com/shirok/Gauche/pull/518/commits/a342dedf9d944035abe54af7554ea28e1e7ccfdb#diff-86406329889f2c13524766839f0a96b3R2512
[L8]:https://github.com/shirok/Gauche/pull/518/commits/a342dedf9d944035abe54af7554ea28e1e7ccfdb#diff-86406329889f2c13524766839f0a96b3R2597
[L9]:https://github.com/shirok/Gauche/pull/518/commits/a342dedf9d944035abe54af7554ea28e1e7ccfdb#diff-86406329889f2c13524766839f0a96b3R2327

[TSPL4 5.6]:https://scheme.com/tspl4/control.html#./control:s56

[L10]:https://github.com/shirok/Gauche/pull/518/commits/a342dedf9d944035abe54af7554ea28e1e7ccfdb#diff-86406329889f2c13524766839f0a96b3R2589
[L11]:https://github.com/shirok/Gauche/pull/518/commits/a342dedf9d944035abe54af7554ea28e1e7ccfdb#diff-86406329889f2c13524766839f0a96b3L1866
[L12]:https://github.com/shirok/Gauche/blob/77c3ba123c4ed1c90fc7d0a27d11c242d738d978/libsrc/gauche/parameter.scm#L118

[L13]:https://github.com/shirok/Gauche/pull/518/commits/a342dedf9d944035abe54af7554ea28e1e7ccfdb#diff-86406329889f2c13524766839f0a96b3R2512
[L14]:https://github.com/shirok/Gauche/pull/518/commits/a342dedf9d944035abe54af7554ea28e1e7ccfdb#diff-86406329889f2c13524766839f0a96b3R2597

[L15]:https://github.com/shirok/Gauche/pull/518/commits/a342dedf9d944035abe54af7554ea28e1e7ccfdb#diff-86406329889f2c13524766839f0a96b3R2491

[Gauche-effects]:https://github.com/Hamayama/Gauche-effects
