### PR TITLE
srfi-115: fix regexp-replace taking a single symbol or number

### DIFF
--- a/doc/modr7rs.texi
+++ b/doc/modr7rs.texi
@@ -7081,11 +7081,10 @@ match will be replaced instead of the first one.
 
 @var{subst} can be either a string (the replacement), an integer or a
 symbol to refer to the capture group that will be used as the
-replacement.
+replacement, or a list of those.
 
 The special symbols @code{pre} and @code{post} use the substring to
-the left or right of the match as replacement, respectively. But this
-is not supported yet.
+the left or right of the match as replacement, respectively.
 
 As a Gauche extension, @var{subst} could also be a procedure, which is
 called with the given match object and the result will be used as the

--- a/test/srfi.scm
+++ b/test/srfi.scm
@@ -1970,6 +1970,12 @@
 (test* "regexp-replace"
        "  abc-  abc"
        (regexp-replace '(: ($ (+ alpha)) ":" (* space)) "  abc: " '(1 "-" pre 1)))
+(test* "regexp-replace"
+       "abcghighi"
+       (regexp-replace "def" "abcdefghi" 'post))
+(test* "regexp-replace"
+       "abcabcghi"
+       (regexp-replace "def" "abcdefghi" 'pre))
 
 (test* "regexp-replace"
        "-abc \t\n d ef  "


### PR DESCRIPTION
The underlying regexp-replace code in librx.scm expects substitution to
be either a procedure or a list of things. The SRFI-115 wrapper does not
wrap symbols or numbers properly (it does wrap strings), and will
trigger an error:

    gosh[r7rs.user]$ (regexp-replace "abc" "abcdefghi" 0)
    *** ERROR: pair required, but got 0

Fix this.

Also catch the ambiguous case where the user has a capture group named
'pre or 'post and also uses 'pre or 'post in regexp-replace. We can't be
sure if the user wants a capture group as the substitution, or
regexp-{before,after}.

Raise an error (and the user may need to rename their capture
groups). The current behavior is always treat 'pre/'post as
regexp-before/after, which could be unexpected.