### PR TITLE
libmacbase.scm: keep all macro tracing messages in stderr

### DIFF
--- a/src/libmacbase.scm
+++ b/src/libmacbase.scm
@@ -143,11 +143,11 @@
       ;; NB: We need to apply unravel-syntax on expr and out at once,
       ;; so that we can correspond the identifiers from input and output.
       (let1 unraveled (unravel-syntax (cons expr out))
-        (display "Macro input>>>\n")
+        (display "Macro input>>>\n" (current-error-port))
         (pprint (car unraveled) :port (current-error-port) :level #f :length #f)
-        (display "\nMacro output<<<\n")
+        (display "\nMacro output<<<\n" (current-error-port))
         (pprint (cdr unraveled) :port (current-error-port) :level #f :length #f)
-        (display "\n")))
+        (display "\n" (current-error-port))))
     out))
 
 (define-cproc make-syntax (name::<symbol> proc)


### PR DESCRIPTION
When `*trace-macro*` is set to #t (a wonderful thing to debug, should be
documented!) it prints the sexp body to stderr, the header though is to
stdout. This does not work well when I pipe both to 'less' and
the (buffered) headers are only flushed out at the end, disconnected
from all the sexp.