### PR TITLE
Display additional stack trace for r7rs#import error

### DIFF
--- a/src/error.c
+++ b/src/error.c
@@ -937,7 +937,7 @@ void Scm_DumpStackTrace(ScmVM *vm, ScmPort *port)
 
     /* display additional stack trace */
     if (vm->errorCont) {
-        ScmContFrame    *vmcont = vm->cont;
+        ScmContFrame *vmcont = vm->cont;
         ScmCompiledCode *vmbase = vm->base;
         vm->cont = vm->errorCont;
         vm->base = NULL;
@@ -947,6 +947,7 @@ void Scm_DumpStackTrace(ScmVM *vm, ScmPort *port)
         Scm_ShowStackTrace(port, stack2, 0, 0, 0, 0);
         vm->cont = vmcont;
         vm->base = vmbase;
+        /* reset information for additional stack trace */
         vm->errorCont = NULL;
     }
 

--- a/src/error.c
+++ b/src/error.c
@@ -937,13 +937,16 @@ void Scm_DumpStackTrace(ScmVM *vm, ScmPort *port)
 
     /* display additional stack trace */
     if (vm->errorCont) {
-        ScmContFrame *vmcont = vm->cont;
+        ScmContFrame    *vmcont = vm->cont;
+        ScmCompiledCode *vmbase = vm->base;
         vm->cont = vm->errorCont;
+        vm->base = NULL;
         ScmObj stack2 = Scm_VMGetStackLite(vm);
         SCM_PUTZ("Stack Trace on Error:\n", -1, port);
         SCM_PUTZ("_______________________________________\n", -1, port);
         Scm_ShowStackTrace(port, stack2, 0, 0, 0, 0);
         vm->cont = vmcont;
+        vm->base = vmbase;
         vm->errorCont = NULL;
     }
 

--- a/src/error.c
+++ b/src/error.c
@@ -942,9 +942,11 @@ void Scm_DumpStackTrace(ScmVM *vm, ScmPort *port)
         vm->cont = vm->errorCont;
         vm->base = NULL;
         ScmObj stack2 = Scm_VMGetStackLite(vm);
-        SCM_PUTZ("Stack Trace on Error:\n", -1, port);
-        SCM_PUTZ("_______________________________________\n", -1, port);
-        Scm_ShowStackTrace(port, stack2, 0, 0, 0, 0);
+        if (!Scm_EqualP(stack, stack2)) {
+            SCM_PUTZ("Stack Trace on Error:\n", -1, port);
+            SCM_PUTZ("_______________________________________\n", -1, port);
+            Scm_ShowStackTrace(port, stack2, 0, 0, 0, 0);
+        }
         vm->cont = vmcont;
         vm->base = vmbase;
         /* reset information for additional stack trace */

--- a/src/error.c
+++ b/src/error.c
@@ -934,6 +934,19 @@ void Scm_DumpStackTrace(ScmVM *vm, ScmPort *port)
     SCM_PUTZ("Stack Trace:\n", -1, port);
     SCM_PUTZ("_______________________________________\n", -1, port);
     Scm_ShowStackTrace(port, stack, 0, 0, 0, 0);
