### PR TITLE
typo fixes starting 'a' to 'd'

### DIFF
--- a/doc/corelib.texi
+++ b/doc/corelib.texi
@@ -446,7 +446,7 @@ do not call @code{object-equal?} directly; call @code{equal?} on each element.
 @deffn {Method} object-equal? (obj1 <top>) (obj2 <top>)
 @c EN
 This method catches @code{equal?} between two objects of a user-defined
-classe, in case the user doesn't define a specialized method for the class.
+class, in case the user doesn't define a specialized method for the class.
 
 When called, it scans the registered default comparators that can handle
 both @var{obj1} and @var{obj2},
@@ -1098,7 +1098,7 @@ depending on the equality predicate).
 Gaucheでは、これらの関数は単に引数の型チェックをして(必要なら大文字小文字の
 区別をなくした後)、組み込みの@code{default-hash}を呼び出しているだけです。
 これらは@code{scheme.comparator}で定義されているために提供されていますが、
-特にポータビリティが必要でなければ@code{defailt-hash}
+特にポータビリティが必要でなければ@code{default-hash}
 (あるいは、等価述語によっては@code{eq-hash}や
 @code{eqv-hash})を呼んでしまう方が簡単だし高速です。
 @c COMMON
@@ -1605,7 +1605,7 @@ that satisfy the type predicates of @var{cmpr}.  The procedure
 returns either -1, 0 or 1, depending on whether the first object
 is less than, equal to, or greater than the second.  The comparator
 must be ordered, that is, it must have an ordering predicate
-(or a comparison procedure, if it is created by SRFI-114 consturctor).
+(or a comparison procedure, if it is created by SRFI-114 constructor).
 @c JP
 これはSRFI-114の手続きですが、
 @code{scheme.comparator}比較器でも時々便利なことがあります。
@@ -2415,7 +2415,7 @@ Returns @code{#t} if @var{x} is a number represented by a floating-point
 number, @code{#f} otherwise.  In Gauche, inexact real numbers
 are flonums.
 
-@xref{R7RS flonum}, for comprehesive flonum library.
+@xref{R7RS flonum}, for comprehensive flonum library.
 @c JP
 @var{x}が浮動小数点数で表現される数値の場合に@code{#t}を、それ以外の場合に
 @code{#f}を返します。Gaucheでは、不正確な実数がflonumです。
@@ -2981,7 +2981,7 @@ R7RS division library (@code{scheme.division}) introduces
 other variation of integer divisions
 (@pxref{R7RS integer division}).
 @c JP
-R7RS除算ライブラリ(@code{scheme.divison})では、
+R7RS除算ライブラリ(@code{scheme.division})では、
 他の整数除算のバリエーションが定義されています。
 (@ref{R7RS integer division}参照)。
 @c COMMON
@@ -5903,7 +5903,7 @@ If no pair matches, these return @code{#f}.
 @c COMMON
 
 @c EN
-If the optional argument of @code{ascoc} is given,
+If the optional argument of @code{assoc} is given,
 it is called instead of @code{equal?}
 to check the equivalence of @var{obj} and each key.
 @c JP
@@ -6518,7 +6518,7 @@ Returns @code{#t} if @var{obj} is a keyword.
 @defun make-keyword name
 @c EN
 Returns a keyword whose name is @var{name} prepended by @code{:}.
-The @var{name} argment can be a string or a symbol.
+The @var{name} argument can be a string or a symbol.
 @c JP
 @var{name}の前に@code{:}を付加した名前を持つキーワードを返します。
 @var{name}には文字列かシンボルが許されます。
@@ -7620,7 +7620,7 @@ whose Unicode codepoint is represented by 4-digit and 8-digit hexadecimal
 numbers, respectively.  
 @item \s
 Whitespace characters
-(space, newline, tab, form feed, vertical tab, carrige return).
+(space, newline, tab, form feed, vertical tab, carriage return).
 Members of @code{char-set:ascii-whitespace}.
 @item \S
 Complement of whitespace characters.
@@ -7711,7 +7711,7 @@ Here are some examples:
 @item \x@var{N};
 Unicodeコードポイントが@var{N}(16進数表記)の文字。
 @item \s
-空白文字(space, newline, tab, form feed, vertical tab, carrige return).
+空白文字(space, newline, tab, form feed, vertical tab, carriage return).
 文字セット@code{char-set:ascii-whitespace}の要素。
 @item \S
 空白でない文字。(@code{\s}の補集合)
@@ -7966,7 +7966,7 @@ If you intend to mean ASCII-only words, use @code{char-set:ascii-word}.
 @defvarx char-set:ascii-printing
 @defvarx char-set:ascii-whitespace
 @defvarx char-set:ascii-blank
-@defvarx char-set:ascii-contorl
+@defvarx char-set:ascii-control
 @defvarx char-set:ascii-punctuation
 @defvarx char-set:ascii-symbol
 @defvarx char-set:ascii-word
@@ -8942,7 +8942,7 @@ Returns @code{#t} iff all arguments are strings with the same content.
 
 @c EN
 If any of arguments is incomplete string, it returns @code{#t} iff
-all argumnets are incomplete and have exactly the same content.
+all arguments are incomplete and have exactly the same content.
 In other words, a complete string and an incomplete string never equal
 to each other.
 @c JP
@@ -9462,7 +9462,7 @@ Compatibility note:
 The @var{grammar} argument is added for the consistency of srfis
 (srfi-130, srfi-152, @pxref{String library (reduced)}).
 However, for the backward compatibility and
-the covenience, it also accepts @var{limit} without @var{grammar} argument;
+the convenience, it also accepts @var{limit} without @var{grammar} argument;
 it is distinguishable since @var{grammar} is a symbol and
 @var{limit} is an integer.
 For the code that's compatible to srfi-152, use the first form that takes
@@ -20289,7 +20289,7 @@ controls.
 @code{write}は二つまでそういった引数を取ります。すなわち、@code{write}は
 以下のいずれの形式でも呼び出すことができます:
 @code{(write obj)}、@code{(write obj port)}、
-@code{(write obj contorls)}、@code{(write obj port controls)}、
+@code{(write obj controls)}、@code{(write obj port controls)}、
 @code{(write obj controls port)}。
 省略された場合、ポートは現在の出力ポート、出力制御についてはデフォルトの出力制御が
 使われます。

--- a/doc/coresyn.texi
+++ b/doc/coresyn.texi
@@ -3624,7 +3624,7 @@ Suppose you define @var{x} as follows:
 Then, the code @code{(list x)} is compiled to the same code
 as @code{(list '#(1 2 3))}.
 
-This distinctino is especially important when you do AOT (ahead of time)
+This distinction is especially important when you do AOT (ahead of time)
 compilation.
 @c JP
 すると、コード@code{(list x)}は@code{(list '#(1 2 3))}と同じコードにコンパイルされます。
@@ -3858,7 +3858,7 @@ that file (@pxref{Multibyte scripts}).
 @c EN
 If @var{filename} is absolute, the file is just searched.  If it
 is relative, the file
-is first searched relative to the file contaning the @code{include}
+is first searched relative to the file containing the @code{include}
 form, then the directories in @code{*load-path*} are tried.
 @c JP
 @var{filename}が絶対パスならば、そのパスに正確に合致するファイルが探されます。
@@ -4058,7 +4058,7 @@ won't persist after @code{load}.
 @c EN
 Usually, @code{require} (or @code{use} and @code{extend}) are
 better way to incorporate sources in other files.  The @code{include}
-form is mainly for the tricks that can't be acheved with
+form is mainly for the tricks that can't be achieved with
 @code{require}.  For example, you have a third-party R5RS code
 and you want to wrap it with Gauche module system.  Using @code{include},
 you place the following small source file along the third-party code,
@@ -5048,7 +5048,7 @@ list the name with prefix.
 @c COMMON
 
 @c EN
-Note: R7RS has @code{import} form, which has slightly differnent
+Note: R7RS has @code{import} form, which has slightly different
 syntax and semantics.  @xref{Three forms of import}, for the details.
 @c JP
 註: R7RSにも@code{import}フォームがありますが、若干構文と意味が異なります。
@@ -5699,7 +5699,7 @@ quote them, import @code{gauche.keyword} separately.
 @example
 ;; R7RS program
 (import (scheme base)
-        (prefix (gauche base) gauche/) ; use gauche builting with gauche/ prefix
+        (prefix (gauche base) gauche/) ; use gauche builtin with gauche/ prefix
         (gauche keyword))              ; imports keywords
 
 ;; Without importing gauche.keyword,

--- a/doc/gauche-dev.texi
+++ b/doc/gauche-dev.texi
@@ -1351,7 +1351,7 @@ the integer.
 @end deftypefun
 
 @deftypefun ScmObj Scm_MakeBignumFromDouble (double @var{val})
-Returns a (possible denormalizeD) bignum that represents
+Returns a (possible denormalized) bignum that represents
 the integral part of @var{val}.
 @end deftypefun
 
@@ -1915,7 +1915,7 @@ to @code{ScmStringBody}.
 
 @deftp {Type} ScmStringBody
 The body of the string.  It is immutable---that is, once it
-is constucted, it should never be changed.
+is constructed, it should never be changed.
 @end deftp
 
 @deftypevr {Constant} int SCM_STRING_IMMUTABLE
@@ -2301,7 +2301,7 @@ and @code{prefix} as defined in @code{srfi-13}'s @code{string-join}.
 @deftypefunx ScmObj Scm_StringScanChar (ScmString *@var{s1}, ScmChar @var{ch}, int @var{retmode})
 Scheme's @code{string-scan}.
 Search a string @var{s2} or a character @var{ch} within a string @var{s1},
-respectively.  Return value depens on the @var{retmode} argument, as follows:
+respectively.  Return value depends on the @var{retmode} argument, as follows:
 @table @code
 @item SCM_STRING_SCAN_INDEX
 Returns an index of the first found instance of @var{s1}/@var{ch},
@@ -3457,7 +3457,7 @@ They are to help build and installation process.
 
 The @code{gauche-package} command is the front-end of managing
 Gauche extension packages.  It can perform the various operations
-accoring to @var{operation} argument.
+according to @var{operation} argument.
 
 @table @asis
 @item Download, compile and install packages

--- a/doc/modgauche.texi
+++ b/doc/modgauche.texi
@@ -1402,7 +1402,7 @@ hexadecimal notation of the character code.  (Note that the character
 safely as a C identifier.  The mapping is injective, that is,
 if the source strings differ, the result string always differ.
 
-On the other hand, @code{cgen-safe-name-friendly} convers
+On the other hand, @code{cgen-safe-name-friendly} converts
 the input string into more readable C identifier.  @code{->} becomes
 @code{_TO} (e.g. @code{char->integer} becomes @code{char_TOinteger}),
 other @code{-} and @code{_} become @code{_},
@@ -4558,7 +4558,7 @@ autoconf, though, so if you need to write complex tests
 you may have to switch back to autoconf.  We'll add tests
 as needed.
 @c JP
-ただ、今のところ@code{gauhce.confiugre}はautoconfの機能の小さなサブセット
+ただ、今のところ@code{gauhce.configure}はautoconfの機能の小さなサブセット
 しかカバーしないので、複雑な機能テストが必要ならautoconfに戻らなければ
 ならない場合もあります。必要に応じて機能テストを足して行く予定です。
 @c COMMON
@@ -4567,7 +4567,7 @@ as needed.
 @c EN
 The core feature of @code{gauche.configure} is the ability to generate files
 (e.g. @file{Makefile}) from templates (e.g. @file{Makefile.in}) with replacing
-parameters.  We follow autoconf convension, so the substitution parameters
+parameters.  We follow autoconf convention, so the substitution parameters
 in a template is written like @code{@@VAR@@}.  You should be able
 to reuse @file{Makefile.in} used for autoconf without changing them.
 @c JP
@@ -5605,7 +5605,7 @@ The @var{aggregate} part can be any type name (typedef-ed name is ok).
 
 This corresponds to autoconf's @code{AC_CHECK_MEMBER}.
 
-This test checks if @var{member} is a member of @var{aggrette}, and
+This test checks if @var{member} is a member of @var{aggregate}, and
 returns @code{#t} if so, or returns @code{#f} if not.
 This procedure is intended to be used as a predicate; it doesn't have
 side effects.
@@ -5653,7 +5653,7 @@ This corresponds to autoconf's @code{AC_CHECK_FUNC}.
 @defun cf-check-funcs funcs :key if-found if-not-found
 @c MOD gauche.configure
 For each function name @var{func} in @var{funcs}, call @code{cf-check-func}
-to determine availabiltiy.  If it is available, define
+to determine availability.  If it is available, define
 @code{HAVE_@var{func}}, and calls @code{if-found} with @var{func}
 if provided.  If it is not available, calls @code{if-not-found}
 with @var{func} if provided.
@@ -5978,7 +5978,7 @@ connection-address-name obj                ; optional
 
 At this moment this framework doesn't provide a generic way to
 @emph{create} a connection, since the way to do it may greatly vary
-depending on the concreate implementation.  Each concrete implementation
+depending on the concrete implementation.  Each concrete implementation
 should provide its own procedure to create and return a new connection.
 @end deftp
 
@@ -9847,7 +9847,7 @@ This procedure may raise an error if the input contains
 @c COMMON
 
 @c EN
-There are a few error situations the listener handles diffetently.
+There are a few error situations the listener handles differently.
 @c JP
 エラー状況によりリスナーのエラー処理法が異ります。
 @c COMMON
@@ -17019,7 +17019,7 @@ Both @var{needle} and @var{haystack} must be sequences.
 Searches @var{needle} from @var{haystack} from the beginning of @var{haystack}.
 If @var{needle} is found, the index in @var{haystack} where it begins is
 returned.  Otherwise @code{#f} is returned.  The keyword argument
-@var{test} is used to compare elements; its defaule is @code{eqv?}.
+@var{test} is used to compare elements; its default is @code{eqv?}.
 @c JP
 @var{needle}と@var{haystack}はシーケンスです。
 @var{haystack}の中で、@var{needle}に一致するシーケンスを左から探します。
@@ -17051,7 +17051,7 @@ This can be regarded as generalization of @code{string-contains} in srfi-13
 @c EN
 Searches a sequence @var{needle} from @var{list},
 and if found, breaks @var{list}
-to two parts---the prefix of @var{list} up to right befor @var{needle}
+to two parts---the prefix of @var{list} up to right before @var{needle}
 begins, and the rest---and returns them.
 @var{List} must be a list, but @var{needle} can be any sequence.
 Elements are compared by @var{test}, defaulted to @code{eqv?}.
@@ -18973,7 +18973,7 @@ autoloadに設定されている変数が実際にロードできるか。
 @item
 @c EN
 While testing module, see if the symbols declared in the export list
-are acutally defined.
+are actually defined.
 @c JP
 モジュールをテストしている場合、exportされているシンボルが
 定義されているか。
@@ -23021,7 +23021,7 @@ overlapping.
 @emph{Note:} This procedure used to take just two uniform vectors, @var{target}
 and @var{source}, and just copies contents of @var{source} to @var{target}.
 Both vectors had to be the same type and same length.  The API is revised
-accordnig to srfi-160.  The old interface is still supported
+according to srfi-160.  The old interface is still supported
 for the backward compatibility, but it is deprecated and will be gone
 in the future releases.
 
@@ -23112,7 +23112,7 @@ as follows:
 
 @c EN
 That is, each @var{ssize} slice from @var{source},
- is copied into @var{target}, advaincing source index
+ is copied into @var{target}, advancing source index
 by @var{sstride} and the destination index by @var{dstride}.
 In this case, @var{sstride} defaults to @var{ssize} if omitted.
 @c JP
@@ -24002,7 +24002,7 @@ so you shouldn't assume the return values are freshly
 allocated objects, unless it is noted so explicitly.)
 
 A linear update version may reuse the stoarge of the designated
-argumentt to produce the return value.  Gauche tries to reuse the
+argument to produce the return value.  Gauche tries to reuse the
 argument as much as possible, but you should always use the return
 value and shouldn't assume the argument itself is modified in-place.
 In fact, after calling linear-updating procedure, you can't use
@@ -24468,7 +24468,7 @@ For example, you can read input as an octet stream as follows:
 @end example
 
 @c EN
-If the input port has aleady reached EOF, an EOF object is
+If the input port has already reached EOF, an EOF object is
 returned.  The returned uvector can be shorter than @var{size}
 if the input reaches EOF before @var{size} elements are read.
 @c JP
@@ -25912,7 +25912,7 @@ storage for the data output to the port.
 If @var{uvector} is completely filled, what happens after that
 depends on @var{extendable} - if it is false (default), the rest
 of data is discarded silently.  If it is true, the storage is
-extended automatically to accomodate more data.
+extended automatically to accommodate more data.
 
 If you give true value to @var{extendable}, you have to retrieve
 the result by @code{get-output-uvector} below, since the uvector

--- a/doc/modintro.texi
+++ b/doc/modintro.texi
@@ -295,7 +295,7 @@ limited types of values.  This is also supported by @ref{Arrays}.
 @item
 @emph{String} - a sequence of characters.  See @ref{Strings}
 and @ref{String library}.  Gauche handles multibyte strings---
-see @ref{Multibyte strings} for the defatils.
+see @ref{Multibyte strings} for the details.
 @item
 @emph{Character set} - a set of characters.  See @ref{Character set}
 and @ref{Character-set library}.

--- a/doc/modr7rs.texi
+++ b/doc/modr7rs.texi
@@ -1043,7 +1043,7 @@ Gauche's @code{raise} may return if @var{obj} isn't a
 Distinguishing continuable and noncontinuable exception throw by the
 procedure has an issue when your exception handler wants to reraise
 the condition (you don't know if the original condition is raised
-by @code{raise} or @code{raise-continuable}!).  Yet R7RS adoted
+by @code{raise} or @code{raise-continuable}!).  Yet R7RS adopted
 that model, so we compel.
 
 R7RS @code{raise} is a wrapper of Gauche's @code{raise},
@@ -1052,7 +1052,7 @@ which throws an error if Gauche's @code{raise} returns.
 R7RS @code{raise-continuable} is currently just an alias of
 Gauche's @code{raise}---as long as you don't pass
 @code{<serious-condition>}, it may return.  It is not exactly
-R7RS comformant---it won't return if you pass @code{<serious-condition>}
+R7RS conformant---it won't return if you pass @code{<serious-condition>}
 or object of one of its subclasses (e.g. @code{<error>}), but
 it's weired to expect returning from raising @code{<error>}, isn't it?
 @c JP
@@ -1381,7 +1381,7 @@ Gauche組み込みの@code{digit->integer}はより汎用的なインタフェ�
 
 @node R7RS complex numbers, R7RS cxr accessors, R7RS char library, R7RS small language
 @subsection @code{scheme.complex} - R7RS complex numbers
-@c NODE R7RS複素数, @code{scheme.compex} - R7RS複素数
+@c NODE R7RS複素数, @code{scheme.complex} - R7RS複素数
 
 @deftp {Module} scheme.complex
 @mdindex scheme.complex
@@ -2522,7 +2522,7 @@ Returns a set of elements that are in every @var{list}s.
 @c MOD scheme.list
 @c EN
 Returns a set of elements that are in @var{list1} but not
-in @var{list2}.  In n-ary case, binary differece operation is
+in @var{list2}.  In n-ary case, binary difference operation is
 simply folded.
 @c JP
 @var{list1} には含まれていて、@var{list2} には含まれていない要素の集合を
@@ -3458,7 +3458,7 @@ is already in a bag, you have two items of the kind.
 
 @c EN
 To check whether the items are ``the same'', sets and bags
-takes a comparator at constrution time.  The comparator
+takes a comparator at construction time.  The comparator
 doesn't need to have an ordering predicate (we don't need
 to order the elements) but has to have a hash function.
 @xref{Basic comparators}, for the details of comparators.
@@ -4530,7 +4530,7 @@ built-in but under aliases.
 With this module, procedures are provided as defined in R7RS.  Use this
 module when you're writing portable code.
 
-Srfi-125 also defines compatiblity procedures with srfi-69, although saying
+Srfi-125 also defines compatibility procedures with srfi-69, although saying
 they're deprecated.  Those deprecated procedures are supported in this
 module, too.
 
@@ -4543,7 +4543,7 @@ hash-table-set!     hash-table-update!/default
 hash-table-clear!   hash-table-size   hash-table-keys
 hash-table-values   hash-table-copy   hash-table-empty-copy
 hash-table->alist   hash-table-union! hash-table-intersection!
-hash-table-differnce!                 hash-table-xor!
+hash-table-difference!                hash-table-xor!
 @end example
 
 @xref{Hashtables}, for the description of those procedures.
@@ -4616,7 +4616,7 @@ table @var{ht}.  It is ok if @var{ht} doesn't have @var{key}.
 Returns the number of entries that are actually deleted.
 
 It differs from built-in @code{hash-table-delete!} in two points:
-The bulit-in one can take exactly one @var{key}, and returns
+The built-in one can take exactly one @var{key}, and returns
 a boolean indicating if the entry is actually deleted.
 @end defun
 
@@ -4635,7 +4635,7 @@ and insert a new entry associating @var{key} and the value
 [R7RS hash-table]
 @c MOD scheme.hash-table
 This is the same as built-in @code{hash-table-update!-r7}.
-It takes differnt optional arguments from built-in @code{hash-table-update!}.
+It takes different optional arguments from built-in @code{hash-table-update!}.
 
 @var{Updater} is a procedure that takes one argument,
 @var{failure} is a thunk, and @var{success} is a procedure
@@ -4822,7 +4822,7 @@ This module provides a functional double-ended queue
 (deque, pronounced as ``deck''),
 with amortized O(1) access of queue operations on either end.
 
-It also serves as a convenient bidrectional list structures
+It also serves as a convenient bidirectional list structures
 in a sense that operations from the end of the list is just as
 efficient as the ones from the front.
 
@@ -5236,7 +5236,7 @@ There's no @code{reverse-bytevector-accumulator}.
 The @var{vec} or @var{bvec} argument is a mutable vector or
 bytevector (u8vector), and is used as a buffer.
 
-Returns an accumlator that stores the accumulated values in the
+Returns an accumulator that stores the accumulated values in the
 buffer, starting from the index @var{at}.
 It is an error if the accumulator gets more values after
 the buffer reaches at the end.
@@ -5547,7 +5547,7 @@ to the implementation when two are not @code{eqv?}.
 @end itemize
 
 When you're writing portable code, be careful not to depend on the
-@code{equal?} behavoir.
+@code{equal?} behavior.
 @end deftp
 
 @defun box val
@@ -5627,7 +5627,7 @@ Creates and returns a list-queue whose initial content is @var{lis}.
 In Gauche, a list queue is just an instance of @code{<queue>} (@pxref{Queue}).
 
 The cells in @var{lis} are owned by the queue; the caller shouldn't mutate
-it afterwords, nor assume its structure remains the same.
+it afterwards, nor assume its structure remains the same.
 
 The optional @var{last} argument must be the last pair of @var{lis}.
 If it is passed, @code{make-list-queue} will skip scanning @var{lis}
@@ -7305,7 +7305,7 @@ at this moment.
 [R7RS mapping]
 @c MOD scheme.mapping
 Similar to @code{mapping-unfold}, but keys are generated in the
-ascendnig order
+ascending order
 w.r.t. the comparator.  An implementation may use more efficient algorithm
 than @code{mapping-unfold}. 
 In Gauche, this is the same as @code{mapping-unfold} at this moment.
@@ -7400,7 +7400,7 @@ Linear update version @code{mapping-adjoin!} may destructively modify
 @var{m} to create the return value, while @code{mapping-adjoin}
 creates a new mapping.
 
-Argments are processed in order.
+Arguments are processed in order.
 If there's already an entry in @var{m} with the same key as given to
 @var{arg}, the original entry remains.
 
@@ -7421,7 +7421,7 @@ Linear update version @code{mapping-set!} may destructively modify
 @var{m} to create the return value, while @code{mapping-set}
 creates a new mapping.
 
-Argments are processed in order.
+Arguments are processed in order.
 If there's already an entry in @var{m} with the same key as given to
 @var{arg}, the new key-value pair supersedes the old one.
 
@@ -9828,7 +9828,7 @@ Returns @code{(expt 2 x)}
 @defun flexp-1 x
 [R7RS flonum]
 @c MOD scheme.flonum
-Returns @code{(- 1 (expt fl-e x))}, but is much more accureate
+Returns @code{(- 1 (expt fl-e x))}, but is much more accurate
 when @var{x} is small.  We all C's @code{expm1} internally.
 @end defun
 

--- a/doc/modsrfi.texi
+++ b/doc/modsrfi.texi
@@ -858,7 +858,7 @@ R7RS版は後者です。
 (Note: Gauche has builtin @code{string-hash} and @code{string-ci-hash}
 according to SRFI-128. @xref{Hashing}, for the details.
 SRFI-13's API is upper-compatible to SRFI-128's.  The underlying
-hash algorighm is the same as the builtin ones, so @code{string-hash}
+hash algorithm is the same as the builtin ones, so @code{string-hash}
 returns the same value as the builtin ones for the same string
 if optional arguments are omitted.
 On the other hand, the builtin @code{string-ci-hash} uses string case
@@ -3675,7 +3675,7 @@ It terminates when any one of @var{generator} is exhausted.
 @mdindex srfi-43
 @c EN
 This module is effectively superseded by R7RS and @code{srfi-133}.  
-There are a few procedures that are not compatbile with R7RS and 
+There are a few procedures that are not compatible with R7RS and 
 @code{srfi-133}, and this module remains to support
 legacy code that depends on them.  
 
@@ -5216,7 +5216,7 @@ built-in @code{comparator-ordered?} and @code{comparator-hashable?}.
 [SRFI-114]
 @c MOD srfi-114
 Returns type test predicate of a comparator @var{c}.
-This is an alias of bulit-in @code{comparator-type-test-predicate}.
+This is an alias of built-in @code{comparator-type-test-predicate}.
 @end defun
 
 @defun comparator-equal? c a b
@@ -5224,7 +5224,7 @@ This is an alias of bulit-in @code{comparator-type-test-predicate}.
 @c MOD srfi-114
 Checks equality of @var{a} and @var{b} using the equality predicate
 of a comparator @var{c}.  This can be also written in @code{=?}, which
-is bulit-in (@pxref{Comparator predicates and accessors}).
+is built-in (@pxref{Comparator predicates and accessors}).
 @example
 (=? c a b)
 @end example
@@ -5356,7 +5356,7 @@ That is, @code{make-list-comparator} can be written in
 @example
 (make-list-compartator element-comparator)
   @equiv{}
-  (make-listwise-comparator list? element-compartor null? car cdr)
+  (make-listwise-comparator list? element-comparator null? car cdr)
 @end example
 
 This can be used to compare list-like structures.  For example,
@@ -6130,7 +6130,7 @@ Note: The order of @var{pred} and the source object is different from
 @deftp {Module} srfi-154
 @mdindex srfi-154
 @c EN
-This module provides a convenent way to reify the dynamic environment.
+This module provides a convenient way to reify the dynamic environment.
 A continuation captured by @code{call/cc} includes the dynamic environment,
 as well as the control flow.  Sometimes you only want the dynamic environment
 part.  A dynamic extent is a reified dynamic environment.
@@ -6249,7 +6249,7 @@ but also the dynamic environment.  Yields a procedure.
 
 Note: Since @code{dynamic-lambda} needs to swap the dynamic environment
 after executing @var{body}, the last expression of @var{body} isn't
-called in the tail contenxt even if the procedure created by
+called in the tail context even if the procedure created by
 @code{dynamic-lambda} is called in tail context.
 @c JP
 @code{lambda}のように振る舞いますが、レキシカルな環境だけでなく、

--- a/doc/modutil.texi
+++ b/doc/modutil.texi
@@ -1795,7 +1795,7 @@ which means the blowfish algorithm compatible to bcrypt.
 But @code{$2a$} is vulnerable. Use @code{$2b$} for new code.
 If you omit @var{prefix}, use @code{$2b$} for default value.
 
-The @var{count} arugment specifies the amount of iterations;
+The @var{count} argument specifies the amount of iterations;
 the larger the value is, the more time is required to calculate
 the hash value.  Note that for the password hashing, taking more
 time is actually a good thing, for it works against the dictionary attack.
@@ -1839,7 +1839,7 @@ bcryptアルゴリズムでは少なくとも16バイトの長さが必要です
 @mdindex data.cache
 @c EN
 A cache works similarly as a dictionary, associating keys to values,
-but its entries may dissapear according to the policy of the cache
+but its entries may disappear according to the policy of the cache
 algorithm.  This module defines
 a common protocol for cache datatypes, and also provides several
 typical cache implementations.
@@ -3289,7 +3289,7 @@ Because of this danger, we don't allow @code{<mtqueue>} to be
 passed to this procedure; it would signal an error if you do so.
 
 If you just want to extract the accumulated result in @var{queue} without
-copying, consinder @code{dequeue-all!}, which is safe because it atomically
+copying, consider @code{dequeue-all!}, which is safe because it atomically
 resets the queue.  Use this procedure only when you absolutely need
 to access the contents of the queue without taking them out.
 @c JP
@@ -7004,7 +7004,7 @@ and @ref{Dictionary framework}, respectively).
 @c EN
 An abstract class for dbm-style database.    Inherits
 @code{<dictionary>} (@pxref{Dictionary framework}).
-Defindes the common
+Defines the common
 database operations.   This class has the following instance slots.
 They must be set before the database is actually opened by
 @code{dbm-open}.
@@ -9828,7 +9828,7 @@ To prevent retrying, give 0 to @var{retry-limit}.
 @c EN
 The name of the secondary lock file (or directory).  If omitted,
 @var{lock-name} with a suffix @code{.2} attached is used.
-Note: The secondary lock name must be aggreed on all programs that
+Note: The secondary lock name must be agreed on all programs that
 locks the same (primary) lock file.  I recommend to leave this
 to the default unless there's a good reason to do otherwise.
 @c JP
@@ -10315,7 +10315,7 @@ and you'll save space.
 @c EN
 For relatively small positive integers 
 (below @code{*small-prime-bound*}, to be specific), this procedure
-determines if the input is prime or not, quickly and determinisically.
+determines if the input is prime or not, quickly and deterministically.
 If @var{n} is on or above the bound, this procedure returns @code{#f}.
 
 This can be used to quickly filter out known primes; it never returns
@@ -11275,7 +11275,7 @@ Calls @code{AllocConsole} and @code{FreeConsole}, respectively.
 @c In lazy languages like Haskell this doesn't matter, but we Schemers
 @c are @emph{eager}!
 
-@c The solution is to delay the parser construciton until it is
+@c The solution is to delay the parser construction until it is
 @c actually used.  The @code{$lazy} combinator does the job:
 
 @c @example
@@ -12381,7 +12381,7 @@ those information is given in the @var{host} argument.
 @c COMMON
 
 @c EN
-If the keyword arugment @var{account} is given, its value
+If the keyword argument @var{account} is given, its value
 is passed to ftp @code{ACCT} command when requested by
 the server at login time.  The default value is a null string @code{""}.
 @c JP
@@ -14457,7 +14457,7 @@ argument @var{charset} specifies the character encoding scheme
 in string or symbol.
 whose default is @code{utf-8}.  If @var{charset} differs from
 Gauche's internal encoding and @var{word} is a complete string,
-the procedure convers the character encoding to @var{charset},
+the procedure converts the character encoding to @var{charset},
 then performs transfer encoding.
 @c JP
 @var{word}をRFC2047フォーマットにエンコードします。キーワード引数
@@ -21801,7 +21801,7 @@ EDNのマップとセットは、この比較器を使うGaucheのハッシュ�
 @defunx edn-set item @dots{}
 @c MOD text.edn
 @c EN
-Convenicne procedures to create hash-tables and sets compatible
+Convenience procedures to create hash-tables and sets compatible
 for EDN.
 @c JP
 EDNに使えるハッシュテーブルとセットを構築する便利手続きです。
@@ -21982,7 +21982,7 @@ The @code{construct-edn} procedure calls this internally.
 
 To write out a Gauche object as EDN tagged object, define a method to
 this generic function.   In the method you can call @code{edn-write}
-recursively to write out componends of the object.
+recursively to write out components of the object.
 
 The following example writes @code{#u8(1 2 3 4)} as
 EDN @code{#u8vector[1 2 3 4]}:
@@ -22483,7 +22483,7 @@ notation before the actual content.
   "<a href=\"http://foo/bar\">foobar</a\n>"
 
 (tree->string
-  (html:table :width "100%" :cellpading 0 "content here"))
+  (html:table :width "100%" :cellpadding 0 "content here"))
   @result{}
   "<table width=\"100%\" cellpadding=\"0\">content here</table\n>"
 @end example
@@ -23336,7 +23336,7 @@ of symbols; they specify names of modules to inherit from or to import from.
 
 @c EN
 The keyword arguments @var{bindings} must either be a dictionary
-(anything that inherits @code{<dictonary>}), or a key-value list.
+(anything that inherits @code{<dictionary>}), or a key-value list.
 The mappings represented by it are incorporated to the environment.
 @c JP
 キーワード引数@var{bindings}はディクショナリ(@code{<dictionary>}のサブクラスの
@@ -23726,7 +23726,7 @@ argument that is used to test equality, which defaults to @code{eqv?}.
 
 @defun permutations set
 @defunx permutations* set :optional eq
-@c MOD util.comibinations
+@c MOD util.combinations
 @c EN
 Returns a list of all permutations of a list @var{set}.
 @c JP
@@ -23758,7 +23758,7 @@ each permutation at a time, consider @code{permutations-for-each} below.
 
 @defun permutations-for-each proc set
 @defunx permutations*-for-each proc set :optional eq
-@c MOD util.comibinations
+@c MOD util.combinations
 @c EN
 For each permutation of a list @var{set}, calls @var{proc}.
 Returns an undefined value.
@@ -23770,7 +23770,7 @@ Returns an undefined value.
 
 @defun combinations set n
 @defunx combinations* set n :optional eq
-@c MOD util.comibinations
+@c MOD util.combinations
 @c EN
 Returns a list of all possible combinations of @var{n} elements out
 of a list @var{set}.
@@ -23799,7 +23799,7 @@ Watch out the explosion of combinations when @var{set} is large.
 
 @defun combinations-for-each proc set n
 @defunx combinations*-for-each proc set n :optional eq
-@c MOD util.comibinations
+@c MOD util.combinations
 @c EN
 Calls @var{proc} for each combination of @var{n} elements out of @var{set}.
 Returns an undefined value.
@@ -23811,7 +23811,7 @@ Returns an undefined value.
 
 @defun power-set set
 @defunx power-set* set :optional eq
-@c MOD util.comibinations
+@c MOD util.combinations
 @c EN
 Returns power set (all subsets) of a list @var{set}.
 @c JP
@@ -23829,7 +23829,7 @@ Returns power set (all subsets) of a list @var{set}.
 
 @defun power-set-for-each proc set
 @defunx power-set*-for-each proc set :optional eq
-@c MOD util.comibinations
+@c MOD util.combinations
 @c EN
 Calls @var{proc} for each subset of @var{set}.
 @c JP
@@ -23838,7 +23838,7 @@ Calls @var{proc} for each subset of @var{set}.
 @end defun
 
 @defun power-set-binary set
-@c MOD util.comibinations
+@c MOD util.combinations
 @c EN
 Returns power set of @var{set}, like @code{power-set}, but in different order.
 @code{Power-set-binary} traverses subset space in depth-first order,
@@ -23857,7 +23857,7 @@ while @code{power-set} in breadth-first order.
 
 @defun cartesian-product list-of-sets
 @defunx cartesian-product-right list-of-sets
-@c MOD util.comibinations
+@c MOD util.combinations
 @c EN
 Returns a cartesian product of sets in @var{list-of-sets}.
 @code{Cartesian-product} construct the result in left fixed order
@@ -24095,7 +24095,7 @@ in the result.
 There may be multiple routes, but if you have to pass node Y no matter
 which route you take, then Y is a dominator of X.  There may be
 many dominators of X.  Among them, there's
-always one domniator such that all other X's dominators are also
+always one dominator such that all other X's dominators are also
 its dominators---in other words, the closest dominator of X---which
 is called the immediate dominator of X.)
 @c JP
@@ -25994,7 +25994,7 @@ as @code{(lambda formals (stream-delay body body2 @dots{}))}.
 @end defmac
 
 @node Stream constructors, Stream binding, Stream primitives, Stream library
-@subsection Stream constructos
+@subsection Stream constructors
 
 @defun stream obj @dots{}
 [SRFI-40]
@@ -26295,7 +26295,7 @@ generated.
 @c MOD util.stream
 @c EN
 Returns a sequence starting from @var{seed}, and each successive element
-is calcualted by @code{(@var{f} @var{s})} where @var{s} is the previous
+is calculated by @code{(@var{f} @var{s})} where @var{s} is the previous
 element.
 @c JP
 @c COMMON
@@ -26338,7 +26338,7 @@ Retrun a new stream whose elements are the elements in @var{list}.
 @defun string->stream string :optional tail-stream
 @c MOD util.stream
 @c EN
-Convers a string to a stream of characters.  If an optional
+Converts a string to a stream of characters.  If an optional
 @var{tail-stream} is given, it becomes the tail of the resulting
 stream.
 @c JP
@@ -26441,7 +26441,7 @@ but only the first 10 elements are calculated because of
 [R7RS stream]
 @c MOD util.stream
 @c EN
-Stream comperehension.  Returns a stream in which each element
+Stream comprehension.  Returns a stream in which each element
 is computed by @var{elt-expr}.   
 The @var{clause} creates scope of @var{elt-expr}
 and controls iterations.  Each @var{clause} can be one of the following
@@ -26507,7 +26507,7 @@ triples:
 [R7RS stream]
 @c MOD util.stream
 @c EN
-A convenent macro to define a procedure that yields a stream.
+A convenient macro to define a procedure that yields a stream.
 Same as the following form:
 @c JP
 ストリームを作って返す関数を手軽に定義するマクロです。
@@ -26831,7 +26831,7 @@ the main argument (@var{stream}).
 
 @defun stream->string stream
 @c MOD util.stream
-Conversts a stream to a list.
+Converts a stream to a list.
 All elements of @var{stream} must be characters, or an error is signaled.
 @end defun
 
@@ -27191,7 +27191,7 @@ which the API takes as arguments:
 @c EN
 A comparator to see if an item is a variable, and also
 check equality of two variables.  It must be hashable.
-@xref{Basic comparators}, for the defails of comparators.
+@xref{Basic comparators}, for the details of comparators.
 @c JP
 要素が変数であるかどうかを調べ、また二つの変数が同じかどうかを判定
 するための比較器です。ハッシュ可能でなければなりません。

--- a/doc/program.texi
+++ b/doc/program.texi
@@ -2691,7 +2691,7 @@ When you want to distribute your Gauche scripts or applications,
 the users need to install Gauche runtime on their machine.
 Although it is always the case for any language implementations---you need
 Java runtime to run Java applications, or C runtime to run
-C applciations---it may be an extra effort to ask users to install
+C applications---it may be an extra effort to ask users to install
 not-so-standard language runtimes.
 @c JP
 Gaucheで作ったスクリプトやアプリケーションを配布する場合、
@@ -2963,7 +2963,7 @@ project/src/
 @end example
 
 @c EN
-If you run @code{build-standalone} in the dirctory as @file{src},
+If you run @code{build-standalone} in the directory as @file{src},
 you can just say this:
 @c JP
 @code{build-standalone}を@file{src}の下で実行する場合は、

--- a/ext/binary/io.scm
+++ b/ext/binary/io.scm
@@ -165,7 +165,7 @@
 (define write-binary-long   write-s32)
 (define write-binary-ulong  write-u32)
 
-;; Other compatibility names.  They have been official befor 0.8.10,
+;; Other compatibility names.  They have been official before 0.8.10,
 ;; and used widely.  So we keep them for a while.
 (define read-binary-uint  read-uint)
 (define read-binary-sint  read-sint)

--- a/ext/file/test.scm
+++ b/ext/file/test.scm
@@ -17,7 +17,7 @@
 
 ;; shorthand of normalizing pathname.  this doesn't do anything on
 ;; unix, but on Windows the separator in PATHNAME is replaced.
-;; NB: we remove the drive letter from DOS path to accomodate
+;; NB: we remove the drive letter from DOS path to accommodate
 ;; different installations.
 (define (n pathname . pathnames)
   (define (normalize s)

--- a/ext/peg/test.scm
+++ b/ext/peg/test.scm
@@ -831,7 +831,7 @@
        (with-input-from-string "{\"a\":1, \"b\":2}{\"c\":3, \"d\":4}"
          parse-json*))
 
-(test* "Customizing consturctors"
+(test* "Customizing constructors"
        '(object ("x" array 1 2 3) ("y" array #f #t null))
        (parameterize ([json-array-handler (^[elts] (cons 'array elts))]
                       [json-object-handler (^[pairs] (cons 'object pairs))]

--- a/ext/sparse/sparse.scm
+++ b/ext/sparse/sparse.scm
@@ -113,7 +113,7 @@
        (define (,x-update! sv k proc . fallback)
          (rlet1 tmp (proc (apply ,ref sv k fallback))
            (,set sv k tmp)))
-       ;; Treatment of defauleValue differ between sptab and spvec atm,
+       ;; Treatment of defaultValue differ between sptab and spvec atm,
        ;; so we define push! separately.
        ;; (define (,x-push! sv k val)
        ;;   (,set sv k (cons val (,ref sv k '()))))

--- a/ext/uvector/uvlib.scm.tmpl
+++ b/ext/uvector/uvlib.scm.tmpl
@@ -69,7 +69,7 @@
   (v::<${t}vector> :optional (start::<fixnum> 0) (end::<fixnum> -1))
   Scm_${T}VectorCopy)
 
-;; NB: this function accomodates to two APIs.
+;; NB: this function accommodates to two APIs.
 ;; The 'modern' API, compatible to srfi-13 and srfi-43, takes arguments:
 ;;    (dst dstart src :optional sstart send)
 ;; The old API only takes:

--- a/lib/data/cache.scm
+++ b/lib/data/cache.scm
@@ -49,7 +49,7 @@
 ;;  (cache-write! cache key value) => void                       method
 ;;
 ;;  (cache-storage cache) => dictionary                       procedure
-;;  (cache-compartor cache) => comparator                     procedure
+;;  (cache-comparator cache) => comparator                     procedure
 ;;
 ;; Implementor-side API
 ;;

--- a/lib/data/trie.scm
+++ b/lib/data/trie.scm
@@ -164,7 +164,7 @@
 
 ;;
 ;; Primitive accessors
-;; We have three accessors; they are slightly differnt from each other, and
+;; We have three accessors; they are slightly different from each other, and
 ;; it is simpler to define them separately than compounding them
 ;; into one routine.
 ;;

--- a/lib/gauche/hashutil.scm
+++ b/lib/gauche/hashutil.scm
@@ -151,7 +151,7 @@
 ;; procedures.  We add a check in case the caller mistook this with R7RS one.
 (define (hash-table-map ht proc :optional arg)
   (when (not (undefined? arg))
-    (error "Gauche's bulit-in hash-table-map is called with R7RS interface. \
+    (error "Gauche's built-in hash-table-map is called with R7RS interface. \
             Use hash-table-map-r7, or say (use scheme.hash-table)."))
   (assume-type ht <hash-table>)
   (let1 i ((with-module gauche.internal %hash-table-iter) ht)

--- a/lib/gauche/process.scm
+++ b/lib/gauche/process.scm
@@ -565,7 +565,7 @@
     (process-wait p #f eflag)
     (zero? (process-exit-status p))))
 
-;; For the backward compatiblity.  DEPRECATED.
+;; For the backward compatibility.  DEPRECATED.
 (define (run-process-pipeline . args) ; returns list of processes.
   (let1 p (apply run-pipeline args)
     (append (~ p'upstreams) (list p))))

--- a/lib/gauche/vecutil.scm
+++ b/lib/gauche/vecutil.scm
@@ -47,7 +47,7 @@
   (let* ([len (length lis)]
          [end (if (< end 0) len end)])
     (when (< len start)
-      (errorf "start arugment out of range [0-~s]: ~s" len start))
+      (errorf "start argument out of range [0-~s]: ~s" len start))
     (when (< end start)
       (errorf "start ~s is greater than end ~s" start end))
     (do ([vec (make-vector (- end start))]

--- a/src/gauche/parameter.h
+++ b/src/gauche/parameter.h
@@ -82,7 +82,7 @@ SCM_EXTERN ScmPrimitiveParameter *Scm_BindPrimitiveParameter(ScmModule *mod,
                                                              ScmObj initval,
                                                              u_long flags);
 
-/* TRANSIENT - exposed only for the backward compatiblity - will be gone by 1.0 */
+/* TRANSIENT - exposed only for the backward compatibility - will be gone by 1.0 */
 typedef struct ScmParameterLocRec {
     ScmPrimitiveParameter *p;
 } ScmParameterLoc;

--- a/src/libcmp.scm
+++ b/src/libcmp.scm
@@ -72,7 +72,7 @@
      (Scm_MakeComparator type-test equality-test comparison-proc hash
                          name flags))))
 
-;; Argument checkers for consturctors.
+;; Argument checkers for constructors.
 ;; We use <bottom> for applicability check except type-test, since
 ;; those procs are only required to handle objects that passes type-test.
 (define (ensure-type-test type-test)

--- a/src/list.c
+++ b/src/list.c
@@ -636,7 +636,7 @@ ScmObj Scm_DeleteDuplicatesX(ScmObj list, int cmpmode)
  *  Since the algorithm is generally useful, I implement the core routine
  *  of the algorithm here.
  *
- *  TODO at 1.0: I noticed START argument acutally isn't used in the
+ *  TODO at 1.0: I noticed START argument actually isn't used in the
  *  algorithm at all.  We can drop it and the caller can just say
  *  Scm_Cons(start, Scm_MonotonicMerge(sequences)).   We can't change it
  *  now because of ABI compatibility, but it will be nice to do so when

--- a/src/weak.c
+++ b/src/weak.c
@@ -142,7 +142,7 @@ ScmObj Scm_WeakVectorSet(ScmWeakVector *v, ScmSmallInt index, ScmObj value)
 /* ptr points to the target object weakly.
    Registered flag becomes TRUE whenever ptr points to a GC_malloced object,
    thus &wbox->ptr is registered as a disappearing link.
-   Note that we can distinguish a box that contaning NULL pointer, and
+   Note that we can distinguish a box that containing NULL pointer, and
    a box whose target has been GCed and hence ptr is cleared---in the
    former case registered is FALSE, while in the latter case it is TRUE. */
 struct ScmWeakBoxRec {


### PR DESCRIPTION
This is found by running

    LANG=C hunspell -l `git ls-files doc/*.texi` | sort | uniq

fixes are only up to letter 'd'.

I might fix up the rest if I'm still bored ;-)