### PR TITLE
Fix srfi-115 regexp-replace with start/end parameters

### DIFF
--- a/doc/modr7rs.texi
+++ b/doc/modr7rs.texi
@@ -7325,15 +7325,21 @@ As a Gauche extension, @var{subst} could also be a procedure, which is
 called with the given match object and the result will be used as the
 replacement.
 
-The optional parameters @var{start} and @var{end} restrict both the
-matching and the substitution, to the given indices, such that the
-result is equivalent to omitting these parameters and replacing on
-@code{(substring str start end)}. As a convenience, a value of
-@code{#f} for end is equivalent to @code{(string-length str)}.
+The optional parameters @var{start} and @var{end} essentially
+transform the substitution into this
+
+@example
+   (regexp-replace re (substring str start end) subst)
+@end example
+
+except that @var{end} can take @code{#f} which is the same as
+@code{(string-length str)}.
 
 @example
    (regexp-replace '(+ space) "one two three" "_")
    => "one_two three"
+   (regexp-replace '(+ space) "one two three" "_" 1 10)
+   => "ne_two th"
    (regexp-replace '(+ space) "one two three" "_" 0 #f 0)
    => "one_two three"
    (regexp-replace '(+ space) "one two three" "_" 0 #f 1)

--- a/lib/srfi-115.scm
+++ b/lib/srfi-115.scm
@@ -194,14 +194,18 @@
    [(list? sub) (map check-pre-post sub)]
    [else sub]))
 
+(define (%substring str start end)
+  (if (or (> start 0) end)
+      (substring str start (or end (string-length str)))
+      str))
+
 (define (regexp-replace rx str sub :optional
                         (start 0)
                         (end #f)
                         (count 0))
   (let1 rx (regexp rx)
     ((with-module gauche.internal %regexp-replace)
-     rx
-     str start end
+     rx (%substring str start end)
      (transform-sub rx sub) count 1)))
 
 (define (regexp-replace-all rx str sub :optional
@@ -209,8 +213,7 @@
                             (end #f))
   (let1 rx (regexp rx)
     ((with-module gauche.internal %regexp-replace)
-     rx
-     str start end
+     rx (%substring str start end)
      (transform-sub rx sub) 0 #f)))
 
 (define regexp-match? regmatch?)

--- a/src/librx.scm
+++ b/src/librx.scm
@@ -173,25 +173,17 @@
           (%regexp-replace-rec rx next subpat subskip
                                (and subcount (- subcount 1))))]))))
 
-(define (%regexp-replace rx string start end subpat subskip subcount)
-  (if (not end)
-    (%regexp-replace rx string start (string-length string)
-                     subpat subskip subcount)
-    (with-output-to-string
+(define (%regexp-replace rx string subpat subskip subcount)
+  (with-output-to-string
       (^[]
-        (unless (zero? start)
-          (display (substring string 0 start)))
-        (%regexp-replace-rec rx (substring string start end)
-                             subpat subskip subcount)
-        (unless (= (string-length string) end)
-          (display (substring string end (string-length string))))))))
+        (%regexp-replace-rec rx string subpat subskip subcount))))
 
 (define-in-module gauche (regexp-replace rx string sub)
-  (%regexp-replace rx string 0 #f
+  (%regexp-replace rx string
                    (%regexp-parse-subpattern sub) 0 1))
 
 (define-in-module gauche (regexp-replace-all rx string sub)
-  (%regexp-replace rx string 0 #f
+  (%regexp-replace rx string
                    (%regexp-parse-subpattern sub) 0 #f))
 
 (define (regexp-replace-driver name func-1)

--- a/test/srfi.scm
+++ b/test/srfi.scm
@@ -1999,6 +1999,13 @@
        " abc d ef "
        (regexp-replace-all '(+ space) "  abc \t\n d ef  " " "))
 
+(test* "regexp-replace"
+       "bc pre: <<<bc >>> match1: <<<def>>> post: <<<gh>>>gh"
+       (regexp-replace '(: ($ (+ alpha)) ":" (* space))
+                       "abc def: ghi"
+                       '("pre: <<<" pre ">>> match1: <<<" 1 ">>> post: <<<" post ">>>")
+                       1 11))
+
 ;;-----------------------------------------------------------------------
 (test-section "srfi-117")
 (use srfi-117)


### PR DESCRIPTION
I misread the srfi and handled start/end parameters incorrectly. I only
restricted matching and substitution within [start, end) but what I
should have done is to just pass (substring str start end) to
regexp-replace instead.

A related issue with Chibi implementation showed up in srfi-115 mailing
list and made me realize this [1]. The test case is taken from Chibi [2].

[1] https://srfi-email.schemers.org/srfi-115/msg/12928191/
[2] See 6f281596 (regexp-replace should respect start/end also for
    pre/post substitutions, 2019-12-28) from chibi repo