### PR TITLE
Avoid to use C macro 'complex' for C++ extensions

### DIFF
--- a/ext/uvector/uvector.c.tmpl
+++ b/ext/uvector/uvector.c.tmpl
@@ -573,13 +573,13 @@ static inline uint64_t u64g_mul(uint64_t x, uint64_t y, int clamp)
 #define f64g_mul(x, y, clamp)   (x*y)
 #define f64g_div(x, y, clamp)   (x/y)
 
-static inline complex double complex_half_to_double(ScmHalfComplex x)
+static inline ScmDoubleComplex complex_half_to_double(ScmHalfComplex x)
 {
-    return (complex double)(Scm_HalfToDouble(x.r)
+    return (ScmDoubleComplex)(Scm_HalfToDouble(x.r)
                             + Scm_HalfToDouble(x.i) * _Complex_I);
 }
 
-static inline ScmHalfComplex complex_double_to_half(complex double x)
+static inline ScmHalfComplex complex_double_to_half(ScmDoubleComplex x)
 {
     return (ScmHalfComplex){Scm_DoubleToHalf(creal(x)),
                             Scm_DoubleToHalf(cimag(x))};
@@ -590,8 +590,8 @@ static inline ScmHalfComplex c32c32_add(ScmHalfComplex x,
                                         ScmHalfComplex y,
                                         int clamp SCM_UNUSED)
 {
-    complex double cx = complex_half_to_double(x);
-    complex double cy = complex_half_to_double(y);
+    ScmDoubleComplex cx = complex_half_to_double(x);
+    ScmDoubleComplex cy = complex_half_to_double(y);
     return complex_double_to_half(cx+cy);
 }
 
@@ -599,8 +599,8 @@ static inline ScmHalfComplex c32c32_sub(ScmHalfComplex x,
                                         ScmHalfComplex y,
                                         int clamp SCM_UNUSED)
 {
-    complex double cx = complex_half_to_double(x);
-    complex double cy = complex_half_to_double(y);
+    ScmDoubleComplex cx = complex_half_to_double(x);
+    ScmDoubleComplex cy = complex_half_to_double(y);
     return complex_double_to_half(cx-cy);
 }
 
@@ -608,8 +608,8 @@ static inline ScmHalfComplex c32c32_mul(ScmHalfComplex x,
                                         ScmHalfComplex y,
                                         int clamp SCM_UNUSED)
 {
-    complex double cx = complex_half_to_double(x);
-    complex double cy = complex_half_to_double(y);
+    ScmDoubleComplex cx = complex_half_to_double(x);
+    ScmDoubleComplex cy = complex_half_to_double(y);
     return complex_double_to_half(cx*cy);
 }
 
@@ -617,8 +617,8 @@ static inline ScmHalfComplex c32c32_div(ScmHalfComplex x,
                                         ScmHalfComplex y,
                                         int clamp SCM_UNUSED)
 {
-    complex double cx = complex_half_to_double(x);
-    complex double cy = complex_half_to_double(y);
+    ScmDoubleComplex cx = complex_half_to_double(x);
+    ScmDoubleComplex cy = complex_half_to_double(y);
     return complex_double_to_half(cx/cy);
 }
 

--- a/ext/uvector/uvector.scm
+++ b/ext/uvector/uvector.scm
@@ -369,11 +369,11 @@
             (set! r (Scm_BinarySearchC32 (+ (SCM_C32VECTOR_ELEMENTS v) s)
                                          (- e s) k p (& lb) (& ub))))]         
          [(SCM_UVECTOR_C64)
-          (let* ([k::(complex float) (Scm_GetFloatComplex key)])
+          (let* ([k::(ScmFloatComplex) (Scm_GetFloatComplex key)])
             (set! r (Scm_BinarySearchC64 (+ (SCM_C64VECTOR_ELEMENTS v) s)
                                          (- e s) k p (& lb) (& ub))))]         
          [(SCM_UVECTOR_C128)
-          (let* ([k::(complex double) (Scm_GetDoubleComplex key)])
+          (let* ([k::(ScmDoubleComplex) (Scm_GetDoubleComplex key)])
             (set! r (Scm_BinarySearchC128 (+ (SCM_C128VECTOR_ELEMENTS v) s)
                                           (- e s) k p (& lb) (& ub))))] 
          [else (Scm_Error "[internal] Invalid uvector type: %S" v)]

--- a/ext/uvector/uvgen.scm
+++ b/ext/uvector/uvgen.scm
@@ -295,14 +295,14 @@
     ,@(common-rules 'c32)))
 
 (define (make-c64rules)
-  `((etype     "complex float")
+  `((etype     "ScmFloatComplex")
     (REF_NTYPE ,(^[v i] #"SCM_C64VECTOR_ELEMENTS(~v)[~i]"))
     (UNBOX     ,(^[dst src clamp] #"~dst = Scm_GetFloatComplex(~src)"))
     (BOX       ,(^[dst src]       #"~dst = Scm_FloatComplexToComplex(~src)"))
     ,@(common-rules 'c64)))
 
 (define (make-c128rules)
-  `((etype     "complex double")
+  `((etype     "ScmDoubleComplex")
     (REF_NTYPE ,(^[v i] #"SCM_C128VECTOR_ELEMENTS(~v)[~i]"))
     (UNBOX     ,(^[dst src clamp] #"~dst = Scm_GetDoubleComplex(~src)"))
     (BOX       ,(^[dst src]       #"~dst = Scm_DoubleComplexToComplex(~src)"))

--- a/lib/gauche/cgen/literal.scm
+++ b/lib/gauche/cgen/literal.scm
@@ -751,8 +751,8 @@
     [(eq? class <f32vector>) "float"]
     [(eq? class <f64vector>) "double"]
     [(eq? class <c32vector>) "ScmHalfComplex"]
-    [(eq? class <c64vector>) "complex float"]
-    [(eq? class <c128vector>) "complex double"]
+    [(eq? class <c64vector>) "ScmFloatComplex"]
+    [(eq? class <c128vector>) "ScmDoubleComplex"]
     ))
 
 (define (uvector-class-emit-elt class v)

--- a/src/gauche/float.h
+++ b/src/gauche/float.h
@@ -49,6 +49,10 @@
 
 /* assuming gauche/config.h is read. */
 
+/* We avoid to use C macro 'complex' for C++ extensions. */
+typedef float _Complex ScmFloatComplex;
+typedef double _Complex ScmDoubleComplex;
+
 /*
  * Half float support
  */

--- a/src/gauche/number.h
+++ b/src/gauche/number.h
@@ -258,11 +258,11 @@ SCM_EXTERN ScmObj Scm_MakeCompnum(double real, double imag);
 SCM_EXTERN ScmObj Scm_MakeComplex(double real, double imag);
 SCM_EXTERN ScmObj Scm_MakeComplexPolar(double magnitude, double angle);
 SCM_EXTERN ScmHalfComplex Scm_GetHalfComplex(ScmObj obj);
-SCM_EXTERN complex float  Scm_GetFloatComplex(ScmObj obj);
-SCM_EXTERN complex double Scm_GetDoubleComplex(ScmObj obj);
+SCM_EXTERN ScmFloatComplex  Scm_GetFloatComplex(ScmObj obj);
+SCM_EXTERN ScmDoubleComplex Scm_GetDoubleComplex(ScmObj obj);
 SCM_EXTERN ScmObj Scm_HalfComplexToComplex(const ScmHalfComplex c);
-SCM_EXTERN ScmObj Scm_FloatComplexToComplex(const complex float c);
-SCM_EXTERN ScmObj Scm_DoubleComplexToComplex(const complex double c);
+SCM_EXTERN ScmObj Scm_FloatComplexToComplex(const ScmFloatComplex c);
+SCM_EXTERN ScmObj Scm_DoubleComplexToComplex(const ScmDoubleComplex c);
 
 SCM_EXTERN int    Scm_IntegerP(ScmObj obj);
 SCM_EXTERN int    Scm_OddP(ScmObj obj);

--- a/src/gauche/priv/vectorP.h
+++ b/src/gauche/priv/vectorP.h
@@ -92,11 +92,11 @@ size_t Scm_BinarySearchF64(const double vec[], size_t len, double key,
 size_t Scm_BinarySearchC32(const ScmHalfComplex vec[], size_t len, 
                            ScmHalfComplex key,
                            u_int skip, size_t *floor, size_t *ceil);
-size_t Scm_BinarySearchC64(const complex float vec[], size_t len,
-                           complex float key,
+size_t Scm_BinarySearchC64(const ScmFloatComplex vec[], size_t len,
+                           ScmFloatComplex key,
                            u_int skip, size_t *floor, size_t *ceil);
-size_t Scm_BinarySearchC128(const complex double vec[], size_t len, 
-                            complex double key,
+size_t Scm_BinarySearchC128(const ScmDoubleComplex vec[], size_t len, 
+                            ScmDoubleComplex key,
                             u_int skip, size_t *floor, size_t *ceil);
 
 

--- a/src/gauche/vector.h
+++ b/src/gauche/vector.h
@@ -315,26 +315,26 @@ SCM_CLASS_DECL(Scm_C64VectorClass);
 #define SCM_C64VECTOR(obj)          SCM_UVECTOR(obj)
 #define SCM_C64VECTORP(obj)         SCM_XTYPEP(obj, SCM_CLASS_C64VECTOR)
 #define SCM_C64VECTOR_SIZE(obj)     SCM_UVECTOR_SIZE(obj)
-#define SCM_C64VECTOR_ELEMENTS(obj) ((complex float*)SCM_UVECTOR_ELEMENTS(obj))
+#define SCM_C64VECTOR_ELEMENTS(obj) ((ScmFloatComplex*)SCM_UVECTOR_ELEMENTS(obj))
 #define SCM_C64VECTOR_ELEMENT(obj,k) SCM_C64VECTOR_ELEMENTS(obj)[k]
-SCM_EXTERN ScmObj Scm_MakeC64Vector(ScmSmallInt size, complex float fill);
+SCM_EXTERN ScmObj Scm_MakeC64Vector(ScmSmallInt size, ScmFloatComplex fill);
 SCM_EXTERN ScmObj Scm_MakeC64VectorFromArray(ScmSmallInt size,
-                                             const complex float array[]);
+                                             const ScmFloatComplex array[]);
 SCM_EXTERN ScmObj Scm_MakeC64VectorFromArrayShared(ScmSmallInt size,
-                                                   complex float array[]);
+                                                   ScmFloatComplex array[]);
 
 SCM_CLASS_DECL(Scm_C128VectorClass);
 #define SCM_CLASS_C128VECTOR         (&Scm_C128VectorClass)
 #define SCM_C128VECTOR(obj)          SCM_UVECTOR(obj)
 #define SCM_C128VECTORP(obj)         SCM_XTYPEP(obj, SCM_CLASS_C128VECTOR)
 #define SCM_C128VECTOR_SIZE(obj)     SCM_UVECTOR_SIZE(obj)
-#define SCM_C128VECTOR_ELEMENTS(obj) ((complex double*)SCM_UVECTOR_ELEMENTS(obj))
+#define SCM_C128VECTOR_ELEMENTS(obj) ((ScmDoubleComplex*)SCM_UVECTOR_ELEMENTS(obj))
 #define SCM_C128VECTOR_ELEMENT(obj,k) SCM_C128VECTOR_ELEMENTS(obj)[k]
-SCM_EXTERN ScmObj Scm_MakeC128Vector(ScmSmallInt size, complex double fill);
+SCM_EXTERN ScmObj Scm_MakeC128Vector(ScmSmallInt size, ScmDoubleComplex fill);
 SCM_EXTERN ScmObj Scm_MakeC128VectorFromArray(ScmSmallInt size,
-                                             const complex double array[]);
+                                             const ScmDoubleComplex array[]);
 SCM_EXTERN ScmObj Scm_MakeC128VectorFromArrayShared(ScmSmallInt size,
-                                                   complex double array[]);
+                                                   ScmDoubleComplex array[]);
 
 
 /* For the backward compatibility */

--- a/src/libvec.scm
+++ b/src/libvec.scm
@@ -441,19 +441,19 @@
                                   ceil::size_t*)
    ::size_t (%binary-search ScmHalfComplex hc-eqv hc-lt))
  
- (define-cfn Scm_BinarySearchC64 (vec::(const complex float*)
+ (define-cfn Scm_BinarySearchC64 (vec::(const ScmFloatComplex*)
                                   len::size_t
-                                  key::(complex float)
+                                  key::(ScmFloatComplex)
                                   skip::u_int
                                   floor::size_t*
                                   ceil::size_t*)
-   ::size_t (%binary-search (complex float) common-eqv fc-lt))
+   ::size_t (%binary-search (ScmFloatComplex) common-eqv fc-lt))
 
- (define-cfn Scm_BinarySearchC128 (vec::(const complex double*)
+ (define-cfn Scm_BinarySearchC128 (vec::(const ScmDoubleComplex*)
                                    len::size_t
-                                   key::(complex double)
+                                   key::(ScmDoubleComplex)
                                    skip::u_int
                                    floor::size_t*
                                    ceil::size_t*)
-   ::size_t (%binary-search (complex double) common-eqv dc-lt))
+   ::size_t (%binary-search (ScmDoubleComplex) common-eqv dc-lt))
  )

--- a/src/number.c
+++ b/src/number.c
@@ -842,9 +842,9 @@ ScmHalfComplex Scm_GetHalfComplex(ScmObj z)
     return c;
 }
 
-complex float Scm_GetFloatComplex(ScmObj z)
+ScmFloatComplex Scm_GetFloatComplex(ScmObj z)
 {
-    complex float c = 0.0f;
+    ScmFloatComplex c = 0.0f;
     if (SCM_COMPNUMP(z)) {
         c = (float)SCM_COMPNUM_REAL(z) 
             + (float)SCM_COMPNUM_IMAG(z) * _Complex_I;
@@ -856,9 +856,9 @@ complex float Scm_GetFloatComplex(ScmObj z)
     return c;
 }
 
-complex double Scm_GetDoubleComplex(ScmObj z)
+ScmDoubleComplex Scm_GetDoubleComplex(ScmObj z)
 {
-    complex double c = 0.0f;
+    ScmDoubleComplex c = 0.0f;
     if (SCM_COMPNUMP(z)) {
         c = SCM_COMPNUM_REAL(z) 
             + SCM_COMPNUM_IMAG(z) * _Complex_I;
@@ -876,12 +876,12 @@ ScmObj Scm_HalfComplexToComplex(ScmHalfComplex z)
                            Scm_HalfToDouble(z.i));
 }
 
-ScmObj Scm_FloatComplexToComplex(complex float z)
+ScmObj Scm_FloatComplexToComplex(ScmFloatComplex z)
 {
     return Scm_MakeComplex((double)crealf(z), (double)cimagf(z));
 }
 
-ScmObj Scm_DoubleComplexToComplex(complex double z)
+ScmObj Scm_DoubleComplexToComplex(ScmDoubleComplex z)
 {
     return Scm_MakeComplex(creal(z), cimag(z));
 }

--- a/src/vector.c
+++ b/src/vector.c
@@ -299,8 +299,8 @@ int Scm_UVectorElementSize(ScmClass *klass)
     static const int sizes[] = { 1, 1, 2, 2, 4, 4, 8, 8,
                                  2, sizeof(float), sizeof(double), -1,
                                  sizeof(ScmHalfComplex),
-                                 sizeof(complex float),
-                                 sizeof(complex double),
+                                 sizeof(ScmFloatComplex),
+                                 sizeof(ScmDoubleComplex),
                                  -1 };
     int ind = (int)Scm_UVectorType(klass);
     if (ind >= 0) return sizes[ind];
@@ -567,8 +567,8 @@ DEF_UVCTOR_FILL(F16, ScmHalfFloat)
 DEF_UVCTOR_FILL(F32, float)
 DEF_UVCTOR_FILL(F64, double)
 DEF_UVCTOR_FILL(C32, ScmHalfComplex)
-DEF_UVCTOR_FILL(C64, complex float)
-DEF_UVCTOR_FILL(C128,complex double)
+DEF_UVCTOR_FILL(C64, ScmFloatComplex)
+DEF_UVCTOR_FILL(C128,ScmDoubleComplex)
 
 DEF_UVCTOR_ARRAY(S8,  int8_t)
 DEF_UVCTOR_ARRAY(U8,  uint8_t)
@@ -582,8 +582,8 @@ DEF_UVCTOR_ARRAY(F16, ScmHalfFloat)
 DEF_UVCTOR_ARRAY(F32, float)
 DEF_UVCTOR_ARRAY(F64, double)
 DEF_UVCTOR_ARRAY(C32, ScmHalfComplex)
-DEF_UVCTOR_ARRAY(C64, complex float)
-DEF_UVCTOR_ARRAY(C128,complex double)
+DEF_UVCTOR_ARRAY(C64, ScmFloatComplex)
+DEF_UVCTOR_ARRAY(C128,ScmDoubleComplex)
 
 /*
  * Reader
@@ -711,8 +711,8 @@ DEF_PRINT(F16, f16, ScmHalfFloat, f16pr)
 DEF_PRINT(F32, f32, float, fpr)
 DEF_PRINT(F64, f64, double, fpr)
 DEF_PRINT(C32, c32, ScmHalfComplex, c32pr)
-DEF_PRINT(C64, c64, complex float, c64pr)
-DEF_PRINT(C128, c128, complex double, c128pr)
+DEF_PRINT(C64, c64, ScmFloatComplex, c64pr)
+DEF_PRINT(C128, c128, ScmDoubleComplex, c128pr)
 
 
 /* comparer */
@@ -761,14 +761,14 @@ static inline int c32lt(ScmHalfComplex x, ScmHalfComplex y)
                 && SCM_HALF_FLOAT_CMP(<, x.i, y.i)));
 }
 
-static inline int c64lt(complex float x, complex float y)
+static inline int c64lt(ScmFloatComplex x, ScmFloatComplex y)
 {
     return (crealf(x) < crealf(y)
             || (crealf(x) == crealf(y)
                 && cimagf(x) < cimagf(y)));
 }
 
-static inline int c128lt(complex double x, complex double y)
+static inline int c128lt(ScmDoubleComplex x, ScmDoubleComplex y)
 {
     return (creal(x) < creal(y)
             || (creal(x) == creal(y)
@@ -788,8 +788,8 @@ DEF_CMP(F16, f16, ScmHalfFloat, f16eqv, f16lt)
 DEF_CMP(F32, f32, float, common_eqv, common_lt)
 DEF_CMP(F64, f64, double, common_eqv, common_lt)
 DEF_CMP(C32, c32, ScmHalfComplex, c32eqv, c32lt)
-DEF_CMP(C64, c64, complex float, common_eqv, c64lt)
-DEF_CMP(C128, c128, complex double, common_eqv, c128lt)
+DEF_CMP(C64, c64, ScmFloatComplex, common_eqv, c64lt)
+DEF_CMP(C128, c128, ScmDoubleComplex, common_eqv, c128lt)
 
 /*=====================================================================
  * Utility


### PR DESCRIPTION
C++ を使う外部ライブラリで、gauche.h を読み込んだとき、
C の complex マクロが未定義になるようで、以下のエラーが発生しました。

```
C:\Program Files (x86)\Gauche\lib\gauche-0.97\0.9.9\include/gauche/vector.h:320:55: error: 'complex' has not been declared
  320 | SCM_EXTERN ScmObj Scm_MakeC64Vector(ScmSmallInt size, complex float fill);
      |                                                       ^~~~~~~
```

C++ 用の complex.h を見ると、中で `#undef complex` を実行しているようです。
(C++11 では必ずで、C++03 では complex を include したときのみのもよう)

対策として、src/gauche/float.h で、
ScmFloatComplex と ScmDoubleComplex を typedef して、
それらを使うようにしました。

＜テスト結果＞
https://ci.appveyor.com/project/Hamayama/gauche/builds/29822076
