### PR TITLE
Change dynamic-wind and reset/shift behavior v4

### DIFF
--- a/lib/gauche/partcont.scm
+++ b/lib/gauche/partcont.scm
@@ -2,7 +2,7 @@
   (export reset shift call/pc))
 (select-module gauche.partcont)
 
-(define %reset (with-module gauche.internal %apply-rec0))
+(define %reset (with-module gauche.internal %reset))
 (define %call/pc (with-module gauche.internal %call/pc))
 
 (define-syntax reset

--- a/src/gauche.h
+++ b/src/gauche.h
@@ -640,6 +640,7 @@ SCM_EXTERN ScmObj Scm_VMCall(ScmObj *args, int argcnt, void *data);
 
 SCM_EXTERN ScmObj Scm_VMCallCC(ScmObj proc);
 SCM_EXTERN ScmObj Scm_VMCallPC(ScmObj proc);
+SCM_EXTERN ScmObj Scm_VMReset(ScmObj proc);
 SCM_EXTERN ScmObj Scm_VMDynamicWind(ScmObj pre, ScmObj body, ScmObj post);
 SCM_EXTERN ScmObj Scm_VMDynamicWindC(ScmSubrProc *before,
                                      ScmSubrProc *body,

--- a/src/gauche/vm.h
+++ b/src/gauche/vm.h
@@ -114,6 +114,7 @@ typedef struct ScmEnvFrameRec {
  *   |  base  |
  *   |   pc   |
  *   |  cpc   |
+ *   | marker |
  *   | size=N |
  *   |  env   |
  *   |..prev..|<--- ScmContFrame* cont
@@ -132,6 +133,7 @@ typedef struct ScmContFrameRec {
     struct ScmContFrameRec *prev; /* previous frame */
     ScmEnvFrame *env;             /* saved environment */
     int size;                     /* size of argument frame */
+    int marker;                   /* end marker of partial continuation */
     SCM_PCTYPE cpc;               /* current PC (for debugging info) */
     SCM_PCTYPE pc;                /* next PC */
     ScmCompiledCode *base;        /* base register value */
@@ -276,6 +278,8 @@ typedef struct ScmEscapePointRec {
                                    for they can be executed on anywhere
                                    w.r.t. cstack. */
     ScmObj xhandler;            /* saved exception handler */
+    ScmObj resetChain;          /* for reset/shift */
+    ScmObj partHandlers;        /* for reset/shift */
     int errorReporting;         /* state of SCM_VM_ERROR_REPORTING flag
                                    when this ep is captured.  The flag status
                                    should be restored when the control
@@ -535,6 +539,14 @@ struct ScmVMRec {
                                    Set by vm_register. */
 
     ScmCallTrace *callTrace;
+
+    /* for reset/shift */
+    ScmObj resetChain;          /* list of reset information,
+                                   where reset information is
+                                   (delimited . <dynamic handlers chain>).
+                                   the delimited flag is set when 'shift'
+                                   appears in 'reset' and the end marker of
+                                   partial continuation is set. */
 };
 
 SCM_EXTERN ScmVM *Scm_NewVM(ScmVM *proto, ScmObj name);

--- a/src/libproc.scm
+++ b/src/libproc.scm
@@ -73,6 +73,7 @@
 (select-module gauche.internal)
 ;; for partial continuation.  See lib/gauche/partcont.scm
 (define-cproc %call/pc (proc) (return (Scm_VMCallPC proc)))
+(define-cproc %reset (proc) (return (Scm_VMReset proc)))
 
 ;;;
 ;;; Extended argument parsing

--- a/test/dynwind.scm
+++ b/test/dynwind.scm
@@ -3,6 +3,7 @@
 ;;
 
 (use gauche.test)
+(use gauche.parameter)
 
 (test-start "dynamic-wind and call/cc")
 
@@ -529,5 +530,301 @@
 ;; To be written:
 ;;  - tests for interactions of dynamic handlers and partial continuaions.
 ;;  - tests for interactions of partial and full continuations.
+
+(test* "reset/shift combination 1"
+       1000
+       (begin
+         (define k1 #f)
+         (define k2 #f)
+         (define k3 #f)
+         (reset
+          (shift k (set! k1 k)
+                 (shift k (set! k2 k)
+                        (shift k (set! k3 k))))
+          1000)
+         (k1)
+         ;(k2)
+         ;(k3)
+         ))
+
+(test* "reset/shift + values 1"
+       '(1 2 3)
+       (values->list (reset (values 1 2 3))))
+
+(test* "reset/shift + values 2"
+       '(1 2 3)
+       (begin
+         (define k1 #f)
+         (reset
+          (shift k (set! k1 k))
+          (values 1 2 3))
+         (values->list (k1))))
+
+(test* "reset/shift + parameterize 1"
+       "010"
+       (with-output-to-string
+         (^[]
+           (define p (make-parameter 0))
+           (display (p))
+           (reset
+            (parameterize ([p 1])
+              (display (p))
+              ;; expr of 'shift' is executed on the outside of 'reset'
+              (shift k (display (p))))))))
+
+(test* "reset/shift + call/cc 1"
+       "[r01][r02][r02][r03]"
+       (with-output-to-string
+         (^[]
+           (define k1 #f)
+           (define done #f)
+           (call/cc
+            (^[k0]
+              (reset
+               (display "[r01]")
+               (shift k (set! k1 k))
+               (display "[r02]")
+               (unless done
+                 (set! done #t)
+                 (k0))
+               (display "[r03]"))))
+           (k1))))
+
+(test* "reset/shift + call/cc error 1"
+       (test-error)
+       (with-output-to-string
+         (^[]
+           (define k1 #f)
+           (define k2 #f)
+           (define (f1) (call/cc (^[k] (set! k1 k)))
+                        (shift k (set! k2 k))
+                        (display "[f01]"))
+           (define (f2) (display "[f02]"))
+           (reset (f1) (f2))
+           (reset (k1)))))
+
+(test* "reset/shift + call/cc error 2"
+       (test-error)
+       (with-output-to-string
+         (^[]
+           (define k1 #f)
+           (define k2 #f)
+           (define k3 #f)
+           (define (f1) (call/cc (^[k] (set! k1 k)))
+                        (shift k (set! k2 k))
+                        (display "[f01]"))
+           (define (f2) (display "[f02]"))
+           (reset (f1) (f2))
+           (reset (shift k (set! k3 k)) (k1))
+           (k3))))
+
+(test* "reset/shift + call/cc error 3"
+       (test-error)
+       (with-output-to-string
+         (^[]
+           (define k1 #f)
+           (define k2 #f)
+           (reset
+            (call/cc (^[k] (set! k1 k)))
+            (shift k (set! k2 k)))
+           (k2)
+           (k1))))
+
+(test* "reset/shift + with-error-handler 1"
+       "[E01][E02]"
+       (with-output-to-string
+         (^[]
+           (with-error-handler
+            (^[e] (display (~ e 'message)))
+            (^[]
+              (display "[E01]")
+              (reset (error "[E02]"))
+              (display "[E03]"))))))
+
+(test* "dynamic-wind + reset/shift 1"
+       "[d01][d02][d03][d04]"
+       ;"[d01][d02][d04][d01][d03][d04]"
+       (with-output-to-string
+         (^[]
+           (reset
+            (shift
+             k
+             (dynamic-wind
+              (^[] (display "[d01]"))
+              (^[] (display "[d02]")
+                   (k)
+                   (display "[d03]"))
+              (^[] (display "[d04]"))))))))
+
+(test* "dynamic-wind + reset/shift 2"
+       "[d01][d02][d04][d01][d03][d04]"
+       (with-output-to-string
+         (^[]
+           (define k1 #f)
+           (reset
+            (dynamic-wind
+             (^[] (display "[d01]"))
+             (^[] (display "[d02]")
+                  (shift k (set! k1 k))
+                  (display "[d03]"))
+             (^[] (display "[d04]"))))
+           (k1))))
+
+(test* "dynamic-wind + reset/shift 3"
+       "[d01][d02][d01][d02][d01][d02][d01][d02]"
+       (with-output-to-string
+         (^[]
+           (define k1 #f)
+           (define k2 #f)
+           (reset
+            (dynamic-wind
+             (^[] (display "[d01]"))
+             (^[] (shift k (set! k1 k))
+                  (shift k (set! k2 k)))
+             (^[] (display "[d02]"))))
+           (k1)
+           (k2)
+           (k2))))
+
+(test* "dynamic-wind + reset/shift 3-B"
+       "[d01][d02][d01][d11][d12][d02][d01][d11][d12][d02][d01][d11][d12][d02]"
+       (with-output-to-string
+         (^[]
+           (define k1 #f)
+           (define k2 #f)
+           (reset
+            (dynamic-wind
+             (^[] (display "[d01]"))
+             (^[] (shift k (set! k1 k))
+                  (dynamic-wind
+                   (^[] (display "[d11]"))
+                   (^[] (shift k (set! k2 k)))
+                   (^[] (display "[d12]"))))
+             (^[] (display "[d02]"))))
+           (k1)
+           (k2)
+           (k2))))
+
+(test* "dynamic-wind + reset/shift 3-C"
+       "[d01][d02][d21][d01][d11][d12][d02][d01][d11][d12][d02][d01][d11][d12][d02][d22]"
+       ;"[d01][d02][d21][d22][d01][d11][d12][d02][d21][d22][d01][d11][d12][d02][d21][d22][d01][d11][d12][d02][d21][d22]"
+       (with-output-to-string
+         (^[]
+           (define k1 #f)
+           (define k2 #f)
+           (reset
+            (dynamic-wind
+             (^[] (display "[d01]"))
+             (^[] (shift k (set! k1 k))
+                  (dynamic-wind
+                   (^[] (display "[d11]"))
+                   (^[] (shift k (set! k2 k)))
+                   (^[] (display "[d12]"))))
+             (^[] (display "[d02]"))))
+           (dynamic-wind
+            (^[] (display "[d21]"))
+            (^[] (k1)
+                 (k2)
+                 (k2))
+            (^[] (display "[d22]"))))))
+
+(test* "dynamic-wind + reset/shift 4"
+       "[d01][d11][d12][d02][d11][d12]"
+       ;"[d01][d11][d12][d02][d01][d11][d12][d02]"
+       (with-output-to-string
+         (^[]
+           (define k1 #f)
+           (reset
+            (dynamic-wind
+             (^[] (display "[d01]"))
+             (^[] (reset
+                   (dynamic-wind
+                    (^[] (display "[d11]"))
+                    (^[] (shift k (set! k1 k)))
+                    (^[] (display "[d12]")))))
+             (^[] (display "[d02]"))))
+           (k1))))
+
+(test* "dynamic-wind + reset/shift 5"
+       "[d01][d02][d01][d11][d12][d02][d11][d12][d11][d12]"
+       ;"[d01][d02][d01][d11][d12][d02][d01][d11][d12][d02][d01][d11][d12][d02]"
+       (with-output-to-string
+         (^[]
+           (define k1 #f)
+           (define k2 #f)
+           (define k3 #f)
+           (reset
+            (dynamic-wind
+             (^[] (display "[d01]"))
+             (^[] (shift k (set! k1 k))
+                  (reset
+                   (dynamic-wind
+                    (^[] (display "[d11]"))
+                    (^[] (shift k (set! k2 k))
+                         (shift k (set! k3 k)))
+                    (^[] (display "[d12]")))))
+             (^[] (display "[d02]"))))
+           (k1)
+           (k2)
+           (k3))))
+
+(test* "dynamic-wind + reset/shift 6"
+       "[d01][d02][d11][d12][d13][d14][d03][d04]"
+       ;"[d01][d02][d11][d12][d14][d04][d01][d11][d13][d14][d03][d04]"
+       (with-output-to-string
+         (^[]
+           (reset
+            (shift
+             k
+             (dynamic-wind
+              (^[] (display "[d01]"))
+              (^[] (display "[d02]")
+                   (dynamic-wind
+                    (^[] (display "[d11]"))
+                    (^[] (display "[d12]")
+                         (k)
+                         (display "[d13]"))
+                    (^[] (display "[d14]")))
+                   (display "[d03]"))
+              (^[] (display "[d04]"))))))))
+
+(test* "dynamic-wind + reset/shift 7"
+       "[d01][d02][d11][d12][d14][d04][d01][d11][d13][d14][d03][d04]"
+       (with-output-to-string
+         (^[]
+           (define k1 #f)
+           (reset
+            (dynamic-wind
+             (^[] (display "[d01]"))
+             (^[] (display "[d02]")
+                  (dynamic-wind
+                   (^[] (display "[d11]"))
+                   (^[] (display "[d12]")
+                        (shift k (set! k1 k))
+                        (display "[d13]"))
+                   (^[] (display "[d14]")))
+                  (display "[d03]"))
+             (^[] (display "[d04]"))))
+           (k1))))
+
+(test* "dynamic-wind + reset/shift 8"
+       "[d01][d02][d04][d11][d12][d01][d03][d04][d13][d14]"
+       ;"[d01][d02][d04][d11][d12][d14][d01][d03][d04][d11][d13][d14]"
+       (with-output-to-string
+         (^[]
+           (define k1 #f)
+           (reset
+            (dynamic-wind
+             (^[] (display "[d01]"))
+             (^[] (display "[d02]")
+                  (shift k (set! k1 k))
+                  (display "[d03]"))
+             (^[] (display "[d04]"))))
+           (dynamic-wind
+            (^[] (display "[d11]"))
+            (^[] (display "[d12]")
+                 (k1)
+                 (display "[d13]"))
+            (^[] (display "[d14]"))))))
 
 (test-end)


### PR DESCRIPTION
#477 の件に対応したものです。
(関連プルリクエスト #507, #515 ,#518)

#518 との違いは、ScmContFrame に部分継続の終端マーカーを追加したことです。

これによって、部分継続の終端の継続を空にするタイミングを遅らせることができて、
「reset-chain に空にする前の継続を保存しておく」といった
 workaround が不要になりました。

(元々は、vm.c の Scm_VMCallPC 関数で、cp->prev = NULL として、
部分継続の終端の継続を空にしていました。
しかしこれだと、reset と shift の間に call/cc で戻ったときに、
部分継続の実行中だと誤認してしまう不具合がありました。

つまり、動的環境のチェーンを破壊的変更すると、
それをキャプチャしている call/cc 等で問題が出るということだと思います。

今回の変更は、それを解決したものです。

ただ、reset や shift を使わないプログラムにとっては、
ScmContFrame に追加した項目は、メモリを占有するだけですが。。。
(多くの環境で int は 4バイトなので、アライメントによっては、
ScmContFrame のサイズは変わらないかもしれない))

＜テスト結果＞
https://ci.appveyor.com/project/Hamayama/gauche/builds/27748856
