### PR TITLE
Change template of extension library

### DIFF
--- a/ext/Makefile.in
+++ b/ext/Makefile.in
@@ -29,7 +29,7 @@ TEMPLATE_INST_DIR = $(datadir)/gauche-@GAUCHE_ABI_VERSION@/$(GAUCHE_VERSION)
 TEMPLATES = template.Makefile.in template.configure template.configure.ac \
 	    template.extension.h template.extension.c \
 	    template.extensionlib.stub template.module.scm \
-	    template.package.scm template.test.scm
+	    template.package.scm template.test.scm template.util-config.scm
 
 all: $(SUBDIRS)
 

--- a/ext/template.Makefile.in
+++ b/ext/template.Makefile.in
@@ -16,6 +16,12 @@ GAUCHE_CONFIG  = "@GAUCHE_CONFIG@"
 GAUCHE_PACKAGE = "@GAUCHE_PACKAGE@"
 INSTALL        = "@GAUCHE_INSTALL@" -C
 
+# C build settings
+CFLAGS   = @CFLAGS@
+CPPFLAGS = @CPPFLAGS@
+LDFLAGS  = @LDFLAGS@
+LIBS     = @LIBS@
+
 # Other parameters
 SOEXT  = @SOEXT@
 OBJEXT = @OBJEXT@
@@ -39,11 +45,14 @@ GAUCHE_PKGLIBDIR  = "$(DESTDIR)@GAUCHE_PKGLIBDIR@"
 GAUCHE_PKGARCHDIR = "$(DESTDIR)@GAUCHE_PKGARCHDIR@"
 
 @@extname@@_SRCS = $(srcdir)/@@extname@@.c $(srcdir)/@@extname@@lib.stub
+@@extname@@_HDRS = $(srcdir)/@@extname@@.h
 
 all : $(TARGET)
 
-@@extname@@.$(SOEXT): $(@@extname@@_SRCS)
+@@extname@@.$(SOEXT): $(@@extname@@_SRCS) $(@@extname@@_HDRS)
 	$(GAUCHE_PACKAGE) compile \
+	  --cppflags="$(CPPFLAGS)" --cflags="$(CFLAGS)" \
+	  --ldflags="$(LDFLAGS)" --libs="$(LIBS)" \
 	  --local=$(LOCAL_PATHS) --verbose @@extname@@ $(@@extname@@_SRCS)
 
 check : all

--- a/ext/template.configure
+++ b/ext/template.configure
@@ -2,8 +2,9 @@
 ;; Configuring @@package@@
 ;; Run ./configure (or gosh ./configure) to generate Makefiles.
 
+(add-load-path "." :relative)
 (use gauche.configure)
-(use gauche.version)
+(use util-config)
 
 ;; Here you can define handlers of configure arguments by cf-arg-enable
 ;; and cf-arg-with.  Note that --with-local is handled implicitly if you use
@@ -14,25 +15,7 @@
 ;; command-line args and sets up default values.
 (cf-init-gauche-extension)
 
-;; For Gauche 0.9.9 or earlier
-(when (version<=? (gauche-version) "0.9.9")
-  ;; C build settings
-  (unless (cf-have-subst? 'CFLAGS)
-    (cf-subst 'CFLAGS (gauche-config "--default-cflags")))
-  (unless (cf-have-subst? 'CPPFLAGS) (cf-subst 'CPPFLAGS ""))
-  (unless (cf-have-subst? 'LDFLAGS)  (cf-subst 'LDFLAGS  ""))
-  (unless (cf-have-subst? 'LIBS)     (cf-subst 'LIBS     ""))
-
-  ;; For Windows Unicode support
-  (cond-expand
-   [(and gauche.os.windows gauche.ces.utf8)
-    (unless (#/(^-|\s+-)DUNICODE\b/ (cf$ 'CPPFLAGS))
-      (cf-subst-append 'CPPFLAGS "-DUNICODE"))]
-   [else])
-  )
-
 ;; Here you can add feature tests and other cf-define's.
-
 
 ;; Output
 (cf-output-default)

--- a/ext/template.configure
+++ b/ext/template.configure
@@ -3,6 +3,7 @@
 ;; Run ./configure (or gosh ./configure) to generate Makefiles.
 
 (use gauche.configure)
+(use gauche.version)
 
 ;; Here you can define handlers of configure arguments by cf-arg-enable
 ;; and cf-arg-with.  Note that --with-local is handled implicitly if you use
@@ -13,7 +14,25 @@
 ;; command-line args and sets up default values.
 (cf-init-gauche-extension)
 
+;; For Gauche 0.9.9 or earlier
+(when (version<=? (gauche-version) "0.9.9")
+  ;; C build settings
+  (unless (cf-have-subst? 'CFLAGS)
+    (cf-subst 'CFLAGS (gauche-config "--default-cflags")))
+  (unless (cf-have-subst? 'CPPFLAGS) (cf-subst 'CPPFLAGS ""))
+  (unless (cf-have-subst? 'LDFLAGS)  (cf-subst 'LDFLAGS  ""))
+  (unless (cf-have-subst? 'LIBS)     (cf-subst 'LIBS     ""))
+
+  ;; For Windows Unicode support
+  (cond-expand
+   [(and gauche.os.windows gauche.ces.utf8)
+    (unless (#/(^-|\s+-)DUNICODE\b/ (cf$ 'CPPFLAGS))
+      (cf-subst-append 'CPPFLAGS "-DUNICODE"))]
+   [else])
+  )
+
 ;; Here you can add feature tests and other cf-define's.
+
 
 ;; Output
 (cf-output-default)

--- a/ext/template.configure.ac
+++ b/ext/template.configure.ac
@@ -36,6 +36,20 @@ AC_PATH_PROG([GAUCHE_PACKAGE], gauche-package)
 AC_PATH_PROG([GAUCHE_INSTALL], gauche-install)
 AC_PATH_PROG([GAUCHE_CESCONV], gauche-cesconv)
 
+dnl C build settings
+if test -z "$CFLAGS"; then
+  CFLAGS=`"$GAUCHE_CONFIG" --default-cflags`
+fi
+AC_SUBST(CFLAGS)
+AC_SUBST(CPPFLAGS)
+AC_SUBST(LDFLAGS)
+AC_SUBST(LIBS)
+
+dnl For Windows Unicode support
+if gosh -e'(exit (cond-expand ((and gauche.os.windows gauche.ces.utf8) 0) (else 1)))'; then
+  CPPFLAGS="$CPPFLAGS -DUNICODE"
+fi
+
 dnl Usually these parameters are set by AC_PROG_CC, but we'd rather use
 dnl the same one as Gauche has been compiled with.
 SOEXT=`"$GAUCHE_CONFIG" --so-suffix`
@@ -46,6 +60,16 @@ AC_SUBST(OBJEXT)
 AC_SUBST(EXEEXT)
 
 ac_default_prefix=`"$GAUCHE_CONFIG" --prefix`
+
+dnl On MSYS2/MinGW-w64, we must overwrite 'prefix' because
+dnl /mingw64/etc/config.site sets prefix=/mingw64 .
+case "$MSYSTEM" in
+  MINGW64|MINGW32)
+    case "$prefix" in
+      /mingw64|/mingw32)
+        prefix=`"$GAUCHE_CONFIG" --prefix`;;
+    esac;;
+esac
 
 GAUCHE_PKGINCDIR=`"$GAUCHE_CONFIG" --pkgincdir`
 GAUCHE_PKGLIBDIR=`"$GAUCHE_CONFIG" --pkglibdir`

--- a/ext/template.extensionlib.stub
+++ b/ext/template.extensionlib.stub
@@ -8,8 +8,8 @@
 ;; The following entry is a dummy one.
 ;; Replace it for your definitions.
 
-(define-cproc test-@@extname@@ () ::<const-cstring>
-  (result "@@extname@@ is working"))
+(define-cproc test-@@extname@@ ()
+  (return (test_@@extname@@)))
 
 
 ;; Local variables:

--- a/ext/template.util-config.scm
+++ b/ext/template.util-config.scm
@@ -1,0 +1,36 @@
+;;;
+;;; Utility of configure
+;;;
+(define-module util-config
+  (use gauche.configure)
+  (use gauche.version)
+  (export cf-init-gauche-extension))
+(select-module util-config)
+
+;; For the compatibility to Gauche 0.9.7 - 0.9.9
+(define (cf-init-gauche-extension)
+
+  ;; Call original procedure
+  (if (global-variable-bound? 'gauche.configure 'cf-init-gauche-extension)
+    ((with-module gauche.configure cf-init-gauche-extension))
+    (error "procedure 'cf-init-gauche-extension' not found.\n\
+           Gauche 0.9.7 or later is required.  Aborting."))
+
+  ;; For Gauche 0.9.9 or earlier
+  (when (version<=? (gauche-version) "0.9.9")
+    ;; C build settings
+    (unless (cf-have-subst? 'CFLAGS)
+      (cf-subst 'CFLAGS (gauche-config "--default-cflags")))
+    (unless (cf-have-subst? 'CPPFLAGS) (cf-subst 'CPPFLAGS ""))
+    (unless (cf-have-subst? 'LDFLAGS)  (cf-subst 'LDFLAGS  ""))
+    (unless (cf-have-subst? 'LIBS)     (cf-subst 'LIBS     ""))
+
+    ;; For Windows Unicode support
+    (cond-expand
+     [(and gauche.os.windows gauche.ces.utf8)
+      (unless (#/(^-|\s+-)DUNICODE\b/ (cf$ 'CPPFLAGS))
+        (cf-subst-append 'CPPFLAGS "-DUNICODE"))]
+     [else])
+    )
+  )
+

--- a/lib/gauche/configure.scm
+++ b/lib/gauche/configure.scm
@@ -338,17 +338,17 @@
 
   ;; NB: Autoconf uses AC_PROG_CC to set up CC.  However, we need
   ;; to use the same C compiler with which Gauche was compiled, so
-  ;; so we set it as the default.  We also allow env overrides for
-  ;; some common variables.  (In autoconf, AC_PROG_CC issues AC_ARG_VAR
+  ;; we set it as the default.  We also allow env overrides for some
+  ;; common variables.  (In autoconf, AC_PROG_CC issues AC_ARG_VAR
   ;; for them).
   (cf-subst 'CC       (gauche-config "--cc"))
   (cf-arg-var 'CPP)
-  (cf-arg-var 'CPPFALGS)
+  (cf-arg-var 'CPPFLAGS)
   (cf-arg-var 'CC)
   (cf-arg-var 'CFLAGS)
   (cf-arg-var 'LDFLAGS)
   (cf-arg-var 'LIBS)
-  ;; NB: Autoconf detemines these through tests, but we already
+  ;; NB: Autoconf determines these through tests, but we already
   ;; know them at the time Gauche is configured.
   (cf-subst 'SOEXT  (gauche-config "--so-suffix"))
   (cf-subst 'OBJEXT (gauche-config "--object-suffix"))
@@ -600,8 +600,22 @@
   (cf-path-prog 'GAUCHE_INSTALL  "gauche-install")
   (cf-path-prog 'GAUCHE_CESCONV  "gauche-cesconv")
 
+  ;; C build settings
+  (unless (cf-have-subst? 'CFLAGS)
+    (cf-subst 'CFLAGS (gauche-config "--default-cflags")))
+  (unless (cf-have-subst? 'CPPFLAGS) (cf-subst 'CPPFLAGS ""))
+  (unless (cf-have-subst? 'LDFLAGS)  (cf-subst 'LDFLAGS  ""))
+  (unless (cf-have-subst? 'LIBS)     (cf-subst 'LIBS     ""))
+
+  ;; For Windows Unicode support
+  (cond-expand
+   [(and gauche.os.windows gauche.ces.utf8)
+    (unless (#/(^-|\s+-)DUNICODE\b/ (cf$ 'CPPFLAGS))
+      (cf-subst-append 'CPPFLAGS "-DUNICODE"))]
+   [else])
+
   (cf-subst 'default_prefix (gauche-config "--prefix"))
- 
+
   (cf-subst 'GAUCHE_PKGINCDIR  (gauche-config "--pkgincdir"))
   (cf-subst 'GAUCHE_PKGLIBDIR  (gauche-config "--pkglibdir"))
   (cf-subst 'GAUCHE_PKGARCHDIR (gauche-config "--pkgarchdir"))

--- a/src/gauche-package.in
+++ b/src/gauche-package.in
@@ -396,10 +396,12 @@ Options:
              [tmpl-dir (sys-dirname (gauche-library-directory))]
              [scm-subdir (sys-dirname (module-name->path module-name))])
         (make-directory* (simplify-path (build-path package-name scm-subdir)))
-        (dolist [file (cons (if autoconf "configure.ac" "configure")
-                            '("package.scm" "Makefile.in" "extension.c"
-                              "extension.h" "extensionlib.stub"
-                              "module.scm" "test.scm"))]
+        (dolist [file (append (if autoconf
+                                '("configure.ac")
+                                '("configure" "util-config.scm"))
+                              '("package.scm" "Makefile.in" "extension.c"
+                                "extension.h" "extensionlib.stub"
+                                "module.scm" "test.scm"))]
           (let* ([src-path (build-path tmpl-dir #"template.~file")]
                  [dst-name (regexp-replace*
                             file

--- a/test/scripts.scm
+++ b/test/scripts.scm
@@ -179,6 +179,7 @@
     (filter-copy (build-path extdir "template.configure") "test.o/configure")
     (filter-copy (build-path extdir "template.package.scm") "test.o/package.scm")
     (filter-copy (build-path extdir "template.Makefile.in") "test.o/Makefile.in")
+    (filter-copy (build-path extdir "template.util-config.scm") "test.o/util-config.scm")
 
     (with-output-to-file "test.o/src/Makefile.in"
       (^[]


### PR DESCRIPTION
拡張ライブラリのテンプレートをいくつか変更しました。
(毎回手作業で変更していたので。。。)

- Makefile に CFLAGS, CPPFLAGS, LDFLAGS, LIBS の項目を追加
  (CFLAGS が空のときは、`gauche-config --default-cflags` の内容を設定するようにした)
  現状、Gauche 0.9.9 以前でも動作するように、lib/gauche/configure.scm と
  ext/template.configure に同じ処理を記述しています。
  (こうしないと、リリースされている Gauche で使用できないため)

- Windows で内部エンコーディングが utf-8 のときは、
  CPPFLAGS に -DUNICODE を追加するようにした。
  (Gauche 本体と不一致になるとややこしいため)

- configure.ac で MSYS2/MinGW-w64 のときは、prefix を上書きするようにした
  ( /mingw64/etc/config.site が、prefix を /mingw64 に固定してくるため)

- Makefile にヘッダーファイルの依存関係の設定を追加

- stub ファイルのダミー手続きでは、実際に C の関数を呼ぶようにした

- その他、タイポの修正等

＜テスト結果＞
(1) https://ci.appveyor.com/project/Hamayama/gauche/builds/30039916

(2) template.configure のテスト ==> OK
```
gauche-package generate test_ext2
cd test_ext2
./configure
make
make install
make check
```

(3) template.configure.ac のテスト ==> OK
```
gauche-package generate --autoconf test_ext_ac
cd test_ext_ac
autoconf
./configure
make
make install
make check
```
