### PR TITLE
Fix return position of full continuation from the end of partial continuation

### DIFF
--- a/src/gauche/priv/vmP.h
+++ b/src/gauche/priv/vmP.h
@@ -87,8 +87,11 @@ typedef struct ScmEscapePointRec {
                                    for they can be executed on anywhere
                                    w.r.t. cstack. */
     ScmObj xhandler;            /* saved exception handler */
-    ScmObj resetChain;          /* for reset/shift */
-    ScmObj partHandlers;        /* for reset/shift */
+    ScmObj resetChain;          /* saved reset-chain for reset/shift */
+    ScmObj partHandlers;        /* dynamic handlers chain cut for reset/shift
+                                   NB: if it is set to SCM_FALSE, it indicates
+                                   this ep is used for full continuation jump
+                                */
     int errorReporting;         /* state of SCM_VM_ERROR_REPORTING flag
                                    when this ep is captured.  The flag status
                                    should be restored when the control

--- a/src/vm.c
+++ b/src/vm.c
@@ -1572,7 +1572,9 @@ static ScmObj user_eval_inner(ScmObj program, ScmWord *codevec)
                 vm->cont = ep->cont;
                 vm->pc = PC_TO_RETURN;
                 /* restore reset-chain for reset/shift */
-                if (ep->cstack) vm->resetChain = ep->resetChain;
+                if (SCM_FALSEP(ep->partHandlers)) {
+                    vm->resetChain = ep->resetChain;
+                }
                 goto restart;
             } else if (vm->cstack->prev == NULL) {
                 /* This loop is the outermost C stack, and nobody will
@@ -2150,7 +2152,9 @@ ScmObj Scm_VMDefaultExceptionHandler(ScmObj e)
             SCM_VM_RUNTIME_FLAG_SET(vm, SCM_ERROR_BEING_REPORTED);
         }
         /* restore reset-chain for reset/shift */
-        if (ep->cstack) vm->resetChain = ep->resetChain;
+        if (SCM_FALSEP(ep->partHandlers)) {
+            vm->resetChain = ep->resetChain;
+        }
     } else {
         /* We don't have an active error handler, so this is the fallback
            behavior.  Reports the error and rewind dynamic handlers and
@@ -2303,7 +2307,7 @@ static ScmObj with_error_handler(ScmVM *vm, ScmObj handler,
     ep->cstack = vm->cstack;
     ep->xhandler = vm->exceptionHandler;
     ep->resetChain = vm->resetChain;
-    ep->partHandlers = SCM_NIL;
+    ep->partHandlers = SCM_FALSE;
     ep->errorReporting =
         SCM_VM_RUNTIME_FLAG_IS_SET(vm, SCM_ERROR_BEING_REPORTED);
     ep->rewindBefore = rewindBefore;
@@ -2471,14 +2475,8 @@ static ScmObj throw_cont_body(ScmObj handlers,    /* after/before thunks
      * the partial continuation.  The returning part is handled by
      * user_level_inner, but we have to make sure that our current continuation
      * won't be overwritten by execution of the partial continuation.
-     *
-     * NB: As an exception case, if we'll jump into reset,
-     * we might reach to the end of partial continuation even though
-     * the target continuation is a full continuation.
      */
-    if (ep->cstack == NULL || SCM_PAIRP(ep->resetChain)) {
-        save_cont(vm);
-    }
+    if (ep->cstack == NULL) save_cont(vm);
 
     /*
      * now, install the target continuation
@@ -2486,7 +2484,9 @@ static ScmObj throw_cont_body(ScmObj handlers,    /* after/before thunks
     vm->pc = PC_TO_RETURN;
     vm->cont = ep->cont;
     /* restore reset-chain for reset/shift */
-    if (ep->cstack) vm->resetChain = ep->resetChain;
+    if (SCM_FALSEP(ep->partHandlers)) {
+        vm->resetChain = ep->resetChain;
+    }
 
     nargs = Scm_Length(args);
     if (nargs == 1) {
@@ -2527,6 +2527,14 @@ static ScmObj throw_continuation(ScmObj *argframe,
     ScmEscapePoint *ep = (ScmEscapePoint*)data;
     ScmObj args = argframe[0];
     ScmVM *vm = theVM;
+
+    /* If we'll jump into reset, we might reach to the end of partial
+       continuation even though the target continuation is a full
+       continuation (ep->cstack != NULL). In this case, we must treat
+       the continuation like a partial continuation (ep->cstack == NULL). */
+    if (ep->cstack && SCM_PAIRP(ep->resetChain)) {
+        ep->cstack = NULL;
+    }
 
     /* First, check to see if we need to rewind C stack.
        NB: If we are invoking a partial continuation (ep->cstack == NULL),
@@ -2569,7 +2577,7 @@ static ScmObj throw_continuation(ScmObj *argframe,
     }
 
     ScmObj handlers_to_call;
-    if (ep->cstack) {
+    if (SCM_FALSEP(ep->partHandlers)) {
         /* for full continuation */
         handlers_to_call = throw_cont_calculate_handlers(ep->handlers,
                                                          vm->handlers);
@@ -2595,7 +2603,7 @@ ScmObj Scm_VMCallCC(ScmObj proc)
     ep->handlers = vm->handlers;
     ep->cstack = vm->cstack;
     ep->resetChain = vm->resetChain;
-    ep->partHandlers = SCM_NIL;
+    ep->partHandlers = SCM_FALSE;
 
     ScmObj contproc = Scm_MakeSubr(throw_continuation, ep, 0, 1,
                                    SCM_MAKE_STR("continuation"));

--- a/test/dynwind.scm
+++ b/test/dynwind.scm
@@ -661,6 +661,22 @@
                  (display (reset (reset (k2)))))
             (^[] (display "[d03]"))))))
 
+(test* "reset/shift + call/cc 2-E (check return position)"
+       "[r01][s01][s02][s02][r02]"
+       (with-output-to-string
+         (^[]
+           (define k1 #f)
+           (define k2 #f)
+           (reset
+            (display "[r01]")
+            (shift k (set! k1 k))
+            (display "[s01]")
+            (call/cc (lambda (k) (set! k2 k)))
+            (display "[s02]"))
+           (k1)
+           (reset (reset (k2))
+                  (display "[r02]")))))
+
 (test* "reset/shift + call/cc 3"
        "[r01][s01][s01]"
        (with-output-to-string


### PR DESCRIPTION
フル継続のジャンプ後に、部分継続の終端に到達したときの戻り先が、
最外の reset の外側になってしまっていたため、
最内の reset の外側になるように、
修正しました。

例えば、以下の例で、[r02] が表示されない不具合がありました。

```
(use gauche.partcont)
(define k1 #f)
(define k2 #f)
(let ()
  (reset
   (display "[r01]")
   (shift k (set! k1 k))
   (display "[s01]")
   (call/cc (lambda (k) (set! k2 k)))
   (display "[s02]"))
  (k1)
  (reset (reset (k2))
         (display "[r02]")))
;; 修正前
;; ==> [r01][s01][s02][s02]
;; 修正後
;; ==> [r01][s01][s02][s02][r02]
```

どうも throw_continuation 関数内の C stack の rewind が関係しているようで、
reset の中にジャンプする場合は、(部分継続のジャンプと同様に)
ep->cstack = NULL にするようにしたら直りました。

ただ、最外の reset の外側にジャンプする動作は、昔からそうなっていたため、
既存のアプリの動作が変わる可能性があります。
(そんな設計はしないと思いますが。。。)

(元々、フル継続のジャンプでは save_cont していなかったので、
どこに戻るかは未定義状態でしたが、(たまたま) うまく戻れるケースもありました)

(Kahua については、reset が render のところの1段だけなので、
今回の変更で制御フローは変わらないようです)


＜テスト結果＞
(1) https://ci.appveyor.com/project/Hamayama/gauche/builds/29172995

(2) [Gauche-effects] の effects.scm で、`*use-native-reset*` を #t にして、各サンプルを実行 ==> OK

(3) 以下のリークテスト ==> OK
```
(use gauche.partcont)
(define (leak-test1 identity-thunk)
  (let loop ((id (lambda (x) x)))
    (loop (id (identity-thunk)))))
(leak-test1 (lambda () (reset (shift k k))))
```

(4) Kahua の nqueen サンプル実行 ==> OK


(関連プルリクエスト #548)

[Gauche-effects]:https://github.com/Hamayama/Gauche-effects
