### PR TITLE
Support cursors in basic string procedures

### DIFF
--- a/src/gauche/string.h
+++ b/src/gauche/string.h
@@ -426,5 +426,6 @@ SCM_EXTERN ScmObj Scm_StringCursorEnd(ScmString* s);
 SCM_EXTERN ScmObj Scm_StringCursorForward(ScmString* s, ScmObj cursor, int nchars);
 SCM_EXTERN ScmObj Scm_StringCursorBack(ScmString* s, ScmObj cursor, int nchars);
 SCM_EXTERN ScmChar Scm_StringRefCursor(ScmString* s, ScmObj sc, int range_error);
+SCM_EXTERN ScmObj Scm_SubstringCursor(ScmString *str, ScmObj start, ScmObj end);
 
 #endif /* GAUCHE_STRING_H */

--- a/src/gauche/string.h
+++ b/src/gauche/string.h
@@ -425,5 +425,6 @@ SCM_EXTERN ScmObj Scm_StringCursorStart(ScmString* s);
 SCM_EXTERN ScmObj Scm_StringCursorEnd(ScmString* s);
 SCM_EXTERN ScmObj Scm_StringCursorForward(ScmString* s, ScmObj cursor, int nchars);
 SCM_EXTERN ScmObj Scm_StringCursorBack(ScmString* s, ScmObj cursor, int nchars);
+SCM_EXTERN ScmChar Scm_StringRefCursor(ScmString* s, ScmObj sc, int range_error);
 
 #endif /* GAUCHE_STRING_H */

--- a/src/gauche/string.h
+++ b/src/gauche/string.h
@@ -116,6 +116,7 @@ SCM_CLASS_DECL(Scm_StringClass);
 #define SCM_STRING_BODY_LENGTH(body)       ((body)->length)
 #define SCM_STRING_BODY_SIZE(body)         ((body)->size)
 #define SCM_STRING_BODY_START(body)        ((body)->start)
+#define SCM_STRING_BODY_END(body)          ((body)->start + (body)->size)
 #define SCM_STRING_BODY_FLAGS(body)        ((body)->flags)
 
 #define SCM_STRING_BODY_HAS_FLAG(body, flag) \

--- a/src/libstr.scm
+++ b/src/libstr.scm
@@ -101,8 +101,8 @@
   :constant
   (let* ([r::ScmChar (Scm_StringRefCursor str k (SCM_UNBOUNDP fallback))])
     (return (?: (== r SCM_CHAR_INVALID) fallback (SCM_MAKE_CHAR r)))))
