### PR TITLE
Add <string-cursor> type and basic operations (#567)

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -3479,6 +3479,7 @@ void Scm__InitClass(void)
 
     /* string.c */
     CINIT(SCM_CLASS_STRING,           "<string>");
+    CINIT(SCM_CLASS_STRING_CURSOR,    "<string-cursor>");
     CINIT(SCM_CLASS_STRING_POINTER,   "<string-pointer>");
 
     /* symbol.c */

--- a/src/gauche.h
+++ b/src/gauche.h
@@ -532,6 +532,7 @@ typedef struct ScmLazyPairRec       ScmLazyPair;
 typedef struct ScmCharSetRec        ScmCharSet;
 typedef struct ScmStringRec         ScmString;
 typedef struct ScmDStringRec        ScmDString;
+typedef struct ScmStringCursorRec   ScmCursor;
 typedef struct ScmVectorRec         ScmVector;
 typedef struct ScmBignumRec         ScmBignum;
 typedef struct ScmRatnumRec         ScmRatnum;

--- a/src/gauche/string.h
+++ b/src/gauche/string.h
@@ -71,8 +71,8 @@
 */
 typedef struct ScmStringBodyRec {
     u_long flags;
-    ScmSmallInt length;
-    ScmSmallInt size;
+    ScmSmallInt length;         /* in characters */
+    ScmSmallInt size;           /* in bytes */
     const char *start;
 } ScmStringBody;
 
@@ -403,5 +403,26 @@ SCM_EXTERN ScmObj Scm_StringPointerSubstring(ScmStringPointer *sp, int beforep);
 SCM_EXTERN ScmObj Scm_StringPointerCopy(ScmStringPointer *sp);
 SCM_EXTERN void   Scm_StringPointerDump(ScmStringPointer *sp);
 
-#endif /* GAUCHE_STRING_H */
+/*
+ * (Immutable) String cursors
+ */
+typedef struct ScmStringCursorRec {
+    SCM_HEADER;
+    const char *cursor;
+} ScmStringCursor;
 
+SCM_CLASS_DECL(Scm_StringCursorClass);
+#define SCM_CLASS_STRING_CURSOR      (&Scm_StringCursorClass)
+#define SCM_STRING_CURSORP(obj)      SCM_XTYPEP(obj, SCM_CLASS_STRING_CURSOR)
+#define SCM_STRING_CURSOR(obj)       ((ScmStringCursor*)obj)
+#define SCM_STRING_CURSOR_PTR(obj)   ((obj)->cursor)
+
+SCM_EXTERN ScmObj Scm_MakeStringCursorFromIndex(ScmString *src, ScmSmallInt index);
+SCM_EXTERN ScmObj Scm_MakeStringCursorEnd(ScmString *src);
+SCM_EXTERN ScmObj Scm_StringCursorIndex(ScmString *s, ScmObj sc);
+SCM_EXTERN ScmObj Scm_StringCursorStart(ScmString* s);
+SCM_EXTERN ScmObj Scm_StringCursorEnd(ScmString* s);
+SCM_EXTERN ScmObj Scm_StringCursorForward(ScmString* s, ScmObj cursor, int nchars);
+SCM_EXTERN ScmObj Scm_StringCursorBack(ScmString* s, ScmObj cursor, int nchars);
+
+#endif /* GAUCHE_STRING_H */

--- a/src/libstr.scm
+++ b/src/libstr.scm
@@ -407,3 +407,73 @@
 (select-module gauche.internal)
 (define-cproc %string-pointer-dump (sp::<string-pointer>) ::<void>
   Scm_StringPointerDump)
+
+;;
+;; String cursors
+;;
+
+(select-module gauche)
+(inline-stub
+ ;; string pointer
+ (define-type <string-cursor> "ScmStringCursor*" "string cursor"
+   "SCM_STRING_CURSORP" "SCM_STRING_CURSOR")
+ )
+
+(define-cproc string-cursor? (obj) ::<boolean> SCM_STRING_CURSORP)
+(define-cproc string-cursor-start (s::<string>)
+  (return (Scm_MakeStringCursorFromIndex s 0)))
+(define-cproc string-cursor-end (s::<string>)
+  Scm_MakeStringCursorEnd)
+(define-cproc string-cursor-next (s::<string> cursor)
+  (return (Scm_StringCursorForward s cursor 1)))
+(define-cproc string-cursor-prev (s::<string> cursor)
+  (return (Scm_StringCursorBack s cursor 1)))
+(define-cproc string-cursor-forward (s::<string> cursor nchars::<fixnum>)
+  Scm_StringCursorForward)
+(define-cproc string-cursor-back (s::<string> cursor nchars::<fixnum>)
+  Scm_StringCursorBack)
+(define-cproc string-index->cursor (s::<string> index)
+  (if (SCM_STRING_CURSORP index)
+      (return index)
+      (return (Scm_MakeStringCursorFromIndex s (Scm_GetInteger index)))))
+(define-cproc string-cursor->index (s::<string> cursor)
+  Scm_StringCursorIndex)
+
+(define-cproc string-cursor=? (cursor1 cursor2) ::<boolean>
+  (if (and (SCM_STRING_CURSORP cursor1)
+           (SCM_STRING_CURSORP cursor2))
+    (return (== (SCM_STRING_CURSOR_PTR (SCM_STRING_CURSOR cursor1))
+                (SCM_STRING_CURSOR_PTR (SCM_STRING_CURSOR cursor2))))
+    (return (Scm_NumEq cursor1 cursor2))))
+
+(define-cproc string-cursor<? (cursor1 cursor2) ::<boolean>
+  (if (and (SCM_STRING_CURSORP cursor1)
+           (SCM_STRING_CURSORP cursor2))
+    (return (< (SCM_STRING_CURSOR_PTR (SCM_STRING_CURSOR cursor1))
+               (SCM_STRING_CURSOR_PTR (SCM_STRING_CURSOR cursor2))))
+    (return (Scm_NumLT cursor1 cursor2))))
+
+(define-cproc string-cursor>? (cursor1 cursor2) ::<boolean>
+  (if (and (SCM_STRING_CURSORP cursor1)
+           (SCM_STRING_CURSORP cursor2))
+    (return (> (SCM_STRING_CURSOR_PTR (SCM_STRING_CURSOR cursor1))
+               (SCM_STRING_CURSOR_PTR (SCM_STRING_CURSOR cursor2))))
+    (return (Scm_NumGT cursor1 cursor2))))
+
+(define-cproc string-cursor<=? (cursor1 cursor2) ::<boolean>
+  (if (and (SCM_STRING_CURSORP cursor1)
+           (SCM_STRING_CURSORP cursor2))
+    (return (<= (SCM_STRING_CURSOR_PTR (SCM_STRING_CURSOR cursor1))
+                (SCM_STRING_CURSOR_PTR (SCM_STRING_CURSOR cursor2))))
+    (return (Scm_NumLE cursor1 cursor2))))
+
+(define-cproc string-cursor>=? (cursor1 cursor2) ::<boolean>
+  (if (and (SCM_STRING_CURSORP cursor1)
+           (SCM_STRING_CURSORP cursor2))
+    (return (>= (SCM_STRING_CURSOR_PTR (SCM_STRING_CURSOR cursor1))
+                (SCM_STRING_CURSOR_PTR (SCM_STRING_CURSOR cursor2))))
+    (return (Scm_NumGE cursor1 cursor2))))
+
+(define-cproc string-cursor-diff (s::<string> start end)
+  (return (Scm_Sub (Scm_StringCursorIndex s end)
+                   (Scm_StringCursorIndex s start))))


### PR DESCRIPTION
These are from SRFI 130. They will be put in srfi-130 library later but
right now (and probably forever) they are part of Gauche builtin
library. This only covers the "Cursor operations" part of the SRFI.

This adds a new cursor type, disjoint from fixnum, to represent the
cursor. We can move forward and backward faster with this, but
converting to index will be slower. Single byte strings have separate
code paths to speed it up because we probably deal with ASCII most of
the time.