### PR TITLE
Remove dependency to libwinpthread-1.dll on MSYS2/MinGW-w64

### DIFF
--- a/src/mingw-dist.sh
+++ b/src/mingw-dist.sh
@@ -123,16 +123,17 @@ make install-examples
 rm -rf $distdir/lib/libgauche.dll*
 case "$MSYSTEM" in
   MINGW64|MINGW32)
-    for dll in libwinpthread-1.dll; do
-      if [ -f $mingwdir/bin/$dll ]; then
-        cp $mingwdir/bin/$dll $distdir/bin
-      fi
-    done
-    ;;
+    mingw_dll="libwinpthread-1.dll";;
   *)
-    cp $mingwdir/bin/mingwm10.dll $distdir/bin
-    ;;
+    mingw_dll="mingwm10.dll";;
 esac
+if [ -n "$mingw_dll" ]; then
+  for dll in $mingw_dll; do
+    if [ -f $mingwdir/bin/$dll ]; then
+      cp $mingwdir/bin/$dll $distdir/bin
+    fi
+  done
+fi
 
 # Enable using freshly-built gosh for the subsequent operations.
 PATH=$distdir/bin:$PATH


### PR DESCRIPTION
#389 の件に対応したものです。

とりあえずミニマムな感じで実装してみました。
- clock_getres
- clock_gettime
- sched_yield

それで、src/mingw-dist.sh で作られるインストーラの方には、
libwinpthread-1.dll を入れたままにしておいてよいでしょうか。

外部ライブラリで依存しているものがあり、
インストーラを全部対応するのは厳しいので。。。

(nanosleep とか使っていると依存してしまうようです。
Gaucheの本体は、自前の nanosleep 処理を優先していたので大丈夫でした。
コンパイルオプションを付けなくてもリンクしてしまうので、依存がおきやすいです。。。)


＜テスト結果＞
(1) https://ci.appveyor.com/project/Hamayama/gauche/builds/29199482

(2) 以下の結果が変更前と同様であること ==> OK
(sys-clock-getres-monotonic)
;; ==> 0
;; ==> 513
(sys-clock-gettime-monotonic)
;; ==> 687660
;; ==> 922727841

(3) libwinpthread-1.dll を消して起動 ==> OK