+
+    /* display additional stack trace */
+    if (vm->errorCont) {
+        ScmContFrame *vmcont = vm->cont;
+        vm->cont = vm->errorCont;
+        ScmObj stack2 = Scm_VMGetStackLite(vm);
+        SCM_PUTZ("Stack Trace on Error:\n", -1, port);
+        SCM_PUTZ("_______________________________________\n", -1, port);
+        Scm_ShowStackTrace(port, stack2, 0, 0, 0, 0);
+        vm->cont = vmcont;
+        vm->errorCont = NULL;
+    }
+
     if (vm->callTrace) {
         ScmObj trace = Scm_VMGetCallTraceLite(vm);
         SCM_PUTZ("Call Trace:\n", -1, port);

--- a/src/gauche/vm.h
+++ b/src/gauche/vm.h
@@ -513,6 +513,9 @@ struct ScmVMRec {
                                    it per thread.
                                  */
 
+    /* for additional stack trace */
+    ScmContFrame *errorCont;    /* saved continuation when error occurs */
+
     /* Program information */
     int    evalSituation;       /* eval situation (related to eval-when) */
 

--- a/src/gauche/vm.h
+++ b/src/gauche/vm.h
@@ -514,7 +514,7 @@ struct ScmVMRec {
                                  */
 
     /* for additional stack trace */
-    ScmContFrame *errorCont;    /* saved continuation when error occurs */
+    ScmContFrame *errorCont;    /* continuation saved on error */
 
     /* Program information */
     int    evalSituation;       /* eval situation (related to eval-when) */

--- a/src/vm.c
+++ b/src/vm.c
@@ -1692,7 +1692,7 @@ static ScmObj safe_eval_handler(ScmObj *args,
     SCM_ASSERT(nargs == 1);
     ((struct eval_packet_rec *)data)->exception = args[0];
 
-    /* save continuation for additional stack trace */
+    /* save information for additional stack trace */
     if (vm->errorCont == NULL) {
         save_cont(vm);
         vm->errorCont = vm->cont;
@@ -1743,7 +1743,7 @@ static int safe_eval_wrap(int kind, ScmObj arg0, ScmObj args,
     epak.cstr = cstr;
     epak.exception = SCM_UNBOUND;
 
-    /* reset continuation for additional stack trace */
+    /* reset information for additional stack trace */
     vm->errorCont = NULL;
 
     ScmObj proc = Scm_MakeSubr(safe_eval_int, &epak, 0, 0, SCM_FALSE);


### PR DESCRIPTION
#521 の件に対応したものです。

問題がありそうですが、まずは案として挙げておきます。

＜原因＞
r7rs#import は、内部で require を呼んでいる。

require は、内部で Scm_Load を SCM_LOAD_PROPAGATE_ERROR フラグなしで呼んでいる。

Scm_Load は、SCM_LOAD_PROPAGATE_ERROR フラグを指定しないと、
Scm_Apply → safe_eval_wrap → safe_eval_int → Scm_VMWithErrorHandler → with_error_handler
と進んで、with_error_handler でエラーをトラップして戻るようになっている。

このエラーをトラップして戻るときに、
Scm_VMDefaultExceptionHandler で vm->cont = ep->cont が実行され、
スタックが巻き戻って、スタックトレースが捨てられている。

＜対策＞
エラーハンドラ (safe_eval_handler) のところで vm->cont を vm->errorCont に保存し、
Scm_DumpStackTrace で追加のスタックトレースを表示するようにした。

表示例.
```
>gosh -I.
gosh> (import (def))
*** ERROR: invalid application: (() ())
    While loading "./def.sld" at line 3
    While compiling: (import (def))
    While compiling "(windows console standard input)" at line 1: (import (def))

Stack Trace:
_______________________________________
  0  (eval expr env)
        at "C:\\Program Files (x86)\\Gauche\\share\\gauche-0.97\\0.9.9_pre1\\lib
/gauche/interactive.scm":269
Stack Trace on Error:
_______________________________________
  0  (() '())
        at "./def.scm":3
  1  (case-lambda (() '()) ((lst) lst) ((lst x) (cons x lst)))
        at "./def.scm":2
  2  (eval expr env)
        at "C:\\Program Files (x86)\\Gauche\\share\\gauche-0.97\\0.9.9_pre1\\lib
/gauche/interactive.scm":269
```

＜気になる点＞
(1) スタックトレースが2個表示されるため、分かりにくい。
(しかし、1個だけ表示すると、だまされるケースが出そう。。。)

(2) vm->errorCont をリセットするよいタイミングがない。
とりあえず safe_eval_wrap と Scm_DumpStackTrace に入れておいたが、
無関係のエラーのときに表示されたりするかも。

(3) safe_eval_handler に save_cont(vm) を追加したため、
速度やメモリ使用量に影響があるかもしれない。
(単に vm->errorCont = vm->cont のみだと SEGV した)

＜テスト結果＞
https://ci.appveyor.com/project/Hamayama/gauche/builds/27558400
