### PR TITLE
Fix <string-pointer>'s size calculation

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -1414,7 +1414,7 @@ ScmObj Scm_MakeStringPointer(ScmString *src, ScmSmallInt index,
         } else {
             eptr = forward_pos(sptr, end - start);
         }
-        effective_size = eptr - ptr;
+        effective_size = eptr - sptr;
     }
     ScmStringPointer *sp = SCM_NEW(ScmStringPointer);
     SCM_SET_CLASS(sp, SCM_CLASS_STRING_POINTER);


### PR DESCRIPTION
The field "size" is supposed to cover from "start" to "end", not "index"
to "end". In the multibyte code path we calculate it as "index" to "end"
instead. This problem probably does not show up because most of the time
we execute the single-byte code path.

(Detected by removing the special single-byte code path, moving the
optimization inside forward_pos(), then 'make test' fails)