### PR TITLE
Fix combination problem of reset/shift + call/cc v2

### DIFF
--- a/src/gauche/priv/vmP.h
+++ b/src/gauche/priv/vmP.h
@@ -88,6 +88,7 @@ typedef struct ScmEscapePointRec {
                                    w.r.t. cstack. */
     ScmObj xhandler;            /* saved exception handler */
     ScmObj resetChain;          /* for reset/shift */
+    ScmObj partChain;           /* for reset/shift */
     ScmObj partHandlers;        /* for reset/shift */
     int errorReporting;         /* state of SCM_VM_ERROR_REPORTING flag
                                    when this ep is captured.  The flag status

--- a/src/gauche/vm.h
+++ b/src/gauche/vm.h
@@ -133,7 +133,9 @@ typedef struct ScmContFrameRec {
     struct ScmContFrameRec *prev; /* previous frame */
     ScmEnvFrame *env;             /* saved environment */
     int size;                     /* size of argument frame */
-    int marker;                   /* end marker of partial continuation */
+    int marker;                   /* marker of partial continuation
+                                      bit0: end marker
+                                      bit1: inside marker */
     SCM_PCTYPE cpc;               /* current PC (for debugging info) */
     SCM_PCTYPE pc;                /* next PC */
     ScmCompiledCode *base;        /* base register value */
@@ -457,12 +459,13 @@ struct ScmVMRec {
     ScmCallTrace *callTrace;
 
     /* for reset/shift */
-    ScmObj resetChain;          /* list of reset information,
-                                   where reset information is
-                                   (delimited . <dynamic handlers chain>).
-                                   the delimited flag is set when 'shift'
-                                   appears in 'reset' and the end marker of
-                                   partial continuation is set. */
+    ScmObj resetChain;          /* list of reset information, where reset
+                                   information is the dynamic handlers chain
+                                   saved on reset. */
+    ScmObj partChain;           /* list of partial continuation information,
+                                   where the information is only #f that
+                                   indicates we are inside of partial
+                                   continuation. */
 };
 
 SCM_EXTERN ScmVM *Scm_NewVM(ScmVM *proto, ScmObj name);

--- a/src/vm.c
+++ b/src/vm.c
@@ -141,6 +141,7 @@ static void save_stack(ScmVM *vm);
 static ScmSubr default_exception_handler_rec;
 #define DEFAULT_EXCEPTION_HANDLER  SCM_OBJ(&default_exception_handler_rec)
 static ScmObj throw_cont_calculate_handlers(ScmObj target, ScmObj current);
+static void   call_dynamic_handlers(ScmObj target, ScmObj current);
 static ScmObj throw_cont_body(ScmObj, ScmEscapePoint*, ScmObj);
 static void   process_queued_requests(ScmVM *vm);
 static void   vm_finalize(ScmObj vm, void *data);
@@ -1477,8 +1478,6 @@ void Scm_VMPushCC(ScmCContinuationProc *after,
  *   frame pointer) in cstack.cont.
  */
 
-static void call_dynamic_handlers(ScmObj target, ScmObj current);
-
 static ScmObj user_eval_inner(ScmObj program, ScmWord *codevec)
 {
     ScmCStack cstack;
@@ -2593,9 +2592,8 @@ static ScmObj throw_continuation(ScmObj *argframe,
         /* full continuation jump */
 
         /* calc dynamic handlers to call */
-        ScmObj handlers_to_call;
-        handlers_to_call = throw_cont_calculate_handlers(ep->handlers,
-                                                         vm->handlers);
+        ScmObj handlers_to_call = throw_cont_calculate_handlers(ep->handlers,
+                                                                vm->handlers);
         return throw_cont_body(handlers_to_call, ep, args);
     } else {
         /* partial continuation call */

--- a/test/dynwind.scm
+++ b/test/dynwind.scm
@@ -590,6 +590,37 @@
                (display "[r03]"))))
            (k1))))
 
