### PR TITLE
Fix combination problem of reset/shift + call/cc

### DIFF
--- a/test/dynwind.scm
+++ b/test/dynwind.scm
@@ -590,6 +590,39 @@
                (display "[r03]"))))
            (k1))))
 
+
+;; for now, following error occurs
+;; "vm.c", line 2704 (Scm_VMReset): Assertion failed: SCM_PAIRP(vm->resetChain)
+'(test* "reset/shift + call/cc 2"
+       "[r01][s01][s02][s02]"
+       (with-output-to-string
+         (^[]
+           (define k1 #f)
+           (define k2 #f)
+           (reset
+            (display "[r01]")
+            (shift k (set! k1 k))
+            (display "[s01]")
+            (call/cc (lambda (k) (set! k2 k)))
+            (display "[s02]"))
+           (k1)
+           (reset (reset (k2))))))
+
+(test* "reset/shift + call/cc 3"
+       "[r01][s01][s01]"
+       (with-output-to-string
+         (^[]
+           (define k1 #f)
+           (define k2 #f)
+           (reset
+            (display "[r01]")
+            (call/cc (lambda (k)
+                       (set! k1 k)
+                       (shift k (set! k2 k))))
+            (display "[s01]"))
+           (k2)
+           (reset (k1)))))
+
 (test* "reset/shift + call/cc error 1"
        (test-error)
        (with-output-to-string


### PR DESCRIPTION
以下のページの「気になる例4」を修正したものになります。
https://practical-scheme.net/wiliki/wiliki.cgi?Gauche%3A%E9%83%A8%E5%88%86%E7%B6%99%E7%B6%9A%E3%81%A8%E5%8B%95%E7%9A%84%E7%92%B0%E5%A2%83%E3%81%AE%E5%AE%9F%E9%A8%93

vm.c の throw_cont_body 関数内で、save_cont を実行する条件を増やしました。

これで SEGV は回避できましたが、
フル継続 (k1) の戻り先が (k1) の直後ではなく (reset (k1)) の直後になるようで、
少し気になっています。

部分継続の実行中でない (すなわち ep->cstack が NULL でない) ときに、
部分継続の終端に到達した場合、どこかしらに戻ることになりますが、
そのあたりの動作の仕組みが、どうもよく理解できない感じです。

このケースをエラーにすることも検討してみたのですが、
どうも [Gauche-effects] では使っているらしく、
エラーにすると [Gauche-effects] の threads サンプルが動かなくなりました。。。

あと、「気になる例3」の方にも対応しようとしたのですが、
部分継続の内部かどうかの判定自体がけっこう難しいため、
今回は保留にしようと思います。
(部分継続の内部に call/cc で飛び込むようなプログラムは、めったにないと思います。。。)


＜テスト結果＞
https://ci.appveyor.com/project/Hamayama/gauche/builds/28708183

(関連プルリクエスト #529)

[Gauche-effects]:https://github.com/Hamayama/Gauche-effects
