### PR TITLE
Add the remaining two functions in srfi-130

### DIFF
--- a/lib/srfi-130.scm
+++ b/lib/srfi-130.scm
@@ -6,6 +6,7 @@
   (use srfi-13)
   (use gauche.stringutil)
   (export string-contains
+          string-contains-right
           string-fold
           string-fold-right
           string-for-each-cursor
@@ -113,6 +114,17 @@
   (let* ((str1 (%maybe-substring s1 start1 end1))
          (str2 (%maybe-substring s2 start2 end2))
          (res  (string-scan str1 str2 'cursor)))
+    (and res
+         (string-cursor-forward s1
+                                (string-index->cursor s1 start1)
+                                (string-cursor->index str1 res)))))
+
+(define (string-contains-right s1 s2 :optional (start1 (string-cursor-start s1)) end1 start2 end2)
+  (assume-type s1 <string>)
+  (assume-type s2 <string>)
+  (let* ((str1 (%maybe-substring s1 start1 end1))
+         (str2 (%maybe-substring s2 start2 end2))
+         (res  (string-scan-right str1 str2 'cursor)))
     (and res
          (string-cursor-forward s1
                                 (string-index->cursor s1 start1)

--- a/lib/srfi-130.scm
+++ b/lib/srfi-130.scm
@@ -11,6 +11,7 @@
           string-for-each-cursor
           string-index
           string-index-right
+          string-replicate
           string-skip
           string-skip-right
 
@@ -116,3 +117,7 @@
          (string-cursor-forward s1
                                 (string-index->cursor s1 start1)
                                 (string-cursor->index str1 res)))))
+
+;; 'to' is not optional in srfi-130
+(define (string-replicate s from to :optional start end)
+  (xsubstring s from to start end))

--- a/lib/srfi-152.scm
+++ b/lib/srfi-152.scm
@@ -98,16 +98,11 @@
       (loop (cons (string-copy s 0 k) r)
             (string-copy s k)))))
 
-(define (string-contains-right s1 s2 :optional start1 (end1 -1) start2 end2)
-  ;; This looks terrible---but once we reverse the strings, we can take
-  ;; advantage of internal fast string-scan.  It is arguable whether writing
-  ;; yet-another search for reverse direction might be better or not.
-  (let ([rs1 (string-reverse (%subs s1 start1 end1))]
-        [rs2 (string-reverse (%subs s2 start2 end2))])
-    (and-let1 z (string-contains rs1 rs2)
-      (- (if (< end1 0) (string-length s1) end1)
-         z
-         (string-length rs2)))))
+(define (string-contains-right s1 s2 :optional (start1 0) end1 start2 end2)
+  (let* ((str1 (%subs s1 start1 end1))
+         (str2 (%subs s2 start2 end2))
+         (res  (string-scan-right str1 str2)))
+    (and res (+ start1 res))))
 
 ;; Compatibility
 (define string-remove string-delete)

--- a/lib/srfi-152.scm
+++ b/lib/srfi-152.scm
@@ -111,7 +111,7 @@
 
 ;; Compatibility
 (define string-remove string-delete)
-(define string-replicate xsubstring)
 
-
-
+;; 'to' is not optional in srfi-152
+(define (string-replicate s from to :optional start end)
+  (xsubstring s from to start end))

--- a/test/include/srfi-130-tests.scm
+++ b/test/include/srfi-130-tests.scm
@@ -2400,7 +2400,6 @@
           (string-contains ABCDEFFFFOO "efffoo"))
     (fail 'string-contains))
 
-#|
 (OR (eqv? 0
           (string-cursor->index EMPTY
                                 (string-contains-right EMPTY EMPTY)))
@@ -2432,11 +2431,9 @@
     (fail 'string-contains-right))
 
 (OR (eqv? #f
-          (string-cursor->index ABCDEFFFFOO
-                                (string-contains-right ABCDEFFFFOO
-                                                       "efffoo")))
+          (string-contains-right ABCDEFFFFOO
+                                 "efffoo"))
     (fail 'string-contains-right))
-|#
 
 (OR (eqv? 0
           (string-cursor->index EMPTY
@@ -2469,7 +2466,6 @@
 (OR (eqv? #f (string-contains ABCDEFFFFOO "efffoo" 2))
     (fail 'string-contains))
 
-#|
 (OR (eqv? 0
           (string-cursor->index EMPTY
                                 (string-contains-right EMPTY EMPTY 0)))
@@ -2482,9 +2478,8 @@
     (fail 'string-contains-right))
 
 (OR (eqv? #f
-          (string-cursor->index ABCDEFFFFOO
-                                (string-contains-right ABCDEFFFFOO
-                                                       "a" 2)))
+          (string-contains-right ABCDEFFFFOO
+                                 "a" 2))
     (fail 'string-contains-right))
 
 (OR (eqv? 7
@@ -2506,11 +2501,9 @@
     (fail 'string-contains-right))
 
 (OR (eqv? #f
-          (string-cursor->index ABCDEFFFFOO
-                                (string-contains-right ABCDEFFFFOO
-                                                       "efffoo" 2)))
+          (string-contains-right ABCDEFFFFOO
+                                 "efffoo" 2))
     (fail 'string-contains-right))
-|#
 
 
 (OR (eqv? 0
@@ -2547,7 +2540,7 @@
 (OR (eqv? #f (string-contains ABCDEFFFFOO "efffoo" 2 10))
     (fail 'string-contains))
 
-#|
+
 (OR (eqv? 0
           (string-cursor->index EMPTY
                                 (string-contains-right EMPTY EMPTY 0 0)))
@@ -2560,9 +2553,8 @@
     (fail 'string-contains-right))
 
 (OR (eqv? #f
-          (string-cursor->index ABCDEFFFFOO
-                                (string-contains-right ABCDEFFFFOO
-                                                       "a" 2 10)))
+          (string-contains-right ABCDEFFFFOO
+                                 "a" 2 10))
     (fail 'string-contains-right))
 
 (OR (eqv? 7
@@ -2578,17 +2570,14 @@
     (fail 'string-contains-right))
 
 (OR (eqv? #f
-          (string-cursor->index ABCDEFFFFOO
-                                (string-contains-right ABCDEFFFFOO
-                                                       "foo" 2 10)))
+          (string-contains-right ABCDEFFFFOO
+                                 "foo" 2 10))
     (fail 'string-contains-right))
 
 (OR (eqv? #f
-          (string-cursor->index ABCDEFFFFOO
-                                (string-contains-right ABCDEFFFFOO
-                                                       "efffoo" 2 10)))
+          (string-contains-right ABCDEFFFFOO
+                                 "efffoo" 2 10))
     (fail 'string-contains-right))
-|#
 
 (OR (eqv? 0
           (string-cursor->index EMPTY
@@ -2625,7 +2614,6 @@
 (OR (eqv? #f (string-contains ABCDEFFFFOO "efffoo" 2 10 1))
     (fail 'string-contains))
 
-#|
 (OR (eqv? 0
           (string-cursor->index EMPTY
                                 (string-contains-right EMPTY EMPTY 0 0 0)))
@@ -2656,17 +2644,14 @@
     (fail 'string-contains-right))
 
 (OR (eqv? #f
-          (string-cursor->index ABCDEFFFFOO
-                                (string-contains-right ABCDEFFFFOO
-                                                       "foo" 2 10 1)))
+          (string-contains-right ABCDEFFFFOO
+                                 "foo" 2 10 1))
     (fail 'string-contains-right))
 
 (OR (eqv? #f
-          (string-cursor->index ABCDEFFFFOO
-                                (string-contains-right ABCDEFFFFOO
-                                                       "efffoo" 2 10 1)))
+          (string-contains-right ABCDEFFFFOO
+                                 "efffoo" 2 10 1))
     (fail 'string-contains-right))
-|#
 
 (OR (eqv? 0
           (string-cursor->index EMPTY
@@ -2709,7 +2694,6 @@
                                                  "efffoo" 2 10 0 2)))
     (fail 'string-contains))
 
-#|
 (OR (eqv? 0
           (string-cursor->index EMPTY
                                 (string-contains-right EMPTY EMPTY 0 0 0 0)))
@@ -2750,7 +2734,6 @@
                                 (string-contains-right ABCDEFFFFOO
                                                        "efffoo" 2 10 1 3)))
     (fail 'string-contains-right))
-|#
 
 ;;-----------------------------------------------------------------------
 (test-section "The whole string")

--- a/test/include/srfi-130-tests.scm
+++ b/test/include/srfi-130-tests.scm
@@ -2877,8 +2877,6 @@
               v))
     (fail 'string-for-each-cursor))
 
-
-#|
 (OR (string=? "cdefabcdefabcd"
               (string-replicate "abcdef" -4 10))
     (fail 'string-replicate))
@@ -2890,7 +2888,10 @@
 (OR (string=? "ecdecdecde"
               (string-replicate "abcdef" -13 -3 2 5))
     (fail 'string-replicate))
-|#
+
+(test* "string-replicate" "ecdecdecde"
+       (let ([s "abcdef"])
+         (string-replicate s -13 -3 (string-index->cursor s 2) (string-index->cursor s 5))))
 
 (OR (= 6 (string-count "abcdef" char?))
     (fail 'string-count))


### PR DESCRIPTION
These are the last two missing. The srfi (#567) is now complete. Documents come next (work to replace \<string-pointer> is in parallel).

Two equivalent procedures in srfi-152 also get updated while I'm looking at this.