+
+(test* "reset/shift + call/cc 2"
+       "[r01][s01][s02][s02]"
+       (with-output-to-string
+         (^[]
+           (define k1 #f)
+           (define k2 #f)
+           (reset
+            (display "[r01]")
+            (shift k (set! k1 k))
+            (display "[s01]")
+            (call/cc (lambda (k) (set! k2 k)))
+            (display "[s02]"))
+           (k1)
+           (reset (reset (k2))))))
+
+(test* "reset/shift + call/cc 3"
+       "[r01][s01][s01]"
+       (with-output-to-string
+         (^[]
+           (define k1 #f)
+           (define k2 #f)
+           (reset
+            (display "[r01]")
+            (call/cc (lambda (k)
+                       (set! k1 k)
+                       (shift k (set! k2 k))))
+            (display "[s01]"))
+           (k2)
+           (reset (k1)))))
+
 (test* "reset/shift + call/cc error 1"
        (test-error)
        (with-output-to-string

--- a/test/dynwind.scm
+++ b/test/dynwind.scm
@@ -606,6 +606,41 @@
            (k1)
            (reset (reset (k2))))))
 
+(test* "reset/shift + call/cc 2-B"
+       "[r01][s01]"
+       (with-output-to-string
+         (^[]
+           (define k1 #f)
+           (define k2 #f)
+           (reset
+            (display "[r01]")
+            (shift k (set! k1 k))
+            (display "[s01]")
+            (call/cc (lambda (k) (set! k2 k)))
+            ;; empty after call/cc
+            ;(display "[s02]")
+            )
+           (k1)
+           (reset (reset (k2))))))
+
+(test* "reset/shift + call/cc 2-C"
+       "[d01][d02][d03][d01][s01][s02][d03][d01][s02][d03]"
+       (with-output-to-string
+         (^[]
+           (define k1 #f)
+           (define k2 #f)
+           (reset
+            (dynamic-wind
+             (^[] (display "[d01]"))
+             (^[] (display "[d02]")
+                  (shift k (set! k1 k))
+                  (display "[s01]")
+                  (call/cc (lambda (k) (set! k2 k)))
+                  (display "[s02]"))
+             (^[] (display "[d03]"))))
+           (k1)
+           (reset (reset (k2))))))
+
 (test* "reset/shift + call/cc 3"
        "[r01][s01][s01]"
        (with-output-to-string


### PR DESCRIPTION
以下のページの「気になる例3」と「気になる例4」を修正したものになります。
https://practical-scheme.net/wiliki/wiliki.cgi?Gauche%3A%E9%83%A8%E5%88%86%E7%B6%99%E7%B6%9A%E3%81%A8%E5%8B%95%E7%9A%84%E7%92%B0%E5%A2%83%E3%81%AE%E5%AE%9F%E9%A8%93

#543 との違いは、部分継続の実行中を検出可能にしたことです。

まず、ScmVMRec に partChain を追加して、部分継続の実行中を把握できるようにしました。
([L1] [L2] [L3])

しかし、それだけだと「気になる例4」のように、
call/cc のキャプチャ時に部分継続がまだ起動されていないケース に対応できなかったため、
ScmContFrameRec の marker に 1ビット割り当てて、そちらからも追跡するようにしました。
([L4] [L5] [L6])

これで、部分継続の実行中を把握できるようになったため、
「気になる例3」の対策として、部分継続の内部にフル継続 (call/cc) でジャンプするときには、
resetChain と partChain を上書きしないようにしました。
([L7] [L8] [L9])

また、「気になる例4」の対策として、部分継続の内部にフル継続 (call/cc) でジャンプするときには、
throw_cont_body 関数内で save_cont(vm) を呼び出すようにしました。
([L10])

また、partcont_wrapper と throw_continuation の処理を見直して、
将来的に、Racket のように、call/cc でも部分継続のような動作をさせる余地があるようにしてみました。
(参考: [Racket call/cc])

ただ、今のところ、まともに動作しないため、キックするところをコメントアウトしています。
([L11]) (正直、難しくてよく分かりません。。。)

あとは、resetChain の delimited flag 情報が不要になったため、削除しました。
これによって、Scm_VMCallPC の処理が多少すっきりしました。
([L12])


＜テスト結果＞
https://ci.appveyor.com/project/Hamayama/gauche/builds/28750856

[Gauche-effects] の effects.scm で、`*use-native-reset*` を #t にして、各サンプルを実行 ==> OK

(関連プルリクエスト #543)

[L1]:https://github.com/shirok/Gauche/commit/2e62f18993f7ec2d493ebc80e81d3c47562abe01#diff-f7c0ea258aa8c7e3e8ea39db3c02ea72R465
[L2]:https://github.com/shirok/Gauche/commit/2e62f18993f7ec2d493ebc80e81d3c47562abe01#diff-86406329889f2c13524766839f0a96b3R2584
[L3]:https://github.com/shirok/Gauche/commit/2e62f18993f7ec2d493ebc80e81d3c47562abe01#diff-86406329889f2c13524766839f0a96b3R2616

[L4]:https://github.com/shirok/Gauche/commit/2e62f18993f7ec2d493ebc80e81d3c47562abe01#diff-f7c0ea258aa8c7e3e8ea39db3c02ea72L136
[L5]:https://github.com/shirok/Gauche/commit/2e62f18993f7ec2d493ebc80e81d3c47562abe01#diff-86406329889f2c13524766839f0a96b3R2644
[L6]:https://github.com/shirok/Gauche/commit/2e62f18993f7ec2d493ebc80e81d3c47562abe01#diff-86406329889f2c13524766839f0a96b3R2674

[L7]:https://github.com/shirok/Gauche/commit/2e62f18993f7ec2d493ebc80e81d3c47562abe01#diff-86406329889f2c13524766839f0a96b3R1550
[L8]:https://github.com/shirok/Gauche/commit/2e62f18993f7ec2d493ebc80e81d3c47562abe01#diff-86406329889f2c13524766839f0a96b3R2131
[L9]:https://github.com/shirok/Gauche/commit/2e62f18993f7ec2d493ebc80e81d3c47562abe01#diff-86406329889f2c13524766839f0a96b3R2453

[L10]:https://github.com/shirok/Gauche/commit/2e62f18993f7ec2d493ebc80e81d3c47562abe01#diff-86406329889f2c13524766839f0a96b3R2440

[Racket call/cc]:https://docs.racket-lang.org/reference/cont.html#%28def._%28%28quote._~23~25kernel%29._call-with-current-continuation%29%29

[L11]:https://github.com/shirok/Gauche/commit/2e62f18993f7ec2d493ebc80e81d3c47562abe01#diff-86406329889f2c13524766839f0a96b3R2525

[L12]:https://github.com/shirok/Gauche/commit/2e62f18993f7ec2d493ebc80e81d3c47562abe01#diff-f7c0ea258aa8c7e3e8ea39db3c02ea72L460

[Gauche-effects]:https://github.com/Hamayama/Gauche-effects