-(define-cproc substring (str::<string> start::<fixnum> end::<fixnum>)
-  (return (Scm_Substring str start end FALSE)))
+(define-cproc substring (str::<string> start end)
+  (return (Scm_SubstringCursor str start end)))
 
 (select-module gauche)
 (define-cproc string-size (str::<string>) ::<fixnum> :constant

--- a/src/libstr.scm
+++ b/src/libstr.scm
@@ -97,9 +97,9 @@
 (select-module scheme)
 (define-cproc string-length (str::<string>) ::<fixnum> :constant
   (return (SCM_STRING_BODY_LENGTH (SCM_STRING_BODY str))))
-(define-cproc string-ref (str::<string> k::<fixnum> :optional fallback)
+(define-cproc string-ref (str::<string> k :optional fallback)
   :constant
-  (let* ([r::ScmChar (Scm_StringRef str k (SCM_UNBOUNDP fallback))])
+  (let* ([r::ScmChar (Scm_StringRefCursor str k (SCM_UNBOUNDP fallback))])
     (return (?: (== r SCM_CHAR_INVALID) fallback (SCM_MAKE_CHAR r)))))
 (define-cproc substring (str::<string> start::<fixnum> end::<fixnum>)
   (return (Scm_Substring str start end FALSE)))

--- a/src/string.c
+++ b/src/string.c
@@ -785,7 +785,7 @@ static ScmObj substring(const ScmStringBody *xb,
         if (start) s = forward_pos(SCM_STRING_BODY_START(xb), start);
         else s = SCM_STRING_BODY_START(xb);
         if (len == end) {
-            e = SCM_STRING_BODY_START(xb) + SCM_STRING_BODY_SIZE(xb);
+            e = SCM_STRING_BODY_END(xb);
         } else {
             e = forward_pos(s, end - start);
             flags &= ~SCM_STRING_TERMINATED;
@@ -1410,7 +1410,7 @@ ScmObj Scm_MakeStringPointer(ScmString *src, ScmSmallInt index,
         sptr = forward_pos(SCM_STRING_BODY_START(srcb), start);
         ptr = forward_pos(sptr, index);
         if (end == len) {
-            eptr = SCM_STRING_BODY_START(srcb) + SCM_STRING_BODY_SIZE(srcb);
+            eptr = SCM_STRING_BODY_END(srcb);
         } else {
             eptr = forward_pos(sptr, end - start);
         }
@@ -1562,7 +1562,7 @@ static ScmObj Scm_MakeStringCursor(ScmString *src, const char *cursor)
         Scm_Error("making a cursor of incomplete strings is not supported");
     }
     if (cursor < SCM_STRING_BODY_START(srcb) ||
-        cursor > SCM_STRING_BODY_START(srcb) + SCM_STRING_BODY_SIZE(srcb)) {
+        cursor > SCM_STRING_BODY_END(srcb)) {
         Scm_Error("cursor out of range");
     }
 
@@ -1592,7 +1592,7 @@ ScmObj Scm_MakeStringCursorEnd(ScmString *src)
 
     ScmStringCursor *sc = SCM_NEW(ScmStringCursor);
     SCM_SET_CLASS(sc, SCM_CLASS_STRING_CURSOR);
-    sc->cursor = SCM_STRING_BODY_START(srcb) + SCM_STRING_BODY_SIZE(srcb);
+    sc->cursor = SCM_STRING_BODY_END(srcb);
     return SCM_OBJ(sc);
 }
 

--- a/src/string.c
+++ b/src/string.c
@@ -1578,7 +1578,7 @@ ScmObj Scm_MakeStringCursorFromIndex(ScmString *src, ScmSmallInt index)
     if (index < 0 || index > len) {
         Scm_Error("index out of range: %ld", index);
     }
-    return Scm_MakeStringCursor(src, SCM_STRING_BODY_START(srcb) + index);
+    return Scm_MakeStringCursor(src, forward_pos(srcb, SCM_STRING_BODY_START(srcb), index));
 }
 
 ScmObj Scm_MakeStringCursorEnd(ScmString *src)

--- a/src/string.c
+++ b/src/string.c
@@ -1680,6 +1680,36 @@ ScmObj Scm_StringCursorBack(ScmString* s, ScmObj sc, int nchars)
     return Scm_MakeStringCursor(s, new_cursor);
 }
 
+ScmChar Scm_StringRefCursor(ScmString* s, ScmObj sc, int range_error)
+{
+    const ScmStringBody *b = SCM_STRING_BODY(s);
+    ScmSmallInt size = SCM_STRING_BODY_SIZE(b);
+
+    if (SCM_STRING_BODY_INCOMPLETE_P(b)) {
+        Scm_Error("incomplete string not allowed : %S", SCM_OBJ(s));
+    }
+
+    if (SCM_INTP(sc)) {
+        return Scm_StringRef(s, SCM_INT_VALUE(sc), range_error);
+    }
+    if (!SCM_STRING_CURSORP(sc)) {
+        Scm_Error("expected an integer or <string-cursor>, got: %S", sc);
+    }
+
+    ScmStringCursor *c = SCM_STRING_CURSOR(sc);
+    if (c->cursor < SCM_STRING_BODY_START(b) ||
+        c->cursor >= SCM_STRING_BODY_START(b) + size) {
+        if (range_error) {
+            Scm_Error("argument out of range of string %S", SCM_OBJ(s));
+        } else {
+            return SCM_CHAR_INVALID;
+        }
+    }
+    ScmChar ch;
+    SCM_CHAR_GET(c->cursor, ch);
+    return ch;
+}
+
 /*==================================================================
  *
  * Dynamic strings

--- a/src/string.c
+++ b/src/string.c
@@ -1563,7 +1563,7 @@ static ScmObj Scm_MakeStringCursor(ScmString *src, const char *cursor)
     }
     if (cursor < SCM_STRING_BODY_START(srcb) ||
         cursor > SCM_STRING_BODY_END(srcb)) {
-        Scm_Error("cursor out of range");
+        Scm_Error("cursor out of range of %S", SCM_OBJ(src));
     }
 
     ScmStringCursor *sc = SCM_NEW(ScmStringCursor);
@@ -1603,7 +1603,7 @@ ScmObj Scm_StringCursorIndex(ScmString *src, ScmObj sc)
     }
 
     if (!SCM_STRING_CURSORP(sc)) {
-        Scm_Error("must be either an index or a cursor: %S", sc);
+        Scm_Error("must be either an index or a cursor on string %S", SCM_OBJ(src));
     }
 
     ScmStringCursor     *c       = SCM_STRING_CURSOR(sc);
@@ -1612,7 +1612,7 @@ ScmObj Scm_StringCursorIndex(ScmString *src, ScmObj sc)
 
     if (c->cursor < current ||
         c->cursor > current + SCM_STRING_BODY_SIZE(srcb)) {
-        Scm_Error("cursor out of range");
+        Scm_Error("cursor out of range of string %S", SCM_OBJ(src));
     }
 
     if (SCM_STRING_BODY_SINGLE_BYTE_P(srcb)) {
@@ -1626,7 +1626,7 @@ ScmObj Scm_StringCursorIndex(ScmString *src, ScmObj sc)
         index++;
     }
     if (current != c->cursor) {
-        Scm_Error("bad cursor");
+        Scm_Error("bad cursor of string %S", SCM_OBJ(src));
     }
 
     return SCM_MAKE_INT(index);
@@ -1666,7 +1666,7 @@ ScmObj Scm_StringCursorBack(ScmString* s, ScmObj sc, int nchars)
     }
 
     if (!SCM_STRING_CURSORP(sc)) {
-        Scm_Error("must be either an index or a cursor: %S", sc);
+        Scm_Error("must be either an index or a cursor of string %S", SCM_OBJ(s));
     }
 
     const ScmStringBody *srcb = SCM_STRING_BODY(s);

--- a/test/euc-jp.scm
+++ b/test/euc-jp.scm
@@ -131,6 +131,77 @@
 (test* "string-pointer-prev!" #\ﾞ (string-pointer-prev! sp))
 
 ;;-------------------------------------------------------------------
+(test-section "string-cursor")
+
+(define str "いろはにhoへと")
+(define ss #f)
+(define se #f)
+(test* "string-cursor-start" #t
+       (begin
+         (set! ss (string-cursor-start str))
+         (string-cursor? ss)))
+(test* "string-cursor-start" #t
+       (begin
+         (set! se (string-cursor-end str))
+         (string-cursor? se)))
+(test* "string-cursor-next" #\ろ
+       (string-ref str (string-cursor-next str ss)))
+(test* "string-cursor-forward" #\に
+       (string-ref str (string-cursor-forward str ss 3)))
+(test* "string-cursor-prev" #\と
+       (string-ref str (string-cursor-prev str se)))
+(test* "string-cursor-back" #\に
+       (string-ref str (string-cursor-back str se 5)))
+(test* "string-index->cursor" #\へ
+       (string-ref str (string-index->cursor str 6)))
+(test* "string-cursor->index" 0
+       (string-cursor->index str ss))
+(test* "string-cursor->index" 8
+       (string-cursor->index str se))
+(test* "substring with cursors" "はにho"
+       (substring str
+                  (string-cursor-forward str ss 2)
+                  (string-cursor-back str se 2)))
+(test* "substring with cursors" "はにho"
+       (substring str
+                  2
+                  (string-cursor-back str se 2)))
+(test* "substring with cursors" "はにh"
+       (substring str
+                  (string-cursor-forward str ss 2)
+                  5))
+(test* "string->list" '(#\ろ #\は #\に #\h #\o #\へ)
+       (string->list str
+                     (string-cursor-next str ss)
+                     (string-cursor-prev str se)))
+(test* "string->list" '(#\ろ #\は #\に #\h #\o #\へ)
+       (string->list str
+                     1
+                     (string-cursor-prev str se)))
+(test* "string->list" '(#\ろ #\は #\に #\h #\o #\へ)
+       (string->list str
+                     (string-cursor-next str ss)
+                     7))
+(test* "string-cursor=?" #t
+       (string-cursor=? ss (string-cursor-back str se 8)))
+(test* "string-cursor=?" #t
+       (string-cursor=? 0 0))
+(test* "string-cursor<?" #t
+       (string-cursor<? ss se))
+(test* "string-cursor<=?" #t
+       (string-cursor<=? ss se))
+(test* "string-cursor<=?" #t
+       (string-cursor<=? ss ss))
+(test* "string-cursor>?" #t
+       (string-cursor>? se ss))
+(test* "string-cursor>=?" #t
+       (string-cursor>=? se se))
+(test* "string-cursor-diff" 8
+       (string-cursor-diff str ss se))
+(test* "string-cursor-diff" -8
+       (string-cursor-diff str se ss))
+
+;;-------------------------------------------------------------------
 (test-section "incomplete strings")
 
 (test* "string-length" 6 (string-length #*"あいう"))

--- a/test/sjis.scm
+++ b/test/sjis.scm
@@ -146,6 +146,77 @@
                (string-pointer-substring sp :after #t))))
 
 ;;-------------------------------------------------------------------
+(test-section "string-cursor")
+
+(define str "‚¢‚ë‚Í‚Ého‚Ö‚Æ")
+(define ss #f)
+(define se #f)
+(test* "string-cursor-start" #t
+       (begin
+         (set! ss (string-cursor-start str))
+         (string-cursor? ss)))
+(test* "string-cursor-start" #t
+       (begin
+         (set! se (string-cursor-end str))
+         (string-cursor? se)))
+(test* "string-cursor-next" #\‚ë
+       (string-ref str (string-cursor-next str ss)))
+(test* "string-cursor-forward" #\‚É
+       (string-ref str (string-cursor-forward str ss 3)))
+(test* "string-cursor-prev" #\‚Æ
+       (string-ref str (string-cursor-prev str se)))
+(test* "string-cursor-back" #\‚É
+       (string-ref str (string-cursor-back str se 5)))
+(test* "string-index->cursor" #\‚Ö
+       (string-ref str (string-index->cursor str 6)))
+(test* "string-cursor->index" 0
+       (string-cursor->index str ss))
+(test* "string-cursor->index" 8
+       (string-cursor->index str se))
+(test* "substring with cursors" "‚Í‚Ého"
+       (substring str
+                  (string-cursor-forward str ss 2)
+                  (string-cursor-back str se 2)))
+(test* "substring with cursors" "‚Í‚Ého"
+       (substring str
+                  2
+                  (string-cursor-back str se 2)))
+(test* "substring with cursors" "‚Í‚Éh"
+       (substring str
+                  (string-cursor-forward str ss 2)
+                  5))
+(test* "string->list" '(#\‚ë #\‚Í #\‚É #\h #\o #\‚Ö)
+       (string->list str
+                     (string-cursor-next str ss)
+                     (string-cursor-prev str se)))
+(test* "string->list" '(#\‚ë #\‚Í #\‚É #\h #\o #\‚Ö)
+       (string->list str
+                     1
+                     (string-cursor-prev str se)))
+(test* "string->list" '(#\‚ë #\‚Í #\‚É #\h #\o #\‚Ö)
+       (string->list str
+                     (string-cursor-next str ss)
+                     7))
+(test* "string-cursor=?" #t
+       (string-cursor=? ss (string-cursor-back str se 8)))
+(test* "string-cursor=?" #t
+       (string-cursor=? 0 0))
+(test* "string-cursor<?" #t
+       (string-cursor<? ss se))
+(test* "string-cursor<=?" #t
+       (string-cursor<=? ss se))
+(test* "string-cursor<=?" #t
+       (string-cursor<=? ss ss))
+(test* "string-cursor>?" #t
+       (string-cursor>? se ss))
+(test* "string-cursor>=?" #t
+       (string-cursor>=? se se))
+(test* "string-cursor-diff" 8
+       (string-cursor-diff str ss se))
+(test* "string-cursor-diff" -8
+       (string-cursor-diff str se ss))
+
+;;-------------------------------------------------------------------
 (test-section "incomplete strings")
 
 (test* "string-length" 6 (string-length #*"‚ ‚¢‚¤"))

--- a/test/string.scm
+++ b/test/string.scm
@@ -477,6 +477,77 @@
              (string-pointer-substring sp :after #t)))
 
 ;;-------------------------------------------------------------------
+(test-section "string-cursor")
+
+(define str "abcdefg")
+(define ss #f)
+(define se #f)
+(test* "string-cursor-start" #t
+       (begin
+         (set! ss (string-cursor-start str))
+         (string-cursor? ss)))
+(test* "string-cursor-start" #t
+       (begin
+         (set! se (string-cursor-end str))
+         (string-cursor? se)))
+(test* "string-cursor-next" #\b
+       (string-ref str (string-cursor-next str ss)))
+(test* "string-cursor-forward" #\d
+       (string-ref str (string-cursor-forward str ss 3)))
+(test* "string-cursor-prev" #\g
+       (string-ref str (string-cursor-prev str se)))
+(test* "string-cursor-back" #\d
+       (string-ref str (string-cursor-back str se 4)))
+(test* "string-index->cursor" #\f
+       (string-ref str (string-index->cursor str 5)))
+(test* "string-cursor->index" 0
+       (string-cursor->index str ss))
+(test* "string-cursor->index" 7
+       (string-cursor->index str se))
+(test* "substring with cursors" "cde"
+       (substring str
+                  (string-cursor-forward str ss 2)
+                  (string-cursor-back str se 2)))
+(test* "substring with cursors" "cde"
+       (substring str
+                  2
+                  (string-cursor-back str se 2)))
+(test* "substring with cursors" "cde"
+       (substring str
+                  (string-cursor-forward str ss 2)
+                  5))
+(test* "string->list" '(#\b #\c #\d #\e #\f)
+       (string->list str
+                     (string-cursor-next str ss)
+                     (string-cursor-prev str se)))
+(test* "string->list" '(#\b #\c #\d #\e #\f)
+       (string->list str
+                     1
+                     (string-cursor-prev str se)))
+(test* "string->list" '(#\b #\c #\d #\e #\f)
+       (string->list str
+                     (string-cursor-next str ss)
+                     6))
+(test* "string-cursor=?" #t
+       (string-cursor=? ss (string-cursor-back str se 7)))
+(test* "string-cursor=?" #t
+       (string-cursor=? 0 0))
+(test* "string-cursor<?" #t
+       (string-cursor<? ss se))
+(test* "string-cursor<=?" #t
+       (string-cursor<=? ss se))
+(test* "string-cursor<=?" #t
+       (string-cursor<=? ss ss))
+(test* "string-cursor>?" #t
+       (string-cursor>? se ss))
+(test* "string-cursor>=?" #t
+       (string-cursor>=? se se))
+(test* "string-cursor-diff" 7
+       (string-cursor-diff str ss se))
+(test* "string-cursor-diff" -7
+       (string-cursor-diff str se ss))
+
+;;-------------------------------------------------------------------
 (test-section "input string port")
 
 ;; These also tests port's ungetc and scratch buffer, and

--- a/test/utf-8.scm
+++ b/test/utf-8.scm
@@ -126,6 +126,77 @@
               (string-pointer-substring sp :after #t))))
 
 ;;-------------------------------------------------------------------
+(test-section "string-cursor")
+
+(define str "いろはにhoへと")
+(define ss #f)
+(define se #f)
+(test* "string-cursor-start" #t
+       (begin
+         (set! ss (string-cursor-start str))
+         (string-cursor? ss)))
+(test* "string-cursor-start" #t
+       (begin
+         (set! se (string-cursor-end str))
+         (string-cursor? se)))
+(test* "string-cursor-next" #\ろ
+       (string-ref str (string-cursor-next str ss)))
+(test* "string-cursor-forward" #\に
+       (string-ref str (string-cursor-forward str ss 3)))
+(test* "string-cursor-prev" #\と
+       (string-ref str (string-cursor-prev str se)))
+(test* "string-cursor-back" #\に
+       (string-ref str (string-cursor-back str se 5)))
+(test* "string-index->cursor" #\へ
+       (string-ref str (string-index->cursor str 6)))
+(test* "string-cursor->index" 0
+       (string-cursor->index str ss))
+(test* "string-cursor->index" 8
+       (string-cursor->index str se))
+(test* "substring with cursors" "はにho"
+       (substring str
+                  (string-cursor-forward str ss 2)
+                  (string-cursor-back str se 2)))
+(test* "substring with cursors" "はにho"
+       (substring str
+                  2
+                  (string-cursor-back str se 2)))
+(test* "substring with cursors" "はにh"
+       (substring str
+                  (string-cursor-forward str ss 2)
+                  5))
+(test* "string->list" '(#\ろ #\は #\に #\h #\o #\へ)
+       (string->list str
+                     (string-cursor-next str ss)
+                     (string-cursor-prev str se)))
+(test* "string->list" '(#\ろ #\は #\に #\h #\o #\へ)
+       (string->list str
+                     1
+                     (string-cursor-prev str se)))
+(test* "string->list" '(#\ろ #\は #\に #\h #\o #\へ)
+       (string->list str
+                     (string-cursor-next str ss)
+                     7))
+(test* "string-cursor=?" #t
+       (string-cursor=? ss (string-cursor-back str se 8)))
+(test* "string-cursor=?" #t
+       (string-cursor=? 0 0))
+(test* "string-cursor<?" #t
+       (string-cursor<? ss se))
+(test* "string-cursor<=?" #t
+       (string-cursor<=? ss se))
+(test* "string-cursor<=?" #t
+       (string-cursor<=? ss ss))
+(test* "string-cursor>?" #t
+       (string-cursor>? se ss))
+(test* "string-cursor>=?" #t
+       (string-cursor>=? se se))
+(test* "string-cursor-diff" 8
+       (string-cursor-diff str ss se))
+(test* "string-cursor-diff" -8
+       (string-cursor-diff str se ss))
+
+;;-------------------------------------------------------------------
 (test-section "incomplete strings")
 
 (test "string-length" 9 (lambda () (string-length #*"あいう")))


### PR DESCRIPTION
This is the second part of #567. r7rs procedures are updated to handle both indexes and cursors. As a consequence of updating `%maybe-substring`, a bunch other procedures may support cursors as well, but I haven't checked them all.

The first four commits are cleanups and bugfixes. The next three add support to string-ref, substring and string->list respectively.

One thing I haven't really thought through is whether cursor-based should be the core code and other functions that take indexes should be just wrappers around it. While it sounds better, it's not clear if there's significant performance improvement to justify changing all proven-working code. Right now I basically just add cursor stuff on top.

Cursor code is not extensively tested (I just have a small scm file to run through and check output manually). That would be the next commit if things go well.