### PR TITLE
Fix Scm_MaybeSubstring() when start cursor is used

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -859,7 +859,8 @@ ScmObj Scm_MaybeSubstring(ScmString *x, ScmObj start, ScmObj end)
         Scm_Error("exact integer or cursor required for start, but got %S", start);
 
     if (no_end) {
-        if (istart == 0 || cstart == SCM_STRING_CURSOR(start)) {
+        if ((!cstart && istart == 0) ||
+            (cstart && cstart->cursor == SCM_STRING_BODY_START(xb))) {
             return SCM_OBJ(x);
         }
         iend = SCM_STRING_BODY_LENGTH(xb);


### PR DESCRIPTION
There are two problems with d7872206f (Update Scm_MaybeSubstring to
support cursors, 2020-01-27). The first one is when "start" is a cursor
and no "end" is specified, e.g.

    (string-copy str (string-cursor-start str))

we fail to check that "start" is the start of a string in order to
return the original string unchanged, because I used wrong macro, sigh.

Secondly, istart is not always initialized. If start is a cursor, we
delay converting it to index until we absolutely need it to save some
cycles (especially on a very long string).

But this leaves a gap where istart can be used uninitialized (same case
as above actually). If istart happens to be zero on stack, we'll
accidentally return full string even if the start cursor points to
somewhere else. Noticed by @Hamayama.