### PR TITLE
Fix combination problem of reset/shift + call/cc v3

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -140,6 +140,7 @@ static void save_stack(ScmVM *vm);
 static ScmSubr default_exception_handler_rec;
 #define DEFAULT_EXCEPTION_HANDLER  SCM_OBJ(&default_exception_handler_rec)
 static ScmObj throw_cont_calculate_handlers(ScmObj target, ScmObj current);
+static void   call_dynamic_handlers(ScmObj target, ScmObj current);
 static ScmObj throw_cont_body(ScmObj, ScmEscapePoint*, ScmObj);
 static void   process_queued_requests(ScmVM *vm);
 static void   vm_finalize(ScmObj vm, void *data);
@@ -1482,6 +1483,8 @@ static ScmObj user_eval_inner(ScmObj program, ScmWord *codevec)
     /* Save prev_pc, for the boundary continuation uses pc slot
        to mark the boundary. */
     ScmWord * volatile prev_pc = PC;
+    ScmObj vmhandlers = vm->handlers;
+    ScmObj vmresetChain = vm->resetChain;
 
     /* Push extra continuation.  This continuation frame is a 'boundary
        frame' and marked by pc == &boundaryFrameMark.   VM loop knows
@@ -1512,7 +1515,14 @@ static ScmObj user_eval_inner(ScmObj program, ScmWord *codevec)
             POP_CONT();
             PC = prev_pc;
         } else if (vm->cont == NULL) {
-            /* we're finished with executing partial continuation.*/
+            /* we're finished with executing partial continuation. */
+
+            /* restore reset-chain for reset/shift */
+            vm->resetChain = vmresetChain;
+
+            /* call dynamic handlers for returning to the caller */
+            call_dynamic_handlers(vmhandlers, vm->handlers);
+
             vm->cont = cstack.cont;
             POP_CONT();
             PC = prev_pc;
@@ -2373,6 +2383,9 @@ static ScmObj throw_cont_calculate_handlers(ScmObj target, ScmObj current)
     ScmObj h = SCM_NIL, t = SCM_NIL, p;
     ScmObj h2 = SCM_NIL;
 
+    /* shortcut */
+    if (target == current) return SCM_NIL;
+
     SCM_FOR_EACH(p, current) {
         SCM_ASSERT(SCM_PAIRP(SCM_CAR(p)));
         if (!SCM_FALSEP(Scm_Memq(SCM_CAR(p), target))) break;
@@ -2387,6 +2400,21 @@ static ScmObj throw_cont_calculate_handlers(ScmObj target, ScmObj current)
     }
     SCM_APPEND(h, t, h2);
     return h;
+}
+
+static void call_dynamic_handlers(ScmObj target, ScmObj current)
+{
+    ScmVM *vm = theVM;
+    ScmObj handlers_to_call = throw_cont_calculate_handlers(target, current);
+    ScmObj p;
+    SCM_FOR_EACH(p, handlers_to_call) {
+        ScmObj before_flag = SCM_CAAR(p);
+        ScmObj handler     = SCM_CADR(SCM_CAR(p));
+        ScmObj chain       = SCM_CDDR(SCM_CAR(p));
+        if (SCM_FALSEP(before_flag))  vm->handlers = chain;
+        Scm_ApplyRec(handler, SCM_NIL);
+        if (!SCM_FALSEP(before_flag)) vm->handlers = chain;
+    }
 }
 
 static ScmObj throw_cont_cc(ScmObj, void **);
@@ -2427,8 +2455,14 @@ static ScmObj throw_cont_body(ScmObj handlers,    /* after/before thunks
      * the partial continuation.  The returning part is handled by
      * user_level_inner, but we have to make sure that our current continuation
      * won't be overwritten by execution of the partial continuation.
+     *
+     * NB: As an exception case, if we'll jump into reset,
+     * we might reach to the end of partial continuation even though
+     * the target continuation is a full continuation.
      */
-    if (ep->cstack == NULL) save_cont(vm);
+    if (ep->cstack == NULL || SCM_PAIRP(ep->resetChain)) {
+        save_cont(vm);
+    }
 
     /*
      * now, install the target continuation
@@ -2512,6 +2546,12 @@ static ScmObj throw_continuation(ScmObj *argframe,
         save_cont(vm);
     }
 
+    /* check reset-chain to avoid the wrong return from partial
+       continuation */
+    if (ep->cstack == NULL && !SCM_PAIRP(ep->resetChain)) {
+        Scm_Error("reset missing.");
+    }
+
     ScmObj handlers_to_call;
     if (ep->cstack) {
         /* for full continuation */
@@ -2524,60 +2564,7 @@ static ScmObj throw_continuation(ScmObj *argframe,
                                                         vm->handlers),
                                             vm->handlers);
     }
-
     return throw_cont_body(handlers_to_call, ep, args);
-}
-
-/* Body of the partial continuation SUBR */
-static ScmObj partcont_wrapper(ScmObj *argframe,
-                               int nargs SCM_UNUSED, void *data)
-{
-    ScmEscapePoint *ep = (ScmEscapePoint*)data;
-    ScmObj args = argframe[0];
-    ScmVM *vm = theVM;
-
-    /* check reset-chain to avoid the wrong return from partial
-       continuation */
-    if (!SCM_PAIRP(ep->resetChain)) {
-        Scm_Error("reset missing.");
-    }
-
-    /* capture the dynamic handlers chain before calling partial
-       continuation */
-    ScmObj k_handlers = vm->handlers;
-
-    ScmObj contproc = Scm_MakeSubr(throw_continuation, ep, 0, 1,
-                                   SCM_MAKE_STR("partial continuation"));
-    ScmObj ret = Scm_ApplyRec(contproc, args);
-
-    /* save return values */
-    int nvals = vm->numVals;
-    ScmObj *vals = NULL;
-    if (nvals > 1) {
-        vals = SCM_NEW_ARRAY(ScmObj, nvals-1);
-        memcpy(vals, vm->vals, sizeof(ScmObj)*(nvals-1));
-    }
-
-    /* call dynamic handlers for reset/shift */
-    ScmObj handlers_to_call = throw_cont_calculate_handlers(k_handlers,
-                                                            vm->handlers);
-    ScmObj p;
-    SCM_FOR_EACH(p, handlers_to_call) {
-        ScmObj before_flag = SCM_CAAR(p);
-        ScmObj handler     = SCM_CADR(SCM_CAR(p));
-        ScmObj chain       = SCM_CDDR(SCM_CAR(p));
-        if (SCM_FALSEP(before_flag))  vm->handlers = chain;
-        Scm_ApplyRec(handler, SCM_NIL);
-        if (!SCM_FALSEP(before_flag)) vm->handlers = chain;
-    }
-
-    /* restore return values */
-    vm->numVals = nvals;
-    if (vals != NULL) {
-        memcpy(vm->vals, vals, sizeof(ScmObj)*(nvals-1));
-    }
-
-    return ret;
 }
 
 ScmObj Scm_VMCallCC(ScmObj proc)
@@ -2621,7 +2608,7 @@ ScmObj Scm_VMCallPC(ScmObj proc)
         /*empty*/;
 
     /* set the end marker of partial continuation */
-    if (cp && cp->marker == 0) {
+    if (cp && !MARKER_FRAME_P(cp)) {
         cp->marker = 1;
         /* also set the delimited flag in reset information */
         if (SCM_PAIRP(vm->resetChain)) {
@@ -2651,28 +2638,19 @@ ScmObj Scm_VMCallPC(ScmObj proc)
     }
     ep->partHandlers = h;
 
-    /* call dynamic handlers for reset/shift */
-    ScmObj handlers_to_call = throw_cont_calculate_handlers(reset_handlers,
-                                                            ep->handlers);
-    ScmObj p2;
-    SCM_FOR_EACH(p2, handlers_to_call) {
-        ScmObj before_flag = SCM_CAAR(p2);
-        ScmObj handler     = SCM_CADR(SCM_CAR(p2));
-        ScmObj chain       = SCM_CDDR(SCM_CAR(p2));
-        if (SCM_FALSEP(before_flag))  vm->handlers = chain;
-        Scm_ApplyRec(handler, SCM_NIL);
-        if (!SCM_FALSEP(before_flag)) vm->handlers = chain;
-    }
+    /* call dynamic handlers for exiting reset */
+    call_dynamic_handlers(reset_handlers, ep->handlers);
 
-    ScmObj contproc = Scm_MakeSubr(partcont_wrapper, ep, 0, 1,
-                                   SCM_MAKE_STR("partial continuation wrapper"));
+    ScmObj contproc = Scm_MakeSubr(throw_continuation, ep, 0, 1,
+                                   SCM_MAKE_STR("continuation"));
     /* Remove the saved continuation chain.
        NB: vm->cont can be NULL if we've been executing a partial continuation.
            It's ok, for a continuation pointed by cstack will be restored
-           in user_eval_inner. 
+           in user_eval_inner.
        NB: If the delimited flag in reset information is not set,
            we can consider we've been executing a partial continuation. */
-    if (cp && SCM_PAIRP(vm->resetChain) && SCM_FALSEP(SCM_CAAR(vm->resetChain))) {
+    if (cp && (SCM_PAIRP(vm->resetChain) &&
+               SCM_FALSEP(SCM_CAAR(vm->resetChain)))) {
         vm->cont = NULL;
     } else {
         vm->cont = c;

--- a/test/dynwind.scm
+++ b/test/dynwind.scm
@@ -590,6 +590,72 @@
                (display "[r03]"))))
            (k1))))
 
+
+(test* "reset/shift + call/cc 2"
+       "[r01][s01][s02][s02]"
+       (with-output-to-string
+         (^[]
+           (define k1 #f)
+           (define k2 #f)
+           (reset
+            (display "[r01]")
+            (shift k (set! k1 k))
+            (display "[s01]")
+            (call/cc (lambda (k) (set! k2 k)))
+            (display "[s02]"))
+           (k1)
+           (reset (reset (k2))))))
+
+(test* "reset/shift + call/cc 2-B"
+       "[r01][s01]"
+       (with-output-to-string
+         (^[]
+           (define k1 #f)
+           (define k2 #f)
+           (reset
+            (display "[r01]")
+            (shift k (set! k1 k))
+            (display "[s01]")
+            (call/cc (lambda (k) (set! k2 k)))
+            ;; empty after call/cc
+            ;(display "[s02]")
+            )
+           (k1)
+           (reset (reset (k2))))))
+
+(test* "reset/shift + call/cc 2-C"
+       "[d01][d02][d03][d01][s01][s02][d03][d01][s02][d03]"
+       (with-output-to-string
+         (^[]
+           (define k1 #f)
+           (define k2 #f)
+           (reset
+            (dynamic-wind
+             (^[] (display "[d01]"))
+             (^[] (display "[d02]")
+                  (shift k (set! k1 k))
+                  (display "[s01]")
+                  (call/cc (lambda (k) (set! k2 k)))
+                  (display "[s02]"))
+             (^[] (display "[d03]"))))
+           (k1)
+           (reset (reset (k2))))))
+
+(test* "reset/shift + call/cc 3"
+       "[r01][s01][s01]"
+       (with-output-to-string
+         (^[]
+           (define k1 #f)
+           (define k2 #f)
+           (reset
+            (display "[r01]")
+            (call/cc (lambda (k)
+                       (set! k1 k)
+                       (shift k (set! k2 k))))
+            (display "[s01]"))
+           (k2)
+           (reset (k1)))))
+
 (test* "reset/shift + call/cc error 1"
        (test-error)
        (with-output-to-string


### PR DESCRIPTION
以下のページの「気になる例3」と「気になる例4」を修正したものになります。
https://practical-scheme.net/wiliki/wiliki.cgi?Gauche%3A%E9%83%A8%E5%88%86%E7%B6%99%E7%B6%9A%E3%81%A8%E5%8B%95%E7%9A%84%E7%92%B0%E5%A2%83%E3%81%AE%E5%AE%9F%E9%A8%93

#544 と違って、部分継続の実行中の管理はしていません。

user_eval_inner の部分継続からリターンする箇所に、
resetChain の復帰と dynamic-wind の巻き戻しを追加したところ、
いろいろとシンプルになり、partcont_wrapper まで不要になりました。。。

部分継続とフル継続を組み合わせた場合の動作としては、不完全かもしれませんが、
最終的な状態については、( vm->resetChain と vm->handlers 関して )
つじつまが合うようになったと思います。

結局、元の設計がシンプルで筋がよかったのかも。。。


＜テスト結果＞
(1) https://ci.appveyor.com/project/Hamayama/gauche/builds/28789710

(2) [Gauche-effects] の effects.scm で、`*use-native-reset*` を #t にして、各サンプルを実行 ==> OK

(3) 以下のリークテスト ==> OK
```
(use gauche.partcont)
(define (leak-test1 identity-thunk)
  (let loop ((id (lambda (x) x)))
    (loop (id (identity-thunk)))))
(leak-test1 (lambda () (reset (shift k k))))
```

(関連プルリクエスト #543, #544)

[Gauche-effects]:https://github.com/Hamayama/Gauche-effects
