### PR TITLE
Change char-set:digit and char-set:letter+digit to cover full Unicode range

### DIFF
--- a/doc/modr7rs.texi
+++ b/doc/modr7rs.texi
@@ -4525,10 +4525,13 @@ Returns a character set that adds @var{char1} @dots{} to
 @end defvar
 
 @defvar char-set:digit
+@defvarx char-set:ascii-digit
 @defvarx char-set:hex-digit
 @defvarx char-set:letter+digit
 [R7RS charset]
 @c MOD scheme.charset
+@code{char-set:ascii-digit} is Gauche extension that covers only ASCII
+digits.
 @end defvar
 
 @defvar char-set:graphic

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -347,7 +347,7 @@ $(libgc_pic_LIBRARY): $(GCLIB) $(libgc_pic_OBJECTS)
 # If you're not sure which files are needed, just run something like
 #    make UNICODEDATA=/ char-data
 # and the script will tell you the required files.
-char_attr.c : unicode-data.scm
+char_attr.c : unicode-data.scm gen-unicode.scm
 	$(BUILD_GOSH) $(srcdir)/gen-unicode.scm --compile $(srcdir)/unicode-data.scm
 
 char-data : gen-unicode.scm

--- a/src/char.c
+++ b/src/char.c
@@ -1045,11 +1045,11 @@ ScmObj Scm_CharSetRead(ScmPort *input, int *complement_p,
                     goto ordchar;
                 case 'd':
                     moreset_complement = FALSE;
-                    moreset = Scm_GetStandardCharSet(SCM_CHAR_SET_DIGIT);
+                    moreset = Scm_GetStandardCharSet(SCM_CHAR_SET_ASCII_DIGIT);
                     break;
                 case 'D':
                     moreset_complement = TRUE;
-                    moreset = Scm_GetStandardCharSet(SCM_CHAR_SET_DIGIT);
+                    moreset = Scm_GetStandardCharSet(SCM_CHAR_SET_ASCII_DIGIT);
                     break;
                 case 's':
                     moreset_complement = FALSE;
@@ -1197,7 +1197,7 @@ ScmObj read_predef_charset(const char **cp, int error_p)
         } else if (strncmp(name, ":cntrl:", 7) == 0) {
             return Scm_GetStandardCharSet(SCM_CHAR_SET_ISO_CONTROL);
         } else if (strncmp(name, ":digit:", 7) == 0) {
-            return Scm_GetStandardCharSet(SCM_CHAR_SET_DIGIT);
+            return Scm_GetStandardCharSet(SCM_CHAR_SET_ASCII_DIGIT);
         } else if (strncmp(name, ":graph:", 7) == 0) {
             return Scm_GetStandardCharSet(SCM_CHAR_SET_GRAPHIC);
         } else if (strncmp(name, ":lower:", 7) == 0) {
@@ -1417,7 +1417,7 @@ ScmChar Scm_CharFoldcase(ScmChar ch)
  */
 
 /* NB: The predefined character sets covers full Unicode range,
-   except DIGIT, LETTER_DIGIT, HEX_DIGIT, WHITESPACE, BLANK and WORD.
+   except ASCII_DIGIT, LETTER_DIGIT, HEX_DIGIT, WHITESPACE, BLANK and WORD.
    (You can find the code that determines the exact membership of these
    sets in src/gen-unicode.scm (build-code-sets)).
 
@@ -1485,7 +1485,7 @@ void Scm__InitChar(void)
     DEFCS("upper-case", UPPER);
     DEFCS("title-case", TITLE);
     DEFCS("letter", LETTER);
-    DEFCS("digit", DIGIT);
+    DEFCS("digit", ASCII_DIGIT);
     DEFCS("letter+digit", LETTER_DIGIT);
     DEFCS("graphic", GRAPHIC);
     DEFCS("printing", PRINTING);

--- a/src/char.c
+++ b/src/char.c
@@ -1417,7 +1417,7 @@ ScmChar Scm_CharFoldcase(ScmChar ch)
  */
 
 /* NB: The predefined character sets covers full Unicode range,
-   except ASCII_DIGIT, LETTER_DIGIT, HEX_DIGIT, WHITESPACE, BLANK and WORD.
+   except ASCII_DIGIT, HEX_DIGIT, WHITESPACE, BLANK and WORD.
    (You can find the code that determines the exact membership of these
    sets in src/gen-unicode.scm (build-code-sets)).
 
@@ -1444,6 +1444,7 @@ void Scm__InitChar(void)
     predef_sets[SCM_CHAR_SET_LOWER] = predef_sets[SCM_CHAR_SET_Ll];
     predef_sets[SCM_CHAR_SET_UPPER] = predef_sets[SCM_CHAR_SET_Lu];
     predef_sets[SCM_CHAR_SET_TITLE] = predef_sets[SCM_CHAR_SET_Lt];
+    predef_sets[SCM_CHAR_SET_DIGIT] = predef_sets[SCM_CHAR_SET_Nd];
     predef_sets[SCM_CHAR_SET_ISO_CONTROL] = predef_sets[SCM_CHAR_SET_Cc];
     predef_sets[SCM_CHAR_SET_FULL] = Scm_CharSetComplement(make_charset());
     
@@ -1485,7 +1486,8 @@ void Scm__InitChar(void)
     DEFCS("upper-case", UPPER);
     DEFCS("title-case", TITLE);
     DEFCS("letter", LETTER);
-    DEFCS("digit", ASCII_DIGIT);
+    DEFCS("digit", DIGIT);
+    DEFCS("ascii-digit", ASCII_DIGIT);
     DEFCS("letter+digit", LETTER_DIGIT);
     DEFCS("graphic", GRAPHIC);
     DEFCS("printing", PRINTING);

--- a/src/gauche/priv/charP.h
+++ b/src/gauche/priv/charP.h
@@ -80,8 +80,8 @@ enum {
     SCM_CHAR_SET_UPPER,         /* Lu */
     SCM_CHAR_SET_TITLE,         /* Lt */
     SCM_CHAR_SET_LETTER,        /* Lu|Ll|Lt|Lm|Lo */
-    SCM_CHAR_SET_DIGIT,         /* Nd */
-    SCM_CHAR_SET_LETTER_DIGIT,  /* L*|Nd */
+    SCM_CHAR_SET_ASCII_DIGIT,   /* [0-9] */
+    SCM_CHAR_SET_LETTER_DIGIT,  /* L*|[0-9] */
     SCM_CHAR_SET_GRAPHIC,       /* L*|N*|P*|S* */
     SCM_CHAR_SET_PRINTING,      /* L*|N*|P*|S*|Z* */
     SCM_CHAR_SET_WHITESPACE,    /* Z*|\u0009-\u000d */

--- a/src/gauche/priv/charP.h
+++ b/src/gauche/priv/charP.h
@@ -80,8 +80,9 @@ enum {
     SCM_CHAR_SET_UPPER,         /* Lu */
     SCM_CHAR_SET_TITLE,         /* Lt */
     SCM_CHAR_SET_LETTER,        /* Lu|Ll|Lt|Lm|Lo */
+    SCM_CHAR_SET_DIGIT,         /* Nd */
     SCM_CHAR_SET_ASCII_DIGIT,   /* [0-9] */
-    SCM_CHAR_SET_LETTER_DIGIT,  /* L*|[0-9] */
+    SCM_CHAR_SET_LETTER_DIGIT,  /* L*|Nd */
     SCM_CHAR_SET_GRAPHIC,       /* L*|N*|P*|S* */
     SCM_CHAR_SET_PRINTING,      /* L*|N*|P*|S*|Z* */
     SCM_CHAR_SET_WHITESPACE,    /* Z*|\u0009-\u000d */

--- a/src/gen-unicode.scm
+++ b/src/gen-unicode.scm
@@ -634,7 +634,7 @@
   (hash-table-put! sets 'LETTER_DIGIT
                    (code-set-union 'LETTER_DIGIT
                                    (hash-table-ref sets 'LETTER)
-                                   (hash-table-ref sets 'ASCII_DIGIT)))
+                                   (hash-table-ref sets 'Nd)))
   (hash-table-put! sets 'WHITESPACE
                    (rlet1 cs (make <char-code-set> :name 'WHITESPACE)
                      (add-code-range! cs 9 13) ;TAB,LF,LTAB,FF,CR

--- a/src/gen-unicode.scm
+++ b/src/gen-unicode.scm
@@ -407,7 +407,7 @@
   ;; bind predefined charset
   (print "static void init_predefined_charsets() {")
   (dolist [cat (append (ucd-general-categories)
-                       '(LETTER DIGIT LETTER_DIGIT GRAPHIC PRINTING
+                       '(LETTER ASCII_DIGIT LETTER_DIGIT GRAPHIC PRINTING
                          WHITESPACE BLANK PUNCTUATION SYMBOL HEX_DIGIT
                          ASCII EMPTY WORD))]
     (print #"  predef_sets[SCM_CHAR_SET_~|cat|] =")
@@ -626,15 +626,15 @@
                                    (hash-table-ref sets 'Lt)
                                    (hash-table-ref sets 'Lm)
                                    (hash-table-ref sets 'Lo)))
-  (hash-table-put! sets 'DIGIT
-                   (rlet1 cs (make <char-code-set> :name 'DIGIT)
+  (hash-table-put! sets 'ASCII_DIGIT
+                   (rlet1 cs (make <char-code-set> :name 'ASCII_DIGIT)
                      (add-code-range! cs 
                                       (char->integer #\0)
                                       (char->integer #\9))))
   (hash-table-put! sets 'LETTER_DIGIT
                    (code-set-union 'LETTER_DIGIT
                                    (hash-table-ref sets 'LETTER)
-                                   (hash-table-ref sets 'DIGIT)))
+                                   (hash-table-ref sets 'ASCII_DIGIT)))
   (hash-table-put! sets 'WHITESPACE
                    (rlet1 cs (make <char-code-set> :name 'WHITESPACE)
                      (add-code-range! cs 9 13) ;TAB,LF,LTAB,FF,CR

--- a/src/regexp.c
+++ b/src/regexp.c
@@ -433,11 +433,11 @@ static ScmObj rc1_lex(regcomp_ctx *ctx)
         case 'x': case 'u': case 'U':
             return rc1_lex_xdigits(ctx->ipat, ch);
         case 'd':
-            cs = Scm_GetStandardCharSet(SCM_CHAR_SET_DIGIT);
+            cs = Scm_GetStandardCharSet(SCM_CHAR_SET_ASCII_DIGIT);
             rc_register_charset(ctx, SCM_CHAR_SET(cs));
             return cs;
         case 'D':
-            cs = Scm_GetStandardCharSet(SCM_CHAR_SET_DIGIT);
+            cs = Scm_GetStandardCharSet(SCM_CHAR_SET_ASCII_DIGIT);
             rc_register_charset(ctx, SCM_CHAR_SET(cs));
             return Scm_Cons(SCM_SYM_COMP, cs);
         case 'w':

--- a/test/srfi.scm
+++ b/test/srfi.scm
@@ -219,7 +219,7 @@
        (char-set= (string->char-set "eiaou2468013579999")
                   (char-set-unfold null? car cdr
                                    '(#\a #\e #\i #\o #\u #\u #\u)
-                                   char-set:digit)))
+                                   char-set:ascii-digit)))
 (test* "char-set-unfold (default)" #t
        (char-set= (string->char-set "aeiou")
                   (char-set-unfold null? car cdr


### PR DESCRIPTION
Here's an attempt to fix issue #496 . I split it in two commits to make sure I don't accidentally use the unicode digit charset elsewhere. Though if somebody else maintains a fork of Gauche and uses `SCM_CHAR_SET_DIGIT` then he will be surprised.