### PR TITLE
Allow blank Unix #! shebang line

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -415,6 +415,9 @@ static void test_ld_path_setup(char **av, const char *src_path)
     setenv("LD_LIBRARY_PATH", strdup(Scm_GetString(SCM_STRING(new_path))), 1);
 
     execv("/proc/self/exe", av);
+#else
+    (void)av;
+    (void)src_path;
 #endif
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -636,7 +636,7 @@ int execute_script(const char *scriptfile, ScmObj args)
         static ScmObj run_main_proc = SCM_UNDEFINED;
         SCM_BIND_PROC(run_main_proc, "run-main", Scm_GaucheInternalModule());
         SCM_ASSERT(SCM_PROCEDUREP(run_main_proc));
-        
+
         ScmEvalPacket epak;
         int r = Scm_Apply(run_main_proc, SCM_LIST2(mainproc, args), &epak);
         SCM_ASSERT(r == 1 && SCM_INTP(epak.results[0]));
@@ -682,7 +682,7 @@ void enter_repl()
     if (SCM_VM_RUNTIME_FLAG_IS_SET(Scm_VM(), SCM_CASE_FOLD)) {
         Scm_SetPortCaseFolding(SCM_PORT(Scm_Stdin()), TRUE);
     }
-    
+
     if (batch_mode || (!has_terminal() && !interactive_mode)) {
         Scm_LoadFromPort(SCM_PORT(Scm_Stdin()), SCM_LOAD_PROPAGATE_ERROR, NULL);
     } else {
@@ -726,7 +726,7 @@ int main(int ac, char **av)
             Scm_SetCallTraceSize(strtoul(call_trace, NULL, 10));
         }
     }
-    
+
     GC_INIT();
     Scm_Init(GAUCHE_SIGNATURE);
     sig_setup();
@@ -750,7 +750,7 @@ int main(int ac, char **av)
     if (strcmp(safe_basename(argv[0]), "scheme-r7rs") == 0) {
         main_module = SCM_INTERN("r7rs.user");
     }
-    
+
     /* Check command-line options */
     int argind = parse_options(argc, argv);
 

--- a/src/read.c
+++ b/src/read.c
@@ -411,7 +411,7 @@ static int char_is_delimiter(ScmChar ch)
             || SCM_CHAR_EXTRA_WHITESPACE(ch));
 }
 
-static void read_nested_comment(ScmPort *port, 
+static void read_nested_comment(ScmPort *port,
                                 ScmReadContext *ctx SCM_UNUSED)
 {
     int nesting = 0;
@@ -1274,7 +1274,7 @@ static ScmObj read_char(ScmPort *port, ScmReadContext *ctx)
    the read context setting.  INCLUDE_HASH_SIGN allows '#' to appear in
    the word.
 */
-static ScmObj read_word(ScmPort *port, ScmChar initial, 
+static ScmObj read_word(ScmPort *port, ScmChar initial,
                         ScmReadContext *ctx SCM_UNUSED,
                         int temp_case_fold, int include_hash_sign)
 {
@@ -1760,7 +1760,7 @@ static ScmObj read_sharp_word_1(ScmPort *port, char ch, ScmReadContext *ctx)
             || strcmp(w, "c64") == 0
             || strcmp(w, "c128") == 0) {
             tag = w;
-        } 
+        }
         break;
     case 'f':
         if (strcmp(w, "f16") == 0
@@ -1833,7 +1833,7 @@ void Scm__InitRead(void)
         SCM_HASH_TABLE(Scm_MakeHashTableSimple(SCM_HASH_EQ, 0));
     (void)SCM_INTERNAL_MUTEX_INIT(hashBangData.mutex);
 
-    defaultReadContext = 
+    defaultReadContext =
         Scm_MakePrimitiveParameter(SCM_CLASS_PRIMITIVE_PARAMETER, SCM_FALSE,
                                    SCM_OBJ(make_read_context(NULL)),
                                    0);

--- a/src/read.c
+++ b/src/read.c
@@ -1653,11 +1653,11 @@ ScmObj Scm_DefineReaderDirective(ScmObj symbol, ScmObj proc)
 
 static ScmObj read_shebang(ScmPort *port, ScmReadContext *ctx)
 {
-    /* If '#!' appears in the beginning of the input port, and it is
-       followed by '/' or a space, then we consider it as the
-       beginning of shebang and discards entire line.  Otherwise, we
-       take this as #!<identifier> directive as specified in R6RS, and
-       calls appropriate handler.
+    /* If '#!' appears at the beginning of the input port, and it is
+       followed by '/' or a space or a newline, then we consider it as
+       the beginning of shebang and discard the entire line.
+       Otherwise, we take this as #!<identifier> directive as
+       specified in R6RS, and calls appropriate handler.
 
        R6RS is actually not very clean at this corner.  It requires
        distinct modes to parse a script (which always begins with
@@ -1666,12 +1666,12 @@ static ScmObj read_shebang(ScmPort *port, ScmReadContext *ctx)
        parser that strictly covers both situation.
     */
     int c2 = Scm_GetcUnsafe(port);
-    if (port->bytes == 3 && (c2 == '/' || c2 == ' ')) {
+    if (port->bytes == 3 && (c2 == '/' || c2 == ' ' || c2 == '\n')) {
         /* shebang */
         for (;;) {
-            c2 = Scm_GetcUnsafe(port);
             if (c2 == '\n') return SCM_UNDEFINED;
             if (c2 == EOF) return SCM_EOF;
+            c2 = Scm_GetcUnsafe(port);
         }
         /*NOTREACHED*/
     } else {


### PR DESCRIPTION
Sometimes a script needs to be marked as `#!` for some tool to recognize it, without actually specifying the interpreter name. This patch changes Gauche so it recognizes a newline in addition to a space after `#!` at the start of a source file.