### PR TITLE
Add SCM_NORETURN to Scm_Error() and friends

### DIFF
--- a/src/gauche.h
+++ b/src/gauche.h
@@ -1785,11 +1785,11 @@ enum {
 };
 
 /* Throwing error */
-SCM_EXTERN void Scm_Error(const char *msg, ...);
-SCM_EXTERN void Scm_SysError(const char *msg, ...);
+SCM_EXTERN void Scm_Error(const char *msg, ...) SCM_NORETURN;
+SCM_EXTERN void Scm_SysError(const char *msg, ...) SCM_NORETURN;
 SCM_EXTERN void Scm_TypeError(const char *what,
-                              const char *expected, ScmObj got);
-SCM_EXTERN void Scm_PortError(ScmPort *port, int reason, const char *msg, ...);
+                              const char *expected, ScmObj got) SCM_NORETURN;
+SCM_EXTERN void Scm_PortError(ScmPort *port, int reason, const char *msg, ...) SCM_NORETURN;
 
 /* common pattern */
 #define SCM_TYPE_ERROR(arg, expected)  Scm_TypeError(#arg, expected, arg)


### PR DESCRIPTION
These function end with Scm_Panic() which is SCM_NORETURN. gcc can't see
that though because Scm_Error() may be compiled separately from its
caller and may warn about not returning value in the caller.