### PR TITLE
String cursor without heap allocation

### DIFF
--- a/lib/srfi-130.scm
+++ b/lib/srfi-130.scm
@@ -106,14 +106,13 @@
         (proc cur)
         (loop (string-cursor-next s cur))))))
 
-(define (string-contains s1 s2 :optional (start1 0) end1 start2 end2)
+(define (string-contains s1 s2 :optional (start1 (string-cursor-start s1)) end1 start2 end2)
   (assume-type s1 <string>)
   (assume-type s2 <string>)
   (let* ((str1 (%maybe-substring s1 start1 end1))
          (str2 (%maybe-substring s2 start2 end2))
          (res  (string-scan str1 str2 'cursor)))
-    ;; This only works because substring 'str1' shares the same space
-    ;; as the original string 's1', and <string-cursor> just holds a C
-    ;; pointer. If any of that changes, we'll need to convert 'res'
-    ;; (of 'str1') to the cursor of 's1'.
-    res))
+    (and res
+         (string-cursor-forward s1
+                                (string-index->cursor s1 start1)
+                                (string-cursor->index str1 res)))))

--- a/src/class.c
+++ b/src/class.c
@@ -3479,7 +3479,7 @@ void Scm__InitClass(void)
 
     /* string.c */
     CINIT(SCM_CLASS_STRING,           "<string>");
-    CINIT(SCM_CLASS_STRING_CURSOR,    "<string-cursor>");
+    CINIT(SCM_CLASS_STRING_LARGE_CURSOR, "<string-cursor>");
     CINIT(SCM_CLASS_STRING_POINTER,   "<string-pointer>");
 
     /* symbol.c */

--- a/src/gauche.h
+++ b/src/gauche.h
@@ -255,6 +255,10 @@ typedef struct ScmClassRec ScmClass;
  *      -------- -------- -------- 00010011
  *      Used in macro expander.
  *
+ * [String cursor]
+ *      -------- -------- -------- 00011011
+ *      Represent short string cursors.
+ *
  * [Heap object]
  *      -------- -------- -------- -----111
  *      Only appears at the first word of heap-allocated

--- a/src/gauche/string.h
+++ b/src/gauche/string.h
@@ -407,6 +407,10 @@ SCM_EXTERN void   Scm_StringPointerDump(ScmStringPointer *sp);
 
 /*
  * (Immutable) String cursors
+ *
+ * This is only used when the cursor cannot fit in SCM_OBJ
+ * (i.e. "small cursors"). In other words when the string size is more
+ * than 8M (on 32-bit platform?). This should be very rare.
  */
 typedef struct ScmStringLargeCursorRec {
     SCM_HEADER;
@@ -419,6 +423,11 @@ SCM_CLASS_DECL(Scm_StringLargeCursorClass);
 #define SCM_STRING_LARGE_CURSOR(obj)       ((ScmStringLargeCursor*)obj)
 #define SCM_STRING_LARGE_CURSOR_OFFSET(obj)       ((obj)->offset)
 #define SCM_STRING_LARGE_CURSOR_POINTER(sb, obj)  (SCM_STRING_BODY_START(sb) + (obj)->offset)
+
+#define SCM_MAKE_STRING_SMALL_CURSOR(obj)         SCM_OBJ(((uintptr_t)(obj) << 8) + 0x1b)
+#define SCM_STRING_SMALL_CURSORP(obj)             (SCM_TAG8(obj) == 0x1b)
+#define SCM_STRING_SMALL_CURSOR_OFFSET(obj)       (((signed long int)SCM_WORD(obj)) >> 8)
+#define SCM_STRING_SMALL_CURSOR_POINTER(sb, obj)  (SCM_STRING_BODY_START(sb) + SCM_STRING_SMALL_CURSOR_OFFSET(obj))
 
 SCM_EXTERN ScmObj Scm_MakeStringCursorFromIndex(ScmString *src, ScmSmallInt index);
 SCM_EXTERN ScmObj Scm_MakeStringCursorEnd(ScmString *src);

--- a/src/gauche/string.h
+++ b/src/gauche/string.h
@@ -410,13 +410,15 @@ SCM_EXTERN void   Scm_StringPointerDump(ScmStringPointer *sp);
  */
 typedef struct ScmStringCursorRec {
     SCM_HEADER;
-    const char *cursor;
+    ScmSmallInt offset;	 /* in bytes, relative to string body start */
 } ScmStringCursor;
 
 SCM_CLASS_DECL(Scm_StringCursorClass);
 #define SCM_CLASS_STRING_CURSOR      (&Scm_StringCursorClass)
 #define SCM_STRING_CURSORP(obj)      SCM_XTYPEP(obj, SCM_CLASS_STRING_CURSOR)
 #define SCM_STRING_CURSOR(obj)       ((ScmStringCursor*)obj)
+#define SCM_STRING_CURSOR_OFFSET(obj)       ((obj)->offset)
+#define SCM_STRING_CURSOR_POINTER(sb, obj)  (SCM_STRING_BODY_START(sb) + (obj)->offset)
 
 SCM_EXTERN ScmObj Scm_MakeStringCursorFromIndex(ScmString *src, ScmSmallInt index);
 SCM_EXTERN ScmObj Scm_MakeStringCursorEnd(ScmString *src);

--- a/src/gauche/string.h
+++ b/src/gauche/string.h
@@ -408,17 +408,17 @@ SCM_EXTERN void   Scm_StringPointerDump(ScmStringPointer *sp);
 /*
  * (Immutable) String cursors
  */
-typedef struct ScmStringCursorRec {
+typedef struct ScmStringLargeCursorRec {
     SCM_HEADER;
     ScmSmallInt offset;	 /* in bytes, relative to string body start */
-} ScmStringCursor;
+} ScmStringLargeCursor;
 
-SCM_CLASS_DECL(Scm_StringCursorClass);
-#define SCM_CLASS_STRING_CURSOR      (&Scm_StringCursorClass)
-#define SCM_STRING_CURSORP(obj)      SCM_XTYPEP(obj, SCM_CLASS_STRING_CURSOR)
-#define SCM_STRING_CURSOR(obj)       ((ScmStringCursor*)obj)
-#define SCM_STRING_CURSOR_OFFSET(obj)       ((obj)->offset)
-#define SCM_STRING_CURSOR_POINTER(sb, obj)  (SCM_STRING_BODY_START(sb) + (obj)->offset)
+SCM_CLASS_DECL(Scm_StringLargeCursorClass);
+#define SCM_CLASS_STRING_LARGE_CURSOR      (&Scm_StringLargeCursorClass)
+#define SCM_STRING_LARGE_CURSORP(obj)      SCM_XTYPEP(obj, SCM_CLASS_STRING_LARGE_CURSOR)
+#define SCM_STRING_LARGE_CURSOR(obj)       ((ScmStringLargeCursor*)obj)
+#define SCM_STRING_LARGE_CURSOR_OFFSET(obj)       ((obj)->offset)
+#define SCM_STRING_LARGE_CURSOR_POINTER(sb, obj)  (SCM_STRING_BODY_START(sb) + (obj)->offset)
 
 SCM_EXTERN ScmObj Scm_MakeStringCursorFromIndex(ScmString *src, ScmSmallInt index);
 SCM_EXTERN ScmObj Scm_MakeStringCursorEnd(ScmString *src);

--- a/src/gauche/string.h
+++ b/src/gauche/string.h
@@ -417,7 +417,6 @@ SCM_CLASS_DECL(Scm_StringCursorClass);
 #define SCM_CLASS_STRING_CURSOR      (&Scm_StringCursorClass)
 #define SCM_STRING_CURSORP(obj)      SCM_XTYPEP(obj, SCM_CLASS_STRING_CURSOR)
 #define SCM_STRING_CURSOR(obj)       ((ScmStringCursor*)obj)
-#define SCM_STRING_CURSOR_PTR(obj)   ((obj)->cursor)
 
 SCM_EXTERN ScmObj Scm_MakeStringCursorFromIndex(ScmString *src, ScmSmallInt index);
 SCM_EXTERN ScmObj Scm_MakeStringCursorEnd(ScmString *src);
@@ -428,5 +427,6 @@ SCM_EXTERN ScmObj Scm_StringCursorForward(ScmString* s, ScmObj cursor, int nchar
 SCM_EXTERN ScmObj Scm_StringCursorBack(ScmString* s, ScmObj cursor, int nchars);
 SCM_EXTERN ScmChar Scm_StringRefCursor(ScmString* s, ScmObj sc, int range_error);
 SCM_EXTERN ScmObj Scm_SubstringCursor(ScmString *str, ScmObj start, ScmObj end);
+SCM_EXTERN int Scm_StringCursorCompare(ScmObj sc1, ScmObj sc2, int (*numcmp)(ScmObj, ScmObj));
 
 #endif /* GAUCHE_STRING_H */

--- a/src/libstr.scm
+++ b/src/libstr.scm
@@ -441,39 +441,19 @@
   Scm_StringCursorIndex)
 
 (define-cproc string-cursor=? (cursor1 cursor2) ::<boolean>
-  (if (and (SCM_STRING_CURSORP cursor1)
-           (SCM_STRING_CURSORP cursor2))
-    (return (== (SCM_STRING_CURSOR_PTR (SCM_STRING_CURSOR cursor1))
-                (SCM_STRING_CURSOR_PTR (SCM_STRING_CURSOR cursor2))))
-    (return (Scm_NumEq cursor1 cursor2))))
+  (return (Scm_StringCursorCompare cursor1 cursor2 Scm_NumEq)))
 
 (define-cproc string-cursor<? (cursor1 cursor2) ::<boolean>
-  (if (and (SCM_STRING_CURSORP cursor1)
-           (SCM_STRING_CURSORP cursor2))
-    (return (< (SCM_STRING_CURSOR_PTR (SCM_STRING_CURSOR cursor1))
-               (SCM_STRING_CURSOR_PTR (SCM_STRING_CURSOR cursor2))))
-    (return (Scm_NumLT cursor1 cursor2))))
+  (return (Scm_StringCursorCompare cursor1 cursor2 Scm_NumLT)))
 
 (define-cproc string-cursor>? (cursor1 cursor2) ::<boolean>
-  (if (and (SCM_STRING_CURSORP cursor1)
-           (SCM_STRING_CURSORP cursor2))
-    (return (> (SCM_STRING_CURSOR_PTR (SCM_STRING_CURSOR cursor1))
-               (SCM_STRING_CURSOR_PTR (SCM_STRING_CURSOR cursor2))))
-    (return (Scm_NumGT cursor1 cursor2))))
+  (return (Scm_StringCursorCompare cursor1 cursor2 Scm_NumGT)))
 
 (define-cproc string-cursor<=? (cursor1 cursor2) ::<boolean>
-  (if (and (SCM_STRING_CURSORP cursor1)
-           (SCM_STRING_CURSORP cursor2))
-    (return (<= (SCM_STRING_CURSOR_PTR (SCM_STRING_CURSOR cursor1))
-                (SCM_STRING_CURSOR_PTR (SCM_STRING_CURSOR cursor2))))
-    (return (Scm_NumLE cursor1 cursor2))))
+  (return (Scm_StringCursorCompare cursor1 cursor2 Scm_NumLE)))
 
 (define-cproc string-cursor>=? (cursor1 cursor2) ::<boolean>
-  (if (and (SCM_STRING_CURSORP cursor1)
-           (SCM_STRING_CURSORP cursor2))
-    (return (>= (SCM_STRING_CURSOR_PTR (SCM_STRING_CURSOR cursor1))
-                (SCM_STRING_CURSOR_PTR (SCM_STRING_CURSOR cursor2))))
-    (return (Scm_NumGE cursor1 cursor2))))
+  (return (Scm_StringCursorCompare cursor1 cursor2 Scm_NumGE)))
 
 (define-cproc string-cursor-diff (s::<string> start end)
   (return (Scm_Sub (Scm_StringCursorIndex s end)

--- a/src/libstr.scm
+++ b/src/libstr.scm
@@ -420,7 +420,9 @@
    "SCM_STRING_LARGE_CURSORP" "SCM_STRING_LARGE_CURSOR")
  )
 
-(define-cproc string-cursor? (obj) ::<boolean> SCM_STRING_LARGE_CURSORP)
+(define-cproc string-cursor? (obj) ::<boolean>
+  (return (or (SCM_STRING_LARGE_CURSORP obj)
+              (SCM_STRING_SMALL_CURSORP obj))))
 (define-cproc string-cursor-start (s::<string>)
   (return (Scm_MakeStringCursorFromIndex s 0)))
 (define-cproc string-cursor-end (s::<string>)
@@ -434,7 +436,8 @@
 (define-cproc string-cursor-back (s::<string> cursor nchars::<fixnum>)
   Scm_StringCursorBack)
 (define-cproc string-index->cursor (s::<string> index)
-  (if (SCM_STRING_LARGE_CURSORP index)
+  (if (or (SCM_STRING_LARGE_CURSORP index)
+          (SCM_STRING_SMALL_CURSORP index))
       (return index)
       (return (Scm_MakeStringCursorFromIndex s (Scm_GetInteger index)))))
 (define-cproc string-cursor->index (s::<string> cursor)

--- a/src/libstr.scm
+++ b/src/libstr.scm
@@ -416,11 +416,11 @@
 (select-module gauche)
 (inline-stub
  ;; string pointer
- (define-type <string-cursor> "ScmStringCursor*" "string cursor"
-   "SCM_STRING_CURSORP" "SCM_STRING_CURSOR")
+ (define-type <string-cursor> "ScmStringLargeCursor*" "string cursor"
+   "SCM_STRING_LARGE_CURSORP" "SCM_STRING_LARGE_CURSOR")
  )
 
-(define-cproc string-cursor? (obj) ::<boolean> SCM_STRING_CURSORP)
+(define-cproc string-cursor? (obj) ::<boolean> SCM_STRING_LARGE_CURSORP)
 (define-cproc string-cursor-start (s::<string>)
   (return (Scm_MakeStringCursorFromIndex s 0)))
 (define-cproc string-cursor-end (s::<string>)
@@ -434,7 +434,7 @@
 (define-cproc string-cursor-back (s::<string> cursor nchars::<fixnum>)
   Scm_StringCursorBack)
 (define-cproc string-index->cursor (s::<string> index)
-  (if (SCM_STRING_CURSORP index)
+  (if (SCM_STRING_LARGE_CURSORP index)
       (return index)
       (return (Scm_MakeStringCursorFromIndex s (Scm_GetInteger index)))))
 (define-cproc string-cursor->index (s::<string> cursor)

--- a/src/string.c
+++ b/src/string.c
@@ -1782,6 +1782,26 @@ ScmObj Scm_SubstringCursor(ScmString *str,
                      FALSE);
 }
 
+int Scm_StringCursorCompare(ScmObj sc1, ScmObj sc2, int (*numcmp)(ScmObj, ScmObj))
+{
+    if (SCM_STRING_CURSORP(sc1) && SCM_STRING_CURSORP(sc2)) {
+        const char *c1 = SCM_STRING_CURSOR(sc1)->cursor;
+        const char *c2 = SCM_STRING_CURSOR(sc2)->cursor;
+        if (numcmp == Scm_NumEq) {
+            return c1 == c2;
+        } else if (numcmp == Scm_NumLT) {
+            return c1 < c2;
+        } else if (numcmp == Scm_NumLE) {
+            return c1 <= c2;
+        } else if (numcmp == Scm_NumGT) {
+            return c1 > c2;
+        } else if (numcmp == Scm_NumGE) {
+            return c1 >= c2;
+        }
+    }
+    return numcmp(sc1, sc2);
+}
+
 /*==================================================================
  *
  * Dynamic strings

--- a/src/write.c
+++ b/src/write.c
@@ -476,6 +476,13 @@ ScmObj Scm__WritePrimitive(ScmObj obj, ScmPort *port, ScmWriteContext *ctx)
         Scm_PutzUnsafe(buf, -1, port);
         return SCM_MAKE_INT(k);
     }
+    else if (SCM_STRING_SMALL_CURSORP(obj)) {
+        char buf[SPBUFSIZ];
+        int k = snprintf(buf, SPBUFSIZ, "#<string-cursor %ld>",
+			 SCM_STRING_SMALL_CURSOR_OFFSET(obj));
+        Scm_PutzUnsafe(buf, -1, port);
+        return SCM_MAKE_INT(k);
+    }
     return SCM_FALSE;
 }
 


### PR DESCRIPTION
How about this?

This adds a new tag for string cursor so that we can keep the cursor as immediate value. So no allocation. I initially thought the tag space is precious (just 2 bits) but I think I was wrong, at least according to the tag structure comment block.

Since some bits are used as the tag, we can't store all possible cursors as immediate values, we'll fall back to heap-based cursors for those that don't fit. I would expect we use immediate cursors in most common cases and rarely fall back to that because string length would have to be at least a few megabytes long to trigger that.

I did some tests with `gc`, `string-index` and `gc-stat` on a long string. This does help reduce allocation. Before allocation goes up as the string gets longer. After this, allocation is more or less fixed.

This also fixes the `cursor_print` problem. Since the cursor is now made to hold a byte offset instead of a C pointer, we can just print that offset. The change is driven by the immediate cursor because if we hold the C pointer as an immediate value, it's hard to make sure that it's used for common short-string cases (e.g. the strings could be allocated in high addresses and don't fit in).

#567 