### PR TITLE
Typo fixes j to z

### DIFF
--- a/doc/concepts.texi
+++ b/doc/concepts.texi
@@ -612,7 +612,7 @@ Gaucheでは、名前空間はオブジェクトシステムとは直交する�
 
 @c EN
 Gauche has a simple module system that allows
-modularlized development of large software.
+modularized development of large software.
 @c JP
 Gaucheは大きなソフトウェアをモジュール化して開発するための、
 単純なモジュールシステムを備えています。

--- a/doc/corelib.texi
+++ b/doc/corelib.texi
@@ -6076,7 +6076,7 @@ the key first.
 @c COMMON
 @end defun
 
-@defun assoc-update-in alist keys proc :optonal default eq-fn
+@defun assoc-update-in alist keys proc :optional default eq-fn
 @c EN
 This procedure allows to update a nested associative list.
 The @var{alist} argument is a (possibly nested) associative list,
@@ -6125,7 +6125,7 @@ the sequence where specfied key didn't exist.
 
 @c EN
 The @var{default} argument is passed to @var{proc} when there's
-no entry with specified keys.  If ommitted, @code{#f} is assumed.
+no entry with specified keys.  If omitted, @code{#f} is assumed.
 @c JP
 @var{default}引数は、キーに対応するエントリが存在しなかった場合に@var{proc}に
 渡されます。省略値は@code{#f}です。
@@ -7117,7 +7117,7 @@ Unicodeコードポイントでなく内部文字エンコーディングで文�
 @code{\xNN}で記されたASCIIの範囲外の文字の解釈は、
 0.9.3.3およびそれ以前のGaucheとは異なることになります。
 
-リーダのモードを@code{leagcy}にセットすれば(@ref{Reader lexical mode}参照)、
+リーダのモードを@code{legacy}にセットすれば(@ref{Reader lexical mode}参照)、
 @code{#\xNN}は以前と同じ解釈となり、互換性は保たれます
 (ただし、R7RSとは非互換になります)。
 あるいは@code{#\uNNNN}表記や文字そのものを表記することで、
@@ -7820,7 +7820,7 @@ To write code that can work both in new and old syntax, use @code{\u} escape.
 しかし曖昧な場合もあります。@code{#[\x0a;]}は新しい構文では
 改行文字のみのセットですが、古い構文では改行文字とセミコロンになります。
 
-リーダのモードを@code{leagcy}にセットすると、常に古い構文で認識されます。
+リーダのモードを@code{legacy}にセットすると、常に古い構文で認識されます。
 リーダのモードを@code{warn-legacy}にセットすると、
 デフォルトと同じように振る舞いますが、古い構文を見つけた場合は警告が出力されます。
 詳しくは@ref{Reader lexical mode}を参照してください。
@@ -8415,7 +8415,7 @@ behavior, but prints warning when it finds legacy syntax.
 しかし曖昧な場合もあります。@code{"\x0a;"}は新しい構文では
 @code{"\n"}と同じですが、、古い構文では@code{"\n;"}となります。
 
-リーダのモードを@code{leagcy}にセットすると、常に古い構文で認識されます。
+リーダのモードを@code{legacy}にセットすると、常に古い構文で認識されます。
 リーダのモードを@code{warn-legacy}にセットすると、
 デフォルトと同じように振る舞いますが、古い構文を見つけた場合は警告が出力されます。
 詳しくは@ref{Reader lexical mode}を参照してください。
@@ -9415,7 +9415,7 @@ character in @var{string}, and the consecutive characters that caused
 @c EN
 The @var{grammar} argument is the same as @code{string-join} above; it
 must be one of symbols @code{infix}, @code{strict-infix}, @code{prefix}
-or @code{suffix}.  When ommitted, @code{infix} is assumed.
+or @code{suffix}.  When omitted, @code{infix} is assumed.
 @c JP
 @var{grammar}引数の意味は上の@code{string-join}と同じです。
 シンボル@code{infix}、@code{strict-infix}、@code{prefix}、
@@ -10164,7 +10164,7 @@ about the match, including submatches.
 The advantage of using match object, rather than substrings or
 list of indices, is efficiency.  The regmatch object keeps internal
 state of match, and computes indices and/or substrings only when
-requested.  This is particularly effective for mutibyte strings,
+requested.  This is particularly effective for multibyte strings,
 for index access is slow on them.
 @c JP
 正規表現マッチオブジェクトのクラスです。正規表現エンジン@code{rxmatch}は、
@@ -12038,7 +12038,7 @@ the implementation supports one, unless the optional @var{mutable?}
 argument is provided and not false.  Gauche doesn't have immutable
 hash tables so it ignores the optional argument and
 always returns a mutable hash table.  But when you write
-a portable programs, keep it in mynd.
+a portable programs, keep it in mind.
 @c JP
 ハッシュテーブル@var{ht}のコピーを作って返します。
 
@@ -13006,7 +13006,7 @@ is strictly greater than @var{probe}.
 それぞれの手続きは異なった「最も近い」の基準を持っています。
 @code{tree-map-floor}は@var{probe}以下で最大のキーを、
 @code{tree-map-ceiling}は@var{probe}以上で最小のキーを、
-@code{tree-map-precedessor}は@var{probe}未満で最大のキーを、
+@code{tree-map-predecessor}は@var{probe}未満で最大のキーを、
 @code{tree-map-successor}は@var{probe}を越える最小のキーを探します。
 @c COMMON
 @end defun
@@ -19053,7 +19053,7 @@ if not, an incomplete string is returned.
 This doesn't affect the @var{port}'s operation, so you can keep
 accumulating content to @var{port} after calling @code{get-output-string}.
 @c JP
-これは@var{port}の操作には影響をあたえません。@code{get-ouptut-string}を
+これは@var{port}の操作には影響をあたえません。@code{get-output-string}を
 呼んだ後でも、@var{port}に内容を蓄積しつづけることができます。
 @c COMMON
 @end defun

--- a/doc/corelib.texi
+++ b/doc/corelib.texi
@@ -3657,7 +3657,7 @@ for this purpose.  Use @code{real->rational} only when you need finer
 control of error bounds.
 @c JP
 指定されたエラー範囲の中で、有限な実数@var{x}の正確な有理数表現のうち
-最も簡単なものを返します。@code{ratinalize}や@code{exact}はこの手続きを
+最も簡単なものを返します。@code{rationalize}や@code{exact}はこの手続きを
 下請けとして呼び出しています。通常は@code{rationalize} (@ref{Arithmetics}参照)
 を使い、@code{real->rational}は誤差許容値をより細かく制御したい時のみ
 使うのが良いでしょう。
@@ -6112,7 +6112,7 @@ the structure with @var{alist}.
 @c EN
 If @var{alist} doesn't have the entry specified by @var{keys},
 a new entry is added.  A new entry is added at the beginning of
-the sequence where specfied key didn't exist.
+the sequence where specified key didn't exist.
 @c JP
 @var{alist}が@var{keys}で指定されるエントリを持たない場合は新たなエントリが
 追加されます。新たなエントリは、キーが存在しないシーケンスの先頭に付け加えられます。
@@ -9617,7 +9617,7 @@ Gaucheの内部エンコーディングがutf-8であれば、この手続きは
   @result{} "_abc"     ; can be represented as a complete string
 
 (string-incomplete->complete #*"_ab\x80;c")
-  @result{} #f        ; can't be represetend as a complete string
+  @result{} #f        ; can't be represented as a complete string
 
 (string-incomplete->complete #*"_ab\x80;c" :omit)
   @result{} "_abc"     ; omit the illegal bytes
@@ -11996,7 +11996,7 @@ refrain from mutating the returned hash tables.
 @c COMMON
 @end defun
 
-@defun hash-talbe-unfold p f g seed comparator :rest args
+@defun hash-table-unfold p f g seed comparator :rest args
 [R7RS hash-table]
 @c EN
 Constructs and returns a new hash table with those repetitive steps.
@@ -16634,7 +16634,7 @@ from outside of @code{unwind-protect} by invoking continuations
 captured within @var{expr}.
 
 However, keep in mind that once @var{cleanup} are executed,
-some resouces might not be available in @var{expr}.
+some resources might not be available in @var{expr}.
 We still allow it since the reexecuted part of @var{expr} may not
 depend on the resources cleaned up with @var{cleanup}.
 
@@ -24437,7 +24437,7 @@ the handler returns by default.
 @c COMMON
 
 @c EN
-Here are some calls that are not simply restared by signal interruption.
+Here are some calls that are not simply restarted by signal interruption.
 @c JP
 シグナル割り込みによって単純にリスタートされないものは次の通りです。
 @c COMMON

--- a/doc/corelib.texi
+++ b/doc/corelib.texi
@@ -7680,7 +7680,7 @@ Here's the list of POSIX-style character class names:
 @item @code{:LOWER:} @tab Unicode lower-case letters (category @code{Ll}).  @code{char-set:lower-case}, @code{#[a-z]}.
 @item @code{:PRINT:} @tab Unicode printing characters (graphic and whitespace).  @code{char-set:printing}.
 @item @code{:PUNCT:} @tab Unicode punctuation characters (category @code{P*}).  @code{char-set:punctuation}.
-@item @code{:SPACE:} @tab Unicode whitespaces (tab, LF, vertial tab, FF, CR, and category @code{Z*}). @code{char-set:whitespace}.
+@item @code{:SPACE:} @tab Unicode whitespaces (tab, LF, vertical tab, FF, CR, and category @code{Z*}). @code{char-set:whitespace}.
 @item @code{:TITLE:} @tab Unicode titlecase letters (category @code{Lt}).  @code{char-set:title-case}.
 @item @code{:UPPER:} @tab Unicode upper-case letters (category @code{Lu}).  @code{char-set:upper-case}, @code{#[A-Z]}.
 @item @code{:WORD:} @tab Unicode word characters.  @code{char-set:word}.

--- a/doc/coresyn.texi
+++ b/doc/coresyn.texi
@@ -5678,7 +5678,7 @@ Gaucheの組み込みの識別子とともに自己束縛されたキーワー�
 @end example
 
 @c EN
-If you use more sophisitcated import tricks, however, keep in mind
+If you use more sophisticated import tricks, however, keep in mind
 that keywords are just imported symbols by default.
 The following code imports
 Gauche builtin identifiers with prefix @code{gauche/}.  That causes

--- a/doc/coresyn.texi
+++ b/doc/coresyn.texi
@@ -3148,7 +3148,7 @@ that expands to @code{cond} form:
 
 @c EN
 Note the two @code{else}s in the macro definition; one isn't unquoted,
-thus appears liteally in the output, while another is unquoted and
+thus appears literally in the output, while another is unquoted and
 the corresponding macro argument is inserted in its place.
 @c JP
 マクロ定義内の2つの@code{else}に注目してください。ひとつはアンクォート

--- a/doc/coresyn.texi
+++ b/doc/coresyn.texi
@@ -777,7 +777,7 @@ The actual arguments are collected to form a new list and bound to
 the variable.
 @c JP
 手続きは不定個の引数を取ります。
-実引数は新しいリストに集められて、そのリストが@var{varible}に束縛されます。
+実引数は新しいリストに集められて、そのリストが@var{variable}に束縛されます。
 @c COMMON
 
 @example
@@ -2173,7 +2173,7 @@ Each @var{binding} should be one of the following form:
 The @var{expression} is evaluated; if it yields true value, the value
 is bound to @var{variable}, then proceed to the next binding.  If
 no more bindings, evaluates @var{body} @dots{}.   If @var{expression}
-yieds @code{#f}, stops evaluation and returns @code{#f} from @code{and-let*}.
+yields @code{#f}, stops evaluation and returns @code{#f} from @code{and-let*}.
 @c JP
 @var{expression}が評価されます。それが真の値を返したら、その値が@var{variable}
 に束縛され、次の@var{binding}へと進みます。もう@var{binding}が無ければ
@@ -4035,7 +4035,7 @@ anywhere.
 @item
 @c EN
 The file is searched from @code{*load-path*}, except when the
-file begins with @code{./} or @code{../}, in whcih case it is
+file begins with @code{./} or @code{../}, in which case it is
 first tried relative to the current directory before being searched
 from @code{*load-path*}.
 @c JP
@@ -4512,7 +4512,7 @@ and affects the resolution of global variable reference.
 @c EN
 Unlike CommonLisp's packages, which map names to symbols,
 in Gauche symbols are @code{eq?} in principle if two have the
-same name (except uninterened symbols; @pxref{Symbols}).
+same name (except uninterned symbols; @pxref{Symbols}).
 However, Gauche's symbol doesn't have a 'value'
 slot in it.  From a given symbol, a module finds its binding that
 keeps a value.

--- a/doc/gauche-dev.texi
+++ b/doc/gauche-dev.texi
@@ -2105,7 +2105,7 @@ copies the content every time and returns a freshly allocated
 string.
 @end deftypefun
 
-@deftypefun {const char *} Scm_GetStringContent (ScmString *@var{str}, unsigned int *@var{psize}, unsignd int *@var{plen}, unsigned int *@var{pflags})
+@deftypefun {const char *} Scm_GetStringContent (ScmString *@var{str}, unsigned int *@var{psize}, unsigned int *@var{plen}, unsigned int *@var{pflags})
 Use this function if you want to retrieve other attributes of
 the strings at once.  The return value points to the beginning
 of the string content, but it may not be @code{NUL}-terminated.
@@ -3038,7 +3038,7 @@ of the given tree map.
 @deftypefun ScmObj Scm_TreeMapRef (ScmTreeMap *@var{tm}, ScmObj @var{key}, ScmObj @var{fallback})
 Searches an entry with the given @var{key}, and returns its value.
 If there's no entry that has @var{key}, a value passed to @var{fallback}
-is returned (unlinke Scheme-level @code{tree-map-get}, it doesn't
+is returned (unlike Scheme-level @code{tree-map-get}, it doesn't
 signals an error).
 
 A standard way to take a specific action when no entry is found is
@@ -3244,7 +3244,7 @@ these functions.
 
 There are two ways to extend port functionalities and creates
 your own port types.  A @emph{fully virtual port} basically has
-all basic port I/O operations as virutal functions, so you
+all basic port I/O operations as virtual functions, so you
 can override those functionalities as you like.
 A @emph{virtual buffered port}, on the other hand, implements
 buffering by itself, and calls back your routines when it needs

--- a/doc/gauche-dev.texi
+++ b/doc/gauche-dev.texi
@@ -561,7 +561,7 @@ but does not call @code{exit(2)} at the end.  This is useful
 for applications that want to shut down Gauche runtime but
 need to continue running.
 
-Once you call @code{Scm_Cleanup()}, you shoudn't use any
+Once you call @code{Scm_Cleanup()}, you shouldn't use any
 other Gauche functions.
 
 It is harmless to call @code{Scm_Cleanup()} more than once;
@@ -704,7 +704,7 @@ objects referred from @var{obj} are in such state.
 You can't choose which thread will call the finalizer.  Any thread that
 allocates may call the finalizer.
 
-You can ressurrect @var{obj} by storing a pointer to it in some root set.
+You can resurrect @var{obj} by storing a pointer to it in some root set.
 GC doesn't immediately put back @var{obj} to a free memor pool
 after the finalizer is run; basically
 it leaves @var{obj}'s fate to the finalizer.  If the finalizer doesn't keep
@@ -1160,7 +1160,7 @@ Corresponds to Scheme @code{logtest}.
 @deftypefun int Scm_LogBit (ScmObj @var{x}, int @var{b})
 Returns @code{TRUE} or @code{FALSE} if @var{b}-th bit of
 a Scheme exact integer @var{x} is set or not set, respectively.
-0-th bit is the least siginificant bit.
+0-th bit is the least significant bit.
 Corresponds to Scheme @code{logbit}.
 @end deftypefun
 
@@ -2949,7 +2949,7 @@ Must be treated as opaque structure.
 An iterator can point to one of the entries in a tree core,
 or @code{NULL}.  The @code{NULL} indicates the iterator is
 outside of the tree---it's both below the minimum key and above
-the maximum key simulaneously.  That is, when an iterator points
+the maximum key simultaneously.  That is, when an iterator points
 to @code{NULL}, when you call @code{Scm_TreeIterNext} you'll get
 the minimum key entry, while you call @code{Scm_TreeIterPrev} and
 you'll get the maximum key entry.

--- a/doc/gauche-dev.texi
+++ b/doc/gauche-dev.texi
@@ -91,7 +91,7 @@ That said, it won't be too difficult to use Gauche's C API
 as far as you know some fundamental design concepts.
 
 We intend this document to serve both a programmer's guide
-that explains such design concepts, and a programer's reference
+that explains such design concepts, and a programmer's reference
 that describes every C API in detail.
 
 The guide part begins with @ref{Getting started}, that shows
@@ -2264,7 +2264,7 @@ Returns a new Scheme string whose content is concatenation of
 a Scheme string @var{x} and C-level string @var{s}.
 Like @code{Scm_MakeString}, you can give -1 to @var{size} and/or @var{len}
 to make the function calculates those values.  If you give -1 to @var{size},
-@var{s} must be @code{NUL}-terminated; othewise @var{s} doesn't need to be.
+@var{s} must be @code{NUL}-terminated; otherwise @var{s} doesn't need to be.
 @end deftypefun
 
 @deftypefun ScmObj Scm_StringAppend (ScmObj @var{strs})
@@ -2367,7 +2367,7 @@ mutex.
 @deftp {Datatype} ScmDString
 A structure to keep a string under construction.   It is not a
 Scheme datatype (means: you can't cast it to @code{ScmObj}).
-You can allocate it on the C stack for efficient opertaion.
+You can allocate it on the C stack for efficient operation.
 @end deftp
 
 The typical usage of dynamic strings looks like this:
@@ -2680,7 +2680,7 @@ Sets @var{value} to the value field of @var{entry} and returns
 @var{value} itself.
 
 The caller have to make sure @var{value} is a valid @code{ScmObj}.
-Particulary, it is prohibited to pass @code{SCM_UNBOUND} as @var{value}.
+Particularly, it is prohibited to pass @code{SCM_UNBOUND} as @var{value}.
 @end deftypefn
 
 Each core dictionary API provides a search function that takes
@@ -2987,7 +2987,7 @@ flag is cleared.
 
 @deftypefun {ScmDictEntry *} Scm_TreeIterNext (ScmTreeIter *@var{iter})
 @deftypefunx {ScmDictEntry *} Scm_TreeIterPrev (ScmTreeIter *@var{iter})
-Moves the iterator to the next or prevoius entry and returns it,
+Moves the iterator to the next or previous entry and returns it,
 respectively.
 If the iterator was pointing the maximum (minimum) key entry
 before calling @code{Scm_TreeIterNext} (@code{Scm_TreeIterPrev}),
@@ -3201,7 +3201,7 @@ description of ports only useful for debug messages.
 Returns the value of @var{line} slot of the port.
 Most built-in port types keeps track of the line count,
 as far as (1) only character I/O is performed, and
-(2) no random-access opertaion is performed, on the port.
+(2) no random-access operation is performed, on the port.
 If either of such operation is done on the port, the number
 returned from this function doesn't have meaning.
 
@@ -3486,7 +3486,7 @@ Other operations are mainly invoked by @code{make} command.
 
 @deffn {Package Operation} gauche-package install [@var{options}] @var{tarball-path/url}
 
-This opertaion obtains the package source specified by @var{tarball-path/url},
+This operation obtains the package source specified by @var{tarball-path/url},
 then extracts the source, configures and builds,
 runs the tests, and installs the built package.
 Most of the time this is the only command required to install a Gauche
@@ -3499,7 +3499,7 @@ it first.  By default @code{gauche-package} uses the current working
 directory, but you can make it use specific directory by customizing
 @file{~/.gauche-package} (@pxref{Customizing gauche-package}).
 
-The following options are recognized by this opertaion.
+The following options are recognized by this operation.
 
 @deffn {Option} -n, --dry-run
 Shows shell commands to be executed, without running them.

--- a/doc/macro.texi
+++ b/doc/macro.texi
@@ -1130,7 +1130,7 @@ tool to decompose macro input):
 
 @c EN
 This is ok as long as you know you don't need hygiene---e.g. when
-you only use this macro locally in your code, knowning all the
+you only use this macro locally in your code, knowing all the
 macro call site won't contain name conflicts.  However, if you
 provide your @code{when-not} macro for general use,
 you have to protect namespace pollution around the macro use.

--- a/doc/macro.texi
+++ b/doc/macro.texi
@@ -577,7 +577,7 @@ allows mutually recursive macros.
 ローカルマクロを定義します。各@var{name}が
 対応する@var{transformer-spec}で定義されるマクロ変換器へと束縛された
 環境を作り@var{body}を評価します。
-@code{let-synta}では、@var{transformer-spec}は@code{let-syntax}を
+@code{let-syntax}では、@var{transformer-spec}は@code{let-syntax}を
 囲むスコープ内で@var{transformer-spec}を評価するのに対し、
 @code{letrec-syntax}では@var{name}の束縛がなされた環境で
 @var{transformer-spec}を評価します。つまり@code{letrec-syntax}は
@@ -588,7 +588,7 @@ allows mutually recursive macros.
 @subheading Transformer specs
 
 @c EN
-The @var{trasformer-spec} is a special expression that evaluates
+The @var{transformer-spec} is a special expression that evaluates
 to a macro transformer.  It is evaluated in a different phase
 than the other expressions, since macro transformers must be
 executed during compiling.  So there are some restrictions.
@@ -1447,7 +1447,7 @@ If you already have a quasirename form that does intend to produce
 a quasiquoted form, you have to rewrite it with double quasiquote:
 @code{(quasirename r ``form)}.
 
-To help transiation, the handling of quasiquote in of @code{quasirename}
+To help transition, the handling of quasiquote in of @code{quasirename}
 can be customized with the environment variable
 @code{GAUCHE_QUASIRENAME_MODE}.  It can have one of the following
 values:
@@ -1805,7 +1805,7 @@ the setting; it returns the current setting.
 @c COMMON
 
 @c EN
-When called with signle boolean value, it sets the current setting
+When called with single boolean value, it sets the current setting
 to that value.  Returns the updated setting.
 @c JP
 単一の真偽値を引数に渡した場合は、それをマクロトレースの設定値として、

--- a/doc/mapping.texi
+++ b/doc/mapping.texi
@@ -575,9 +575,9 @@ Use @code{read-line} or @code{read-string}.    @xref{Input}.
 @c COMMON
 @item fileno
 @c EN
-@code{port-file-numer}.   @xref{Common port operations}.
+@code{port-file-number}.   @xref{Common port operations}.
 @c JP
-@code{port-file-numer}。@ref{Common port operations} 参照。
+@code{port-file-number}。@ref{Common port operations} 参照。
 @c COMMON
 @item floor
 @c EN

--- a/doc/mapping.texi
+++ b/doc/mapping.texi
@@ -1212,7 +1212,7 @@ the directory at once.  @xref{Directories}.
 @item readlink
 @c EN
 Gauche's @code{sys-readlink}.  @xref{Directory manipulation}.
-This function is available on systems that support symbolink links.
+This function is available on systems that support symbolic links.
 @c JP
 Gauche の @code{sys-readlink}。@ref{Directory manipulation} 参照。
 この関数はシンボリックリンクをサポートしているシステム上で利用可能です。
@@ -1634,7 +1634,7 @@ Not supported yet.
 @item symlink
 @c EN
 Gauche's @code{sys-symlink}.  @xref{Directory manipulation}.
-This function is available on systems that support symbolink links.
+This function is available on systems that support symbolic links.
 @c JP
 Gauche の @code{sys-symlink}。@ref{Directory manipulation}参照。
 この関数は、シンボリックリンクをサポートしているシステム上で利用可能です。

--- a/doc/modgauche.texi
+++ b/doc/modgauche.texi
@@ -5839,7 +5839,7 @@ For each @var{file}, a file named @file{@var{file}.in} is read
 as a template.  Within the file, @code{@@PARAMETER@@} is substituted
 with the value of @code{(cf$ 'PARAMETER)}.  If the named parameter
 isn't registered, a warning is issued and the parameter is left
-unsubstited.
+unsubstituted.
 
 If config headers are not registered via @code{cf-config-headers},
 a substitution parameter @code{DEFS} is replaced with
@@ -6883,7 +6883,7 @@ An integer process id that holding the lock; used only by @code{F_GETLK}.
 @c EN
 A generator is merely a procedure with no arguments and works
 as a source of a series of values.  Every time it is called,
-it yeilds a value.  The EOF value indicates the generator is exhausted.
+it yields a value.  The EOF value indicates the generator is exhausted.
 For example, @code{read-char} can be seen as a generator that
 generates characters from the current input port.
 
@@ -6943,7 +6943,7 @@ using one of generator constructors
 may connect generator operators that modifies the stream of
 generated items as you wish (@pxref{Generator operations}).
 Eventually you need to extract actual values from the generator
-to consume; there are utitlity procedures provided
+to consume; there are utility procedures provided
 (@pxref{Generator consumers}).  Overall, you create a pipeline
 (or DAG) of generators that works as lazy value-propagation network.
 @c JP
@@ -10031,7 +10031,7 @@ Pathname of the log file.  The output is written to it.
 @itemx @code{#t}
 The output goes to the current error port.
 @item @code{current-output}
-The output goes to the urrent output port.
+The output goes to the current output port.
 @item @code{syslog}
 The output is sent to the system logger.
 @item @code{ignore}

--- a/doc/modgauche.texi
+++ b/doc/modgauche.texi
@@ -919,7 +919,7 @@ a square matrix, and @var{pow} must be a nonnegative exact integer.
 @c MOD gauche.array
 @c EN
 Inverse of @code{array-mul}; @code{array-div-left}
-rrturns a matrix @code{M} such that @code{(array-mul B M)}
+returns a matrix @code{M} such that @code{(array-mul B M)}
 equals to @code{A}, and @code{array-div-right} returns
 a matrix @code{M} such that @code{(array-mul M B)} equals to @code{A}.
 @var{A} and @var{B} must be a 2-dimensional square matrix.
@@ -1352,7 +1352,7 @@ Placed inside the initialization function, which appears at
 the end of the C source.
 @end table
 
-The following procedures are the simple way to put a souce
+The following procedures are the simple way to put a source
 code fragments in an appropriate part:
 
 @defun cgen-extern code @dots{}
@@ -1879,7 +1879,7 @@ any S-expression (quasiquote comes pretty handy).
 
 C types can be written either as a symbol (e.g. @code{int}) or
 a list (e.g. @code{(const char *)}.  When used in definition, it is
-preceded by @code{::}.  The following example shows typess
+preceded by @code{::}.  The following example shows types
 are used in local variable definitions:
 
 @example
@@ -1889,7 +1889,7 @@ are used in local variable definitions:
 @end example
 
 For the convenience and readability, you can write the variable name,
-separting double-colon and type name concatenated.  You can also concatenate
+separating double-colon and type name concatenated.  You can also concatenate
 point suffixes (@code{char*} instead of @code{char *} in the following example):
 
 @example
@@ -2034,7 +2034,7 @@ generates the latter.
 header files, e.g. @code{(.include <stdint.h>)}.
 @end deffn
 
-@deffn {CiSE Statement} define-cfn name (arg [@code{::} type] @dots{}) [ret-type [qualiter @dots{}]] stmt @dots{}
+@deffn {CiSE Statement} define-cfn name (arg [@code{::} type] @dots{}) [ret-type [qualifier @dots{}]] stmt @dots{}
 Defines a C function.
 
 If @var{type} or @var{ret-type} is omitted, the default type is
@@ -2289,7 +2289,7 @@ supported.
 
 @itemize
 @item
-@code{(setter @var{setter-name})} : specfy setter. @var{setter-name} should
+@code{(setter @var{setter-name})} : specify setter. @var{setter-name} should
 be a cproc name defined in the same stub file
 
 @item
@@ -4599,7 +4599,7 @@ A @file{configure} script tests
 running system's properties to determine values of
 substitution parameters, then read one or more template build files,
 and write out one output build file for each, replacing
-substutition parameters for the assigned values.
+substitution parameters for the assigned values.
 @c JP
 @file{configure}スクリプトは、それを実行しているシステムの特性を調べて
 置換パラメータの値を決定し、ビルドファイルのテンプレート中の置換パラメータを
@@ -5399,7 +5399,7 @@ used instead of the found program name to be set to @var{sym}.
 The list of search paths is taken from @code{PATH} environment
 variable.  You can override the list by the @var{paths} keyword
 argument, which must be a list of directory names.  It may contain
-nonexistent directory names, which are siently skipped.
+nonexistent directory names, which are silently skipped.
 
 The @var{filter} keyword argument, if given, must be a predicate
 that takes full pathname of the executable program.  It is called
@@ -5838,7 +5838,7 @@ This corresponds to autoconf's @code{AC_OUTPUT}.
 For each @var{file}, a file named @file{@var{file}.in} is read
 as a template.  Within the file, @code{@@PARAMETER@@} is substituted
 with the value of @code{(cf$ 'PARAMETER)}.  If the named parameter
-isn't registetered, a warning is issued and the parameter is left
+isn't registered, a warning is issued and the parameter is left
 unsubstited.
 
 If config headers are not registered via @code{cf-config-headers},
@@ -6469,7 +6469,7 @@ When duplicate relations are found, does nothing and returns @code{#f}.
 @end table
 
 Note: At this moment, an attempt to add a relation exactly same as the
-existing one is regareded as a conflict.  This limitation may be
+existing one is regarded as a conflict.  This limitation may be
 lifted in future.
 @end defun
 
@@ -7241,7 +7241,7 @@ MSBからビットを取り出します。
 The optional @var{start} and/or @var{end} arguments are used to specify
 the range of bitfield, LSB being 0.  Unlike @code{list->generator} etc,
 @var{start} specifies the rightmost position (inclusive) and
-@var{end} specfies the leftmost position (exclusive).  It is consistent
+@var{end} specifies the leftmost position (exclusive).  It is consistent
 with other procedures that accesses bit fields in integers
 (@pxref{Bitwise operations}).
 @c JP
@@ -10297,7 +10297,7 @@ the log drain temporary.
 Formats a log message by @var{format} and @var{arg @dots{}}, by using
 @code{format} (@pxref{Output}).    In the first form, the output goes
 to the default destination.  In the second form, the output goes to
-the specfied drain.
+the specified drain.
 @c JP
 ログメッセージを@code{format}手続きでフォーマットし(@ref{Output}参照)、
 指定された行き先に書き出します。最初の形式ではデフォルトの行き先が使われます。
@@ -10982,7 +10982,7 @@ IP アドレスをもつ場合、ソケットアドレスはそれぞれのIPア
 @defun inet-string->address address
 @c MOD gauche.net
 @c EN
-Converts string representating of the internet address @var{address}
+Converts string representing of the internet address @var{address}
 to an integer address.  If @var{address} is parsed successfully,
 returns two values: the integer address value and the recognized
 protocol (the constant value @code{2} (= @code{AF_INET})
@@ -15278,10 +15278,10 @@ of @var{process}, which represents the last process in the pipeline;
 if an other subprocess exits with nonzero status, it is stored in
 its respective process objects, but won't cause a fuss.
 
-If you speficy a true value to @var{nohang} for the pipelined
+If you specify a true value to @var{nohang} for the pipelined
 process, @code{process-wait} still
 probes other subprocesses in the pipeline and updates exit statuses
-of termianted ones, but doesn't wait unterminated subprocesses.
+of terminated ones, but doesn't wait unterminated subprocesses.
 The unterminated subprocesses should be waited individually, or
 by @code{process-wait-any}, to collect their exit statuses.
 @c JP
@@ -18780,7 +18780,7 @@ For example, the following test passes if @code{proc} returns either
 @c EN
 Similar to @code{test-one-of}, but creates a special object
 representing @emph{none of the choices}.
-The test succees if the test expression evaluates to a value that
+The test suceeds if the test expression evaluates to a value that
 don't match any of @var{choice}s.
 @c JP
 @emph{@var{choice} @dots{} のいずれでもない} を表現する特別なオブジェクトを返します。
@@ -19603,7 +19603,7 @@ Once a thread is in this state, the state can no longer be changed.
 @end table
 
 @c EN
-Access to the resouces shared by multiple threads must be protected
+Access to the resources shared by multiple threads must be protected
 explicitly by synchronization primitives.
 @xref{Synchronization primitives}.
 @c JP
@@ -19886,7 +19886,7 @@ if timeout reached.   When @var{timeout-val} is omitted, @code{#f}
 is assumed.
 @c JP
 @code{thread-stop!}の戻り値は、対象スレッドを停止させられたなら
-その@var{thread}オブジェクト、タイムアウトしたなら@var{tiemout-val}です。
+その@var{thread}オブジェクト、タイムアウトしたなら@var{timeout-val}です。
 @var{timeout-val}が省略された場合は@code{#f}とみなされます。
 @c COMMON
 
@@ -20057,7 +20057,7 @@ use following higher-level synchronization utilities:
 @table @asis
 @item Atoms
 An atom is a wrapper of arbitrary Scheme object, and allows synchronized
-access to it somewhat like Java's @code{synchroized} blocks.  Atoms are
+access to it somewhat like Java's @code{synchronized} blocks.  Atoms are
 explained in this section.
 @item MT-Queues
 Thread-safe queues (@code{<mtqueue>}) are provided in @code{data.queue} module
@@ -21475,7 +21475,7 @@ Unicodeとして不正なコードポイントに対しては空リストが返�
 @c MOD gauche.unicode
 @c EN
 Takes @var{octet} as the first octet of UTF-8 sequence, and
-returns the number of total octets requried to decode
+returns the number of total octets required to decode
 the codepoint.
 @c JP
 @var{octet}をutf-8シーケンスの最初のオクテットとみなし、
@@ -23383,7 +23383,7 @@ The optional @var{skip} argument must be a nonnegative exact integer
 or @code{#f}.  If it is a positive integer, the number of elements after
 every key in the @var{uvector} is ignored.  For example, if @var{skip} is 2
 and @var{uvector} is @code{#u8(3 100 101 5 102 103 13 104 105)},
-only @code{3}, @code{5} and @code{13} are subject to seach, and elements
+only @code{3}, @code{5} and @code{13} are subject to search, and elements
 inbetween are ignored.  This allows the caller to store @emph{payload},
 or associated value to each key, in the @var{uvector} itself.
 If @var{skip} is positive integer, the length of the searched portion
@@ -23419,7 +23419,7 @@ match isn't found.  It can be either one of the following values:
 @item @code{#f}
 @c EN
 This is the default.
-The procedure seaches the element that is equal to @var{key}, and
+The procedure searches the element that is equal to @var{key}, and
 returns @code{#f} if such element isn't found.
 @c JP
 これがデフォルトです。@var{key}と等しい要素だけを探し、
@@ -24001,7 +24001,7 @@ arguments as is, or returns a pre-computed value,
 so you shouldn't assume the return values are freshly
 allocated objects, unless it is noted so explicitly.)
 
-A linear update version may reuse the stoarge of the designated
+A linear update version may reuse the storage of the designated
 argument to produce the return value.  Gauche tries to reuse the
 argument as much as possible, but you should always use the return
 value and shouldn't assume the argument itself is modified in-place.
@@ -25021,7 +25021,7 @@ The reason of having @code{<pre-subrelease>} is to allow
 A trick: If you want ``version 1.2 release or later'', you
 can say @code{(version<=? "1.2" v)}.  This excludes prerelease
 versions such as @code{1.2_pre3}.
-If you want ``verison 1.2 release or later'', 
+If you want ``version 1.2 release or later'', 
 you can say @code{(version<=? "1.2_" v)}, which includes
 @code{1.2_pre1} etc., but excludes anything below, such as
 @code{1.1.99999}.
@@ -25133,7 +25133,7 @@ satisfies a version specification.
 @c MOD gauche.version
 @c EN
 This is a syntax checker.  Returns @code{#t} if @var{spec} is
-a valid version specfication, @code{#f} otherwise.
+a valid version specification, @code{#f} otherwise.
 See @code{gauche.version} module description for the definition of
 version specification.
 @c JP
@@ -25147,7 +25147,7 @@ version specification.
 @c MOD gauche.version
 @c EN
 Returns @code{#t} if @var{version} satisfies
-a version specfication @var{spec}, @code{#f} otherwise.
+a version specification @var{spec}, @code{#f} otherwise.
 See @code{gauche.version} module description for the definition of
 version specification.
 @c JP

--- a/doc/modgauche.texi
+++ b/doc/modgauche.texi
@@ -1088,7 +1088,7 @@ A newly created module @emph{inherits} the @code{gauche} module by default.
 
 @c EN
 Sometimes you need a module that doesn't inherit the @code{gauche} module,
-yet you want to use Gauche built-in features.  Particulary, R7RS libraries
+yet you want to use Gauche built-in features.  Particularly, R7RS libraries
 and programs require any bindings to be explicitly imported,
 so R7RS's @code{import} and @code{define-library} sets up the module not
 to inherit the @code{gauche} module.   In R7RS code, you need
@@ -3017,7 +3017,7 @@ neither @var{from-code} nor @var{to-code}.
 @c EN
 @var{buffer-size} specifies the size of internal conversion buffer.
 The characters put to the returned port may stay in the buffer,
-until the port is explicity flushed (by @code{flush}) or
+until the port is explicitly flushed (by @code{flush}) or
 the port is closed.
 @c JP
 @var{buffer-size}は内部で変換に使われるバッファサイズを指定します。
@@ -4518,7 +4518,7 @@ It is used to check the system properties and generates build files
 @c EN
 The primary purpose is to replace autoconf-generated 
 @file{configure} shell scripts
-in Gauche extension pakcages.
+in Gauche extension packages.
 @c JP
 主な目的は、Gauche拡張パッケージにおいて、autoconfが生成する
 @file{configure}シェルスクリプトを置き換えることです。
@@ -5995,7 +5995,7 @@ If @var{connection} is not connected, these methods can return @code{#f}.
 The returned value (other than @code{#f}) must be able to
 be passed to @code{connection-address-name} method.
 
-Currently addresses are only used for logging purpoes within
+Currently addresses are only used for logging purpose within
 the connection framework; however, we may enhance the framework
 to add ``connect'' operation, for example, so the concrete class
 is encouraged to use objects that can be used to create connections.
@@ -7140,7 +7140,7 @@ it to @code{g}.
 @defun list->generator lis :optional start end
 @defunx vector->generator vec :optional start end
 @defunx reverse-vector->generator vec :optional start end
-@defunx string->generator str :optioanl start end
+@defunx string->generator str :optional start end
 @defunx uvector->generator uvec :optional start end
 @defunx bytevector->generator u8vector :optional start end
 [SRFI-158+]
@@ -9450,7 +9450,7 @@ This is a lazy sequence version of @code{grxmatch}
 (@pxref{Generator operations}).
 
 The @var{seq} argument must be a sequence of characters (including
-orginary strings).
+ordinary strings).
 The return value is a lazy sequence of @var{<rxmatch>} objects,
 each representing strings matching to the regular expression @var{rx}.
 @c JP
@@ -9860,7 +9860,7 @@ can no longer go on safely.  You cannot even tell so to the
 listener client, since the connection to the client may be broken.
 All you can do is to clean up the listener session (e.g. removes
 the handler).   This case happens in (1) a low-level system error
-occurrs during reading from @var{input-port}. (A syntax error
+occurs during reading from @var{input-port}. (A syntax error
 of the input isn't count as fatal, and handled as REPL error described
 below.), (2) a @code{SIGPIPE} signal is raised during writing to
 @var{output-port}, or (3) an unhandled error occurred during executing
@@ -9889,7 +9889,7 @@ if it is given.  If @var{fatal-handler} returns @code{#f}, or
 
 @item
 @c EN
-@emph{Leaked error} - If an error occurrs during executing
+@emph{Leaked error} - If an error occurs during executing
 @var{fatal-handler} or @var{finalizer}, we don't have no more
 safety net.  The error is 'leaked' outside the listener handler,
 and should be handled by the user of @code{gauche.listener}.
@@ -11732,7 +11732,7 @@ Transmits the content of @var{msg} through @var{socket}.
 @var{msg} can be either a string or a uniform vector; if you send
 binary packets, uniform vectors are recommended.
 
-Returns the nubmer of octets that are actually sent.
+Returns the number of octets that are actually sent.
 
 When @code{socket-send} is used, @var{socket} must already be connected.
 On the other hand, @code{socket-sendto} can be used for non-connected
@@ -14254,7 +14254,7 @@ categories.
 This can only be given to @code{run-process}.
 If @var{flag} is true, @code{run-process} waits until the
 subprocess terminates, by calling @code{process-wait} internally.
-Othewise the subprocess runs asynchronously
+Otherwise the subprocess runs asynchronously
 and @code{run-process} returns immediately, which is the default behavior.
 
 Note that if the subprocess is running asynchronously, it is the
@@ -15017,7 +15017,7 @@ the low-level process calls such as @code{sys-wait} or
 @c EN
 A condition type mainly used by the process port utility procedures.
 Inherits @code{<error>}.  This type of condition is thrown when
-the high-level process port utilities detect the child proces exited
+the high-level process port utilities detect the child process exited
 with non-zero status code.
 @c JP
 主にプロセスポートユーティリティ関数で使われるコンディション型。
@@ -15739,7 +15739,7 @@ bypass the shell.)
 現在は@code{windows}か@code{posix}が指定可能です。シェルが
 エスケープやクオートを処理する方法がこの二つのプラットフォームで大きく
 異なるからです。@code{windows}フレーバーの場合はMVCSランタイムの
-引数パージングに合わせ、@code{posxi}フレーバーの場合はIEEE Std 1003.1に
+引数パージングに合わせ、@code{posix}フレーバーの場合はIEEE Std 1003.1に
 合わせます。
 省略された場合は、プロセスが走っているプラットフォームが
 デフォルトの値となります。(Cygwinは@code{posix}とみなされます。)
@@ -15775,7 +15775,7 @@ the default value is chosen according to the running platform.
 @c JP
 省略可能な@var{flavor}引数はシンボル@code{windows}か@code{posix}を取り、
 構文を指定します。@code{windows}の場合はMVCSランタイムの
-引数パージングに合わせ、@code{posxi}フレーバーの場合はIEEE Std 1003.1
+引数パージングに合わせ、@code{posix}フレーバーの場合はIEEE Std 1003.1
 Shell Command Languageに合わせます。
 省略された場合は、プロセスが走っているプラットフォームが
 デフォルトの値となります。(Cygwinは@code{posix}とみなされます。)
@@ -15866,7 +15866,7 @@ SRFI-99 and R6RS design.
 
 The syntactic layer is the @code{define-record-type} macro
 that conveniently defines a record type and related procedures
-(a constructor, a predictate, accessors and modifiers) all at once
+(a constructor, a predicate, accessors and modifiers) all at once
 declaratively.   Knowing this macro alone is sufficient for
 most common usage of records.
 
@@ -16040,7 +16040,7 @@ The rest of the arguments specify fields (slots) of the record.
 The first and the third forms define immutable fields, which can only
 be initialized by the constructor but cannot be modified afterwards
 (thus such fields don't have modifiers).
-The second and the fourth forms define multable fields.
+The second and the fourth forms define mutable fields.
 
 The third and fourth forms explicitly name the accessor and modifier.
 With the first and second forms, on the other hand,
@@ -17172,7 +17172,7 @@ return the found index.)
       (receive (k found) (stepper (car haystack) k) ; KMP step
         (if found
           'found
-          (loop (cdr kaystack) k)))))
+          (loop (cdr haystack) k)))))
   'needle-is-empty)
 @end example
 @end defun
@@ -17485,7 +17485,7 @@ The semantics of keyword arguments @var{key}, @var{test},
 @code{delete-neighbor-dups}.
 @c JP
 キーワード引数@var{key}、@var{test}、@var{start}、@var{end}の意味は
-@code{delete-neughbor-dups}と同じです。
+@code{delete-neighbor-dups}と同じです。
 @c COMMON
 @end deffn
 
@@ -18797,7 +18797,7 @@ don't match any of @var{choice}s.
 @defun test-error :optional (condition-type <error>) (message #f)
 @c MOD gauche.test
 @c EN
-Returns a new @code{<test-error>} object that mathes with
+Returns a new @code{<test-error>} object that matches with
 other @code{<test-error>} object with the given @var{condition-type}.
 @c JP
 与えられた@var{condition-type}と適合する@code{<test-error>}オブジェクト
@@ -23075,7 +23075,7 @@ When @var{ssize} is omitted or zero, this procedure does the following:
 @end example
 
 @c EN
-That is, it copies the content of @var{source} (offsetted by @var{sstart},
+That is, it copies the content of @var{source} (offset by @var{sstart},
 which defaults to 0)
 into the @var{target} repeatedly, advancing index with @var{tstride}.
 If either the target index reaches the end or @var{count} copies
@@ -25021,7 +25021,7 @@ The reason of having @code{<pre-subrelease>} is to allow
 A trick: If you want ``version 1.2 release or later'', you
 can say @code{(version<=? "1.2" v)}.  This excludes prerelease
 versions such as @code{1.2_pre3}.
-If you want ``verison 1.2 prelease or later'', 
+If you want ``verison 1.2 release or later'', 
 you can say @code{(version<=? "1.2_" v)}, which includes
 @code{1.2_pre1} etc., but excludes anything below, such as
 @code{1.1.99999}.

--- a/doc/modr7rs.texi
+++ b/doc/modr7rs.texi
@@ -3394,7 +3394,7 @@ between @var{start} and @var{end} so that
 elements smaller than the pivot comes between @code{@var{start}} and
 @code{@var{start} + @var{k}}, and the rest of the elements come
 afterwards.  When omitted, @var{start} is 0 and @var{end} is
-the lenght of the @var{vec}.
+the length of the @var{vec}.
 
 This can be used as a building block for in-place divide-and-conquer
 algorithms.  Runs in O(n) time.
@@ -3687,7 +3687,7 @@ The @var{update} argument is a procedure that takes two arguments,
 as @code{(update new-item retval)}.  It replaces the matching @var{item} in the
 set/bag with @var{new-item}, and returns @var{retval}.
 The @var{remove} argument is a procedure that takes one argument,
-as @code{(remove retval)}.  It removes the mathing @var{item} in
+as @code{(remove retval)}.  It removes the matching @var{item} in
 the set/bag, and returns @var{retval}.
 
 If an item that matches @var{elt} is not found, the @var{failure} procedure
@@ -5330,7 +5330,7 @@ Gauche's native lazy sequence.  It is upper-compatible,
 except that the code that assumes the internal structure could break.
 Notably, the constructor @code{generator->lseq} is the same as
 Gauche's built-in, which returns Gauche's lseq, undistinguishable
-to the oridnary list.
+to the ordinary list.
 
 @example
 (procedure? (generator->lseq (generator 1))) 
@@ -7217,7 +7217,7 @@ The caller must treat mappings and hashmaps as immutable object.
 The modules also provide ``linear update'' APIs, which is @emph{allowed}
 to mutate the mappings passed to the arguments, under assumption
 that the argument won't be used afterwards.  The linear update APIs
-are maked with @code{!} at the end of the name.
+are marked with @code{!} at the end of the name.
 @end deftp
 
 @menu
@@ -9994,7 +9994,7 @@ This is same as Gauche's built-in @code{gamma} (@pxref{Arithmetics}).
 [R7RS flonum]
 @c MOD scheme.flonum
 Returns two values, @code{(log (abs (flgamma x)))} and the sign of
-@code{(flgamma x)} as 1.0 if it is postiive and -1.0 if it is negative.
+@code{(flgamma x)} as 1.0 if it is positive and -1.0 if it is negative.
 
 The first value is calculated by Gauche's built-in @code{lgamma}
 (@pxref{Arithmetics}).  It's more accurate than using @code{gamma} then

--- a/doc/modr7rs.texi
+++ b/doc/modr7rs.texi
@@ -860,7 +860,7 @@ guard quasiquote unquote unquote-splicing case-lambda
 @end example
 @item Macros
 @example
-let-synatx letrec-syntax syntax-rules syntax-error define-syntax
+let-syntax letrec-syntax syntax-rules syntax-error define-syntax
 @end example
 @item Variable definitions
 @example
@@ -3957,7 +3957,7 @@ to be the same, in terms of the equality of items.
 @defunx bag>=? bag1 bag2 @dots{}
 [R7RS set]
 @c MOD scheme.set
-Returs true iff each preceding set/bag is a proper subset of, 
+Returns true iff each preceding set/bag is a proper subset of, 
 a proper superset of, a subset of, or a superset of the following
 set/bags, respectively.
 
@@ -5783,7 +5783,7 @@ queue-related operations with small overhead.
 If you merely need a cheap access the content of the queue,
 consider @code{list-queue-remove-all!}.
 That returns the list of elements of the queue without copying, and
-simultaneoulsy reset the queue to empty, so it's safe.
+simultaneously reset the queue to empty, so it's safe.
 @c JP
 @var{queue}が内部的に保持している要素のリストを返します。
 返されたリストは、@var{queue}が操作されれば破壊的に変更される可能性があり、
@@ -6049,7 +6049,7 @@ being collected if there's no strong reference to the key,
 
 @item
 @c EN
-Refernece to the datum is also a kind of weak; it doesn't prevent the datum
+Reference to the datum is also a kind of weak; it doesn't prevent the datum
 from being collected if there's no strong reference to the datum,
 @emph{and there's no strong reference to the associated key}.
 Note that the datum is retained as long as the key is retained,
@@ -8154,10 +8154,10 @@ This module provides a comprehensive set of integer division operators.
 Quotient and remainder in integer divisions can be defined in multiple
 ways, when you consider the choice of sign of the result with regard to
 the operands.  Gauche has builtin procedures in several flavors:
-R5RS @code{quotient}, @code{remadiner} and @code{modulo},
+R5RS @code{quotient}, @code{remainder} and @code{modulo},
 R6RS @code{div}, @code{mod}, @code{div0} and @code{mod0},
 and R7RS @code{floor-quotient}, @code{floor-remainder}, @code{floor/},
-@code{truncate-quotinet}, @code{truncate-remainder}, @code{truncate/}.
+@code{truncate-quotient}, @code{truncate-remainder}, @code{truncate/}.
 
 This module complements R7RS procedures, by adding @code{ceiling},
 @code{round}, @code{euclidean} and @code{balanced} variants.
@@ -8174,7 +8174,7 @@ R5RSの@code{quotient}、@code{remainder}、@code{modulo}、
 R6RSの@code{div}、@code{mod}、@code{div0}、@code{mod0}、
 そしてR7RSの
 @code{floor-quotient}、@code{floor-remainder}、@code{floor/}、
-@code{truncate-quotinet}、@code{truncate-remainder}、@code{truncate/}、です。
+@code{truncate-quotient}、@code{truncate-remainder}、@code{truncate/}、です。
 
 このモジュールは、R7RSの手続きにさらに
 @code{ceiling}、
@@ -9841,7 +9841,7 @@ Returns @code{(*. x x)} (@pxref{Arithmetics})
 @defun flsqrt x
 [R7RS flonum]
 @c MOD scheme.flonum
-Flonum-speicific verison of @code{sqrt}.
+Flonum-specific version of @code{sqrt}.
 @end defun
 
 @defun flcbrt x

--- a/doc/modsrfi.texi
+++ b/doc/modsrfi.texi
@@ -4715,7 +4715,7 @@ the port specified by
 @var{service}, which must be a string.  A service name solely consists
 of decimal digits is interpreted as a port number.
 @c JP
-@var{serivce}で指定されるポートで待ち受けるサーバソケットを作って返します。
+@var{service}で指定されるポートで待ち受けるサーバソケットを作って返します。
 @var{service}は文字列でなければなりません。@var{service}が全て数字で構成されていた
 場合はポート番号と解釈されます。
 @c COMMON

--- a/doc/modsrfi.texi
+++ b/doc/modsrfi.texi
@@ -131,7 +131,7 @@ named let syntax) within the list of bindings (as in the third
 syntax above).
 @item
 The extended @code{let} syntax accepts the rest parameter binding
-which works like the rest paremter in the @code{lambda} syntax.
+which works like the rest parameter in the @code{lambda} syntax.
 @end itemize
 
 See SRFI-5 document for rationale of this extension.
@@ -2267,7 +2267,7 @@ character, such as @code{~@@a}.
 @c Skip to an alphanumeric character, then matches full
 @c month name in locale.  Sets the month component of the date.
 @c @item ~d
-@c Skip to a numeric character, then maches the day of month.
+@c Skip to a numeric character, then matches the day of month.
 @c Sets the month component of the date.
 @c @item ~e
 
@@ -3610,7 +3610,7 @@ then this qualifier is used.
 
 @deffn {EC Qualifier} :parallel generator @dots{}
 @c EN
-This is used to run through mutiple generators in parallel.
+This is used to run through multiple generators in parallel.
 It terminates when any one of @var{generator} is exhausted.
 @c JP
 複数のジェネレータ節を並列に走査するのに使います。
@@ -5330,7 +5330,7 @@ as @var{element-comparator}.
 
 For a list comparator, it is an error to pass improper lists.
 
-Note that comparing sequences of different lenghts is slightly
+Note that comparing sequences of different lengths is slightly
 different between lists and vector/bytevectors.  List comparator
 uses ``dictionary'' order, so @code{(1 3)} comes after @code{(1 2 3)},
 assuming elements are compared numerically.
@@ -5601,7 +5601,7 @@ you the same performance.  (Be aware that the interface is slightly
 different from the immutable versions.)
 
 We provide this module only for the compatibility.  Gauche-specific
-programs should stay away from this module.  Particulary, avoid
+programs should stay away from this module.  Particularly, avoid
 code like the example in SRFI-118 document (build a string by
 @code{append!}-ing small chunks at a time)---they're quadratic on Gauche.
 @c JP

--- a/doc/modsrfi.texi
+++ b/doc/modsrfi.texi
@@ -4493,7 +4493,7 @@ Each integer occupies @var{size} octets.
 @c @section @code{srfi-78} - Lightweight testing
 @c @c NODE 軽量なテスト, @code{srfi-78} - 軽量なテスト
 
-@c NOTE: Keep this unoffical, until we integrate this into gauche.test.
+@c NOTE: Keep this unofficial, until we integrate this into gauche.test.
 
 @c @deftp {Module} srfi-78
 @c @mdindex srfi-78

--- a/doc/modutil.texi
+++ b/doc/modutil.texi
@@ -11782,7 +11782,7 @@ a list of tokens.   @var{Tokenizer-specs} is passed to
 @c EN
 A utility procedure that consumes any comments and/or whitespace
 characters from @var{iport}, and returns the head character
-that is neither a whitespece nor a comment.  The returned character
+that is neither a whitespace nor a comment.  The returned character
 remains in @var{iport}.
 @c JP
 @var{iport} から、すべてのコメントおよび/または白空白文字を消費し、
@@ -27200,7 +27200,7 @@ check equality of two variables.  It must be hashable.
 @item Value comparator: @code{val-cmpr}
 @c EN
 A comparator to see if an item is a value, and also
-check equality of two vaues.
+check equality of two values.
 Note that if a tree satisfies neither @var{var-cmpr} nor @var{val-compr},
 it is regarded as a tuple.
 @c JP

--- a/doc/modutil.texi
+++ b/doc/modutil.texi
@@ -6902,7 +6902,7 @@ To create or open a database, you need a concrete implementation
 of the database.  With the default build-time configuration,
 the following implementations are included in Gauche.
 Bindings to various other dbm-like libraries are
-available as extension pacakges.
+available as extension packages.
 Each module defines its own low-level accessing functions
 as well as the common interface.
 Note that your system may not have one or more of those DBM libraries;
@@ -8637,7 +8637,7 @@ Takes integer as permission mode bits.
 @item :owner @var{uid}
 @itemx :group @var{gid}
 Takes integer uid/gid of the owner/group of the file/directory.
-Calling process may need special priviledge to change the owner
+Calling process may need special privilege to change the owner
 and/or group.
 @item :symlink @var{path}
 This is only valid for file spec, and it causes
@@ -13713,7 +13713,7 @@ left to be zero, which is to be filled by the kernel
 @defun icmp-packet-type buffer offset
 @defunx icmp-packet-code buffer offset
 @defunx icmp-packet-ident buffer offset
-@defunx icmp-packet-sequence buffer offsetj
+@defunx icmp-packet-sequence buffer offset
 @c MOD rfc.icmp
 @c EN
 Extracts type, code, ident and sequence fields of ICMP packet.
@@ -14702,7 +14702,7 @@ of enclosed message.  If it is other media types such as @code{text}
 or @code{application}, @var{handler} is called on the (only) message body.
 @c JP
 メッセージはマルチパートである必要はありません。メッセージが
-MIME @code{mesasge}タイプである場合は、@var{handler}は囲まれたメッセージの
+MIME @code{message}タイプである場合は、@var{handler}は囲まれたメッセージの
 ボディに対して呼ばれます。メッセージが、@code{text}や@code{application}
 などの他のメディアタイプの場合は、@var{handler}は単にメッセージボディに
 対して呼ばれます。
@@ -22453,7 +22453,7 @@ em       fieldset   form       frame       frameset
 h1       h2         h3         h4          h5        h6
 head     hr         html       i           iframe    img
 input    ins        kbd        label       legend    li
-link     map        meta       nofrmaes    noscript  object
+link     map        meta       noframes    noscript  object
 ol       optgroup   option     p           param     pre
 q        samp       script     select      small     span
 strong   style      sub        sup         table     tbody
@@ -28442,7 +28442,7 @@ The following is the complete rules of SxCSS syntax.
             | ($= <ident> <attrib-value>)           ; E[attrib$=val]
             | (:not <negation-arg>)                 ; E:not(s)
             | (: <ident>)                           ; E:pseudo-class
-            | (: (<fn> <ident> ...))                ; E:pseudl-class(arg)
+            | (: (<fn> <ident> ...))                ; E:pseudo-class(arg)
             | (:: <ident>)                          ; E::pseudo-element
 <element-name> : <ident> | *
 <attrib-value> : <ident> | <string>

--- a/doc/modutil.texi
+++ b/doc/modutil.texi
@@ -4115,7 +4115,7 @@ of nonnegative integers.
 @c EN
 A ring buffer is an array with two fill pointers; in a typical usage,
 a producer adds new data to one end while a consumer removes data
-from the other end; if fill pointer reachers at the end of the array,
+from the other end; if fill pointer reaches at the end of the array,
 it wraps around to the beginning, hence the name.
 @c JP
 リングバッファは、両端を指す二つのポインタを持つ配列と考えられます。良くある使い方は、
@@ -4993,7 +4993,7 @@ All of these sparse matrix subtypes can be accessed by the same API.
 @clindex sparse-f32matrix
 @clindex sparse-f64matrix
 @c MOD data.sparse
-The actual sparce matrix classes.  Inherits @code{<sparse-matrix-base>}.
+The actual sparse matrix classes.  Inherits @code{<sparse-matrix-base>}.
 An instance of @code{<sparse-matrix>} can contain any Scheme objects.
 
 @code{@@} is either one of @code{s8}, @code{u8},
@@ -8882,7 +8882,7 @@ by default.
   @result{} "/bin/ls"
 
 @c EN
-;; @r{example of searchin user preference file of my application}
+;; @r{example of searching user preference file of my application}
 @c JP
 ;; @r{アプリケーション"myapp"のユーザプレファレンスファイルを探す例}
 @c COMMON
@@ -10280,7 +10280,7 @@ On the other hand,
 each sequence returned by @code{primes} are realized individually,
 duplicating calculation.  
 
-The rule of thumb is---if you use primes repeatedly throughtout
+The rule of thumb is---if you use primes repeatedly throughout
 the program, just use @code{*primes*} and you'll save calculation.
 If you need primes one-shot, call @code{primes} and abandon it
 and you'll save space.
@@ -12644,7 +12644,7 @@ format depends on the server.
 @defunx ftp-ls conn :optional path
 @c MOD rfc.ftp
 @c EN
-Return the list of names in the specfied @var{path}, or the current
+Return the list of names in the specified @var{path}, or the current
 remote directory, without any other information.  @code{ftp-ls}
 is just an alias of @code{ftp-name-list} for the convenience.
 @c JP
@@ -13021,7 +13021,7 @@ The following keywords are treated specially.
 
 @table @code
 @item :value
-Speficies the value of the parameter.  The convenience form,
+Specifies the value of the parameter.  The convenience form,
 @code{(@var{name} @var{val})}, is just an abbreviation of
 @code{(@var{name} :value @var{val})}.
 @item :file
@@ -15319,7 +15319,7 @@ Uniform Resource Identifiers、
 @c COMMON
 @end deftp
 
-First, lets review the structur of URI briefly.
+First, lets review the structure of URI briefly.
 The following graph shows how the URI is constructed:
 
 @example
@@ -15695,7 +15695,7 @@ full or part of URIs.  This procedure resolves @var{relative-uri}
 in relative to @var{base-uri}, as defined in RFC3986 Section 5.2.
 ``Relative Resolution''.
 
-If more @var{realtive-uri2}s are given, first @var{relative-uri}
+If more @var{relative-uri2}s are given, first @var{relative-uri}
 is merged to @var{base-uri}, then the next argument is merged
 to the resulting uri, and so on.
 @c JP
@@ -18920,7 +18920,7 @@ one. This lets you pass arguments to the procedure.
 
 @example
 ;; select all <book> elements whose style attribute value is equal to
-;; the <bookstore> element's speciality attribute value.
+;; the <bookstore> element's specialty attribute value.
 (sxpath "//book[/bookstore/@@specialty=@@style]")
 ;; a similar query but this time make sure specialty of _all_
 ;; bookstores is matched
@@ -21977,7 +21977,7 @@ This procedure is thread-safe.
 @deffn {Generic Function} edn-write obj
 @c MOD text.edn
 @c EN
-Write EDN represenation of @var{obj} to the current output port.
+Write EDN representation of @var{obj} to the current output port.
 The @code{construct-edn} procedure calls this internally.
 
 To write out a Gauche object as EDN tagged object, define a method to
@@ -24482,7 +24482,7 @@ Three algorithms are implemented:
 @item Levenshtein distance
 @c EN
 Count deletion of one element, insertion of one element,
-and susbstitution of one element.
+and substitution of one element.
 @c JP
 1要素の削除、1要素の追加、1要素の置き換えそれぞれを1操作と数えます。
 @c COMMON
@@ -26053,7 +26053,7 @@ Creates a new stream whose element is determined as follows:
 @itemize
 @item
 A ``go'' predicate @var{p} is called on the current seed value.
-If it yields @code{#f}, the stream teminates.
+If it yields @code{#f}, the stream terminates.
 @item
 Otherwise, @code{(f s)} is the element of the stream,
 and @code{(g s)} becomes the next seed value, where
@@ -26329,7 +26329,7 @@ Creates a new stream which appends @var{elt} @dots{} before @var{stream}.
 [R7RS stream]
 @c MOD util.stream
 @c EN
-Retrun a new stream whose elements are the elements in @var{list}.
+Returns a new stream whose elements are the elements in @var{list}.
 @c JP
 @var{list}の要素を要素とする新たなストリームを作って返します。
 @c COMMON
@@ -28425,7 +28425,7 @@ The following is the complete rules of SxCSS syntax.
              | (style-decls <declaration> ...)
 
 <pattern>   : <selector> | (:or <selector> ...)
-<seletor>   : <simple-selector>
+<selector>  : <simple-selector>
             | <chained-selector>
 <chained-selector> : (<simple-selector> . (<op>? . <chained-selector>))
 <op>        : > | + | ~

--- a/doc/object.texi
+++ b/doc/object.texi
@@ -1402,7 +1402,7 @@ It is automatically inserted by the system.
 When multiple inheritance is involved, a story becomes a bit
 complicated.  We have to merge multiple CPLs of the superclasses
 into one CPL.  It is called @emph{linearization}, and there are
-several known linealization strategies.  By default, Gauche uses
+several known linearization strategies.  By default, Gauche uses
 an algorithm called @emph{C3 linearization},
 which is consistent with the local precedence order,
 monotonicity, and the extended precedence graph.
@@ -2992,7 +2992,7 @@ rest arguments or not.
 
 @example
 specs:        ((self <myclass>) (index <integer>) value)
-specializers: (<myclas> <integer> <top>)
+specializers: (<myclass> <integer> <top>)
 optional:     #f
 
 specs:        (obj (attr <string>))
@@ -3000,11 +3000,11 @@ specializers: (<top> <string>)
 optional:     #f
 
 specs:        ((self <myclass>) obj . options)
-specializers: (<myclas> <top>)
+specializers: (<myclass> <top>)
 optional:     #t
 
 specs:        ((self <myclass>) obj :optional (a 0) (b 1) :key (c 2))
-specializers: (<myclas> <top>)
+specializers: (<myclass> <top>)
 optional:     #t
 
 specs:        args
@@ -3543,7 +3543,7 @@ next subsection (@pxref{Customizing slot access}).
 If your metaclass needs to initialize auxiliary slots, you can
 define your own @code{initialize} method, in which you call
 @code{next-method} first to set up the core part of the
-@code{<class>} structure, then you sets up metcalss-specific part.  
+@code{<class>} structure, then you sets up metaclass-specific part.  
 One caveat is that, after @code{next-method} handles
 initialization of the core @code{<class>} part, you can no longer
 modify essential class slots.  If you need to tweak those slots,

--- a/doc/program.texi
+++ b/doc/program.texi
@@ -2808,7 +2808,7 @@ how Gauche is configured, and can be checked
 by running system-provided tools, 
 such as @code{ldd} on most Unix systems and MinGW or @code{otool -L} on OSX,
 on the generated standalone binaries.
-You may want to ensure the users have requied libraries.
+You may want to ensure the users have required libraries.
 @c JP
 作られたバイナリファイルは、libpthreadなど外部の動的ライブラリには依存します。
 具体的にどのライブラリに依存するかはプラットフォームとGaucheのコンフィグレーションによります。
@@ -2918,7 +2918,7 @@ basenameから拡張子を除いたものになります。
 @c EN
 Add C preprocessor definitions while compiling the generated C code.
 An important use case of this option is to exclude gdbm dependency
-from the generated binaries, by specifing
+from the generated binaries, by specifying
 @code{-D GAUCHE_STATIC_EXCLUDE_GDBM}.  Note that you need a whitespace
 between @code{-D} and @var{var}.
 
@@ -3030,7 +3030,7 @@ Note that a whitespace is required between @code{-I} and @var{load-path}.
 @deftp {Command Option} --header-dir dir
 @deftpx {Command Option} --library-dir dir
 @c EN
-These tells @code{build-standlone} where to find Gauche C headers
+These tells @code{build-standalone} where to find Gauche C headers
 and static libraries.
 
 If you've installed Gauche on your system, @code{build-standalone}

--- a/doc/program.texi
+++ b/doc/program.texi
@@ -269,7 +269,7 @@ Useful to check precisely which files are loaded in what order.
 Reports whenever a file is included.
 Useful to check precisely which files are included in what order.
 @item warn-legacy-syntax
-Warns if the reader sees leagacy hex-escape syntax in string literals.
+Warns if the reader sees legacy hex-escape syntax in string literals.
 @xref{Reader lexical mode}.
 @item no-source-info
 Don't keep source information for debugging.  Consumes less memory.
@@ -383,7 +383,7 @@ imported for your convenience.
 @xref{Library modules - R7RS standard libraries}, for the details on
 how Gauche supports R7RS.
 
-(Note: The @code{-r7} option doesn't change reader lexiacl mode
+(Note: The @code{-r7} option doesn't change reader lexical mode
 (@pxref{Reader lexical mode}) to @code{strict-r7}.  That's because
 using @code{strict-r7} mode by default prevents many Gauche code
 from being loaded.)
@@ -975,7 +975,7 @@ just type @code{,help} and return.
 gosh> ,help
 You're in REPL (read-eval-print-loop) of Gauche shell.
 Type a Scheme expression to evaluate.
-A word preceeded with comma has special meaning.  Type ,help <cmd> 
+A word preceded with comma has special meaning.  Type ,help <cmd> 
 to see the detailed help for <cmd>.
 Commands can be abbreviated as far as it is not ambiguous.
 
@@ -1744,7 +1744,7 @@ Cのシステムプログラミングに詳しいなら、上のコードは以�
 
 @c EN
 There are quite a few such feature identifiers; each identifier is
-explained in the maunal entry of the procedures that depend on the feature.
+explained in the manual entry of the procedures that depend on the feature.
 Here we list a few important ones:
 @c JP
 このような機能識別子はたくさんあり、それぞれの識別子についてはこのマニュ
@@ -2528,7 +2528,7 @@ working directory.  You can change it by a customization file; see below.
 @c COMMON
 
 @c EN
-If you need a special priviledge to install the files, you can
+If you need a special privilege to install the files, you can
 use @code{--install-as} option which runs @code{make install} part via
 the @code{sudo} program.
 @c JP

--- a/examples/mqueue-cpp/README.adoc
+++ b/examples/mqueue-cpp/README.adoc
@@ -143,14 +143,14 @@ world.  Although it sounds simple, it requires more attention than
 its superficial simplicity.  If you do something wrong here,
 you'll get a nasty bug which is very hard to track.
 
-Typically, there are a few cases with regard to the foreign resouce
+Typically, there are a few cases with regard to the foreign resource
 management.
 
 Case 1::
 You allocate the foreign object via Gauche's allocator.
 (`SCM_NEW` etc.)   In this case, Gauche's GC can take care
 of deallocation, so you don't need specify 'cleanup' procedure
-except you have other resouces to free (e.g. file descriptors).
+except you have other resources to free (e.g. file descriptors).
 
 anchor:frm-case-2[]Case 2::
 The foreign object is allocated by the foreign library, and

--- a/ext/tls/tls.ac
+++ b/ext/tls/tls.ac
@@ -17,7 +17,7 @@ TLSLIBS=axtls,mbedtls
 AC_ARG_WITH(tls,
   AS_HELP_STRING([--with-tls=TLSLIB,...],
   [Select which TLS libraries to be compiled.  Currently we support 'axtls'
-   (to use bundled souce of Cameron Rich's axTLS) and 'mbedtls' (to use mbed
+   (to use bundled source of Cameron Rich's axTLS) and 'mbedtls' (to use mbed
    TLS).  By default, available libraries are autodetected.  Specify this
    option only when you want to exclude some of the libraries.
    Specify --with-tls=no to disable tls support.]),

--- a/ext/uvector/test.scm
+++ b/ext/uvector/test.scm
@@ -470,7 +470,7 @@
 
 ;; there are too many combinations to write down by hand.
 ;;
-;; for each opertaion in add, sub, mul
+;; for each operation in add, sub, mul
 ;;   for each testdata such that:
 ;;     - vector vs vector normal
 ;;     - vector vs vector underflow

--- a/ext/uvector/uvgen.scm
+++ b/ext/uvector/uvgen.scm
@@ -311,7 +311,7 @@
 (define (dummy . _) "/* not implemented */")
 
 ;;===============================================================
-;; Uvector opertaion generator
+;; Uvector operation generator
 ;;
 
 (define (generate-numop)

--- a/gc/cord/cordbscs.c
+++ b/gc/cord/cordbscs.c
@@ -379,7 +379,7 @@ CORD CORD_substr_closure(CORD x, size_t i, size_t n, CORD_fn f)
 
 # define SUBSTR_LIMIT (10 * SHORT_LIMIT)
         /* Substrings of function nodes and flat strings shorter than   */
-        /* this are flat strings.  Othewise we use a functional         */
+        /* this are flat strings.  Otherwise we use a functional         */
         /* representation, which is significantly slower to access.     */
 
 /* A version of CORD_substr that assumes i >= 0, n > 0, and i + n < length(x).*/

--- a/lib/gauche/cgen/precomp.scm
+++ b/lib/gauche/cgen/precomp.scm
@@ -774,7 +774,7 @@
       `((with-module gauche define-syntax) ,@form))
      ;; If the macro needs to exported, check if we can put it in
      ;; precompiled file (it is, if the transformer is a closure).
-     ;; Othewise, we emit the form to *.sci file.
+     ;; Otherwise, we emit the form to *.sci file.
      (when (or (symbol-exported? name)
                (memq name (private-macros-to-keep)))
        (let1 val (global-variable-ref (~ (current-tmodule)'module) name #f)

--- a/lib/gauche/cgen/stub.scm
+++ b/lib/gauche/cgen/stub.scm
@@ -121,7 +121,7 @@
 ;;      <Qual> (qualifier) is a list to adds auxiliary information to the
 ;;      SUBR.  Currently the following <quals> are officially supported.
 ;;
-;;        (setter <setter-name>) : specfy setter.  <setter-name> should
+;;        (setter <setter-name>) : specify setter.  <setter-name> should
 ;;             be a cproc name defined in the same stub file
 ;;        (setter (args ...) body ...) : specify setter anonymously.
 ;;

--- a/lib/gauche/configure.scm
+++ b/lib/gauche/configure.scm
@@ -905,7 +905,7 @@
 ;;;
 
 ;; Various language-specific operations are defined as methods on
-;; the language signleton object inheriting <cf-language>.
+;; the language singleton object inheriting <cf-language>.
 ;; Methods a named with -m suffix to distinguish from cf- API, which
 ;; is a usual procedure dispatches according to the current
 ;; language.

--- a/lib/gauche/connection.scm
+++ b/lib/gauche/connection.scm
@@ -48,7 +48,7 @@
 ;; bidirectional communication to another entity.
 ;;
 ;; The data communication is abstracted as a pair of input and
-;; ouptut ports.  They can be accessed by connection-input-port
+;; output ports.  They can be accessed by connection-input-port
 ;; and connection-output-port.
 ;;
 ;; A connected connection has two endpoints; self and peer.  Each

--- a/lib/gauche/interactive/info.scm
+++ b/lib/gauche/interactive/info.scm
@@ -47,7 +47,7 @@
 
 (define *info-file* "gauche-refe.info")
 
-(define-class <repl-info> () ;; a signleton
+(define-class <repl-info> () ;; a singleton
   ((info  :init-keyword :info)   ;; <info>
    (index :init-keyword :index)  ;; hashtable name -> [(node-name line-no)]
    ))

--- a/lib/gauche/package.scm
+++ b/lib/gauche/package.scm
@@ -218,7 +218,7 @@
                                  *load-path*))
     (generator->lseq g)))
 
-;; scan the directory to find older verison of Gauche library directories.
+;; scan the directory to find older version of Gauche library directories.
 (define (%get-all-version-paths)
   (apply append
          *load-path*

--- a/lib/r7rs-setup.scm
+++ b/lib/r7rs-setup.scm
@@ -260,7 +260,7 @@
   ;; guard quasiquote unquote unquote-splicing case-lambda
 
   ;; 4.3 Macros
-  ;; let-synatx letrec-syntax syntax-rules syntax-error
+  ;; let-syntax letrec-syntax syntax-rules syntax-error
 
   ;; 5.3 Variable definitions
   ;; define define-values

--- a/lib/r7rs-setup.scm
+++ b/lib/r7rs-setup.scm
@@ -382,7 +382,7 @@
 
   ;; 6.13 Input and output
   ;; input-port? output-port? port? current-input-port current-output-port
-  ;; current-error-port close-port close-input-port close-ouptut-port
+  ;; current-error-port close-port close-input-port close-output-port
   ;; open-input-string open-output-string get-output-string read-string
   ;; read-char peek-char read-line eof-object? eof-object char-ready?
   ;; newline write-char write-string

--- a/lib/srfi-42.scm
+++ b/lib/srfi-42.scm
@@ -1176,7 +1176,7 @@
 ; Alternative: Instead of modifying the generator with :until, it is
 ;   possible to use call-with-current-continuation:
 ;
-;   (define-synatx first-ec
+;   (define-syntax first-ec
 ;     ...same as above...
 ;     ((first-ec default qualifier expression)
 ;      (call-with-current-continuation

--- a/lib/www/css.scm
+++ b/lib/www/css.scm
@@ -73,7 +73,7 @@
 ;;;              | ($= <ident> <attrib-value>)           ; E[attrib$=val]
 ;;;              | (:not <negation-arg>)                 ; E:not(s)
 ;;;              | (: <ident>)                           ; E:pseudo-class
-;;;              | (: (<fn> <ident> ...))                ; E:pseudl-class(arg)
+;;;              | (: (<fn> <ident> ...))                ; E:pseudo-class(arg)
 ;;;              | (:: <ident>)                          ; E::pseudo-element
 ;;;  <element-name> : <ident> | *
 ;;;  <attrib-value> : <ident> | <string>

--- a/lib/www/css.scm
+++ b/lib/www/css.scm
@@ -56,7 +56,7 @@
 ;;;               | (style-decls <declaration> ...)
 ;;;
 ;;;  <pattern>   : <selector> | (:or <selector> ...)
-;;;  <seletor>   : <simple-selector>
+;;;  <selector>  : <simple-selector>
 ;;;              | <chained-selector>
 ;;;  <chained-selector> : (<simple-selector> . (<op>? . <chained-selector>))
 ;;;  <op>        : > | + | ~

--- a/libsrc/rfc/mime.scm
+++ b/libsrc/rfc/mime.scm
@@ -192,7 +192,7 @@
         [else word]))
 
 ;; Decode the entire header field body, possibly a mixture of
-;; encoded-words and orginary words.  NOTE: If you apply this to
+;; encoded-words and ordinary words.  NOTE: If you apply this to
 ;; a structured field body, the decoded words may contain special
 ;; characters meaningful to the structured body and thus confuse
 ;; the parser.  The correct order is to parse first, then apply

--- a/m4/lib-link.m4
+++ b/m4/lib-link.m4
@@ -218,7 +218,7 @@ AC_DEFUN([AC_LIB_LINKFLAGS_BODY],
     fi
 ])
   dnl Search the library and its dependencies in $additional_libdir and
-  dnl $LDFLAGS. Using breadth-first-seach.
+  dnl $LDFLAGS. Using breadth-first-search.
   LIB[]NAME=
   LTLIB[]NAME=
   INC[]NAME=

--- a/src/bignum.c
+++ b/src/bignum.c
@@ -1061,7 +1061,7 @@ ScmObj Scm_BignumDivRem(const ScmBignum *dividend, const ScmBignum *divisor)
 }
 
 /*-----------------------------------------------------------------------
- * Logical (bitwise) opertaions
+ * Logical (bitwise) operations
  */
 
 ScmObj Scm_BignumAsh(const ScmBignum *x, int cnt)

--- a/src/class.c
+++ b/src/class.c
@@ -1297,7 +1297,7 @@ static inline void scheme_slot_set(ScmObj obj, ScmSmallInt number, ScmObj val)
 }
 
 /* These three are exposed to Scheme to do some nasty things.
-   We shoudn't do class redefinition check here, since the slot number
+   We shouldn't do class redefinition check here, since the slot number
    is calculated based on the old class, if the class is ever redefined.
 */
 /* OBSOLETED, for the backward compatibility */
@@ -2429,7 +2429,7 @@ static int method_leaf_p(ScmClosure *body)
 /*
  * (initialize <method> (&key lamdba-list generic specializers body method-locked))
  *    Method initialization.   This needs to be hardcoded, since
- *    we can't call Scheme verison of initialize to initialize the
+ *    we can't call Scheme version of initialize to initialize the
  *    "initialize" method (chicken-and-egg circularity).
  */
 static ScmObj method_initialize(ScmNextMethod *nm SCM_UNUSED,

--- a/src/compile-3.scm
+++ b/src/compile-3.scm
@@ -42,7 +42,7 @@
 
 ;; Dispatch pass3 handler.
 ;; Each handler is called with IForm and a list of label nodes.
-;; Returs IForm.
+;; Returns IForm.
 ;; *pass3-dispatch-table* is defined below, after all handlers are defined.
 (define-inline (pass3/rec iform labels)
   ((vector-ref *pass3-dispatch-table* (iform-tag iform)) iform labels))

--- a/src/gauche.h
+++ b/src/gauche.h
@@ -1740,7 +1740,7 @@ SCM_CLASS_DECL(Scm_PromiseClass);
 SCM_EXTERN ScmObj Scm_MakePromise(int forced, ScmObj code);
 SCM_EXTERN ScmObj Scm_Force(ScmObj p);
 
-/* Lazy pair structur is opaque to public.  Whenever you apply to an
+/* Lazy pair structure is opaque to public.  Whenever you apply to an
    ScmObj SCM_PAIRP, a lazy pair morphs itself to a pair, so the normal
    code never see lazy pairs. */
 

--- a/src/gauche/priv/identifierP.h
+++ b/src/gauche/priv/identifierP.h
@@ -1,5 +1,5 @@
 /*
- * identifierP.h - identifier structur
+ * identifierP.h - identifier structure
  *
  *   Copyright (c) 2000-2019  Shiro Kawai  <shiro@acm.org>
  *

--- a/src/gauche/priv/portP.h
+++ b/src/gauche/priv/portP.h
@@ -77,7 +77,7 @@ void Scm__SetupPortsForWindows(int has_console);
  *
  *  The port's lock state is kept in a single pointer, port->lockOwner.
  *  It points to the owner of the port, or NULL if the port is unlocked.
- *  Unlocking the port is a single atomic opertaion, port->lockOwner = NULL,
+ *  Unlocking the port is a single atomic operation, port->lockOwner = NULL,
  *  hence PORT_UNLOCK doesn't need mutex to do that.
  *
  *  To lock the port, the thread needs to grab a system-level lock
@@ -91,7 +91,7 @@ void Scm__SetupPortsForWindows(int has_console);
  *  the port would wait extra timeslice.  Not a big deal.
  *
  *  Note that we cannot use a condition variable to let the locking thread
- *  wait on it.  If we use CV, unlocking becomes two-step opertaion
+ *  wait on it.  If we use CV, unlocking becomes two-step operation
  *  (set lockOwner to NULL, and call cond_signal), so it is no longer
  *  atomic.  We would need to get system-level lock in PORT_UNLOCK as well.
  */

--- a/src/gauche/priv/readerP.h
+++ b/src/gauche/priv/readerP.h
@@ -45,7 +45,7 @@ struct ScmReadContextRec {
 };
 
 enum ScmReadContextFlags {
-    RCTX_SOURCE_INFO = (1L<<0),  /* preserving souce file information */
+    RCTX_SOURCE_INFO = (1L<<0),  /* preserving source file information */
     RCTX_LITERAL_IMMUTABLE = (1L<<1), /* literal should be read as immutable */
     RCTX_DISABLE_CTOR = (1L<<2), /* disable #,() */
     RCTX_RECURSIVELY = (1L<<3),  /* used internally. */

--- a/src/libobj.scm
+++ b/src/libobj.scm
@@ -198,7 +198,7 @@
  (define-cproc %make-next-method (gf methods::<list> args::<list>)
    (let* ([argv::ScmObj*] [argc::ScmSize])
      (unless (Scm_TypeP gf SCM_CLASS_GENERIC)
-       (Scm_Error "generic function requied, but got %S" gf))
+       (Scm_Error "generic function required, but got %S" gf))
      (dolist [mp methods]
        (unless (Scm_TypeP mp SCM_CLASS_METHOD)
          (Scm_Error "method required, but got %S" mp)))

--- a/src/load.c
+++ b/src/load.c
@@ -588,7 +588,7 @@ static void call_initfn(ScmDLObj *dlo, const char *name)
    already loaded from a pseudo pathname "@/DSONAME" (e.g. for
    "gauche--collection", we use "@/gauche--collection".) */
 
-/* Register DSONAME as prelinked.  DSONAME shoudn't have system's suffix.
+/* Register DSONAME as prelinked.  DSONAME shouldn't have system's suffix.
    INITFNS is an array of function pointers, NULL terminated.
    INITFN_NAMES should have prefixed with '_', for call_initfn() searches
    names with '_' first. */

--- a/src/module.c
+++ b/src/module.c
@@ -59,7 +59,7 @@
  *  namespace---for example, a 'sandbox' environment to evaluate an
  *  expression sent over the network during a session.
  *  The anonymous namespace will be garbage-collected if nobody references
- *  it, recovering its resouces.
+ *  it, recovering its resources.
  */
 
 /* Note on mutex of module operation

--- a/src/vm.c
+++ b/src/vm.c
@@ -109,7 +109,7 @@ static unsigned long vminsn_offsets[SCM_VM_NUM_INSNS] = { 0, };
 
 static ScmVM *rootVM = NULL;         /* VM for primodial thread */
 static ScmHashCore vm_table;         /* VMs other than primordial one is
-                                        registered to this hashtalbe, in order
+                                        registered to this hashtable, in order
                                         to avoid being GC-ed. */
 static ScmInternalMutex vm_table_mutex;
 static void vm_register(ScmVM *vm);

--- a/src/write.c
+++ b/src/write.c
@@ -260,7 +260,7 @@ void Scm_WriteWithControls(ScmObj obj, ScmObj p, int mode,
  *
  *  Characters exceeding WIDTH are truncated.
  *  If the output fits within WIDTH, # of characters actually written
- *  is returned.  Othewise, -1 is returned.
+ *  is returned.  Otherwise, -1 is returned.
  *
  *  Currently this API is only used from Scm_Printf, for 'format' has been
  *  moved to libfmt.scm.  I don't like the way this is implemented and would


### PR DESCRIPTION
That's it. I now declare Gauche typo-free [1] [2]! Never ever quote me on this.

[1] with maybe one exception, I'm not sure about 'unformly' (one occurence) maybe it should be uniformly...

[2] English only of course. I can't possibly catch Kanji typos.