### PR TITLE
Implement apropos for strings

### DIFF
--- a/lib/gauche/interactive.scm
+++ b/lib/gauche/interactive.scm
@@ -68,9 +68,7 @@
         [matcher (cond [(symbol? item)
                         (let1 substr (symbol->string item)
                           (^[name] (string-scan name substr)))]
-                       [(string? item)
-                        ;; Note: future extension
-                        (error "Bad object for item: " item)]
+                       [(string? item) (^[name] (string-scan name item))]
                        [(is-a? item <regexp>) (^[name] (rxmatch item name))]
                        [else
                         (error "Bad object for item: " item)])]


### PR DESCRIPTION
Congrats on the new release!

Here's a patch that allows the use of `(apropos "some-string")`. Previously only `(apropos 'some-symbol)` was allowed.

This patch is so obvious that am I missing something? There was TODO comment in the code, so is there a reason that strings are not allowed yet?