### PR TITLE
Document string cursors and srfi-130

### DIFF
--- a/doc/corelib.texi
+++ b/doc/corelib.texi
@@ -8327,6 +8327,7 @@ SRFI-13については@ref{String library}を参照してください。
 * String Predicates::
 * String Constructors::
 * String interpolation::
+* String Cursors::
 * String Accessors & Modifiers::
 * String Comparison::
 * String utilities::
@@ -8650,7 +8651,7 @@ Other class may provide a method to customize the behavior.
 @c COMMON
 @end deffn
 
-@node String interpolation, String Accessors & Modifiers, String Constructors, Strings
+@node String interpolation, String Cursors, String Constructors, Strings
 @subsection String interpolation
 @c NODE 文字列の補間
 
@@ -8896,7 +8897,124 @@ Schemeは他のスクリプト言語より一般的により多くの文字を�
 @c COMMON
 
 
-@node String Accessors & Modifiers, String Comparison, String interpolation, Strings
+@node String Cursors, String Accessors & Modifiers, String interpolation, Strings
+@subsection String Cursors
+
+String cursors are opaque objects that point into strings, similar to
+indexes. Cursors however are more efficient. For example, to get a
+character with @code{string-ref} using an index on a multibyte string,
+Gauche needs to iterate from the beginning of the string until that
+position, or @code{O(n)}. Using cursors you can access in @code{O(1)}
+(for singlebyte strings, Gauche does it in @code{O(1)} even with
+index).
+
+For a string of length @var{n}, there are @code{n + 1} cursors. The
+last cursor at the end of the string does not point to any valid
+character, it's usually used to determine if nothing is found.
+
+A string cursor is associated with a specific string and should not be
+used with another string. A string cursor also becomes invalid when
+the associated string is modified. Accessing an invalid cursor does
+not always fail though. You just have to be careful and make sure you
+don't use invalid cursors.
+
+Most procedures that take indexes in Gauche can also take
+cursors. Relying on this though is unportable. For example, the
+@code{substring} procedure in RnRS standards does not mention anything
+about cursors even though the Gauche version accepts cursors. For
+portable programs, you should only use cursors on procedures from
+srfi-130 module.
+
+@deftp {Builtin Class} <string-cursor>
+Represents a cursor. When printed out, you'll see the
+@emph{byte offset} from the beginning of the string, not the character index.
+@end deftp
+
+@defun string-cursor? @var{obj}
+[SRFI-130]
+
+Returns @code{#t} if @var{obj} is a string cursor, @code{#f} otherwise.
+@end defun
+
+@defun string-cursor-start @var{str}
+[SRFI-130]
+
+Returns a cursor pointing to the start of
+@var{str}. @code{string-cursor-start} returns a valid cursor on an
+empty string too. It's the same as @code{string-cursor-end} in that
+case.
+@end defun
+
+@defun string-cursor-end @var{str}
+[SRFI-130]
+
+Returns a cursor pointing to the end of @var{str} (including empty
+string). This cursor does not point to any valid character of the
+string.
+@end defun
+
+@defun string-cursor-next @var{str} @var{cur}
+[SRFI-130]
+
+Returns the cursor into @var{str} following @var{cur}. @var{cur} can
+also be an index.
+@end defun
+
+@defun string-cursor-prev @var{str} @var{cur}
+[SRFI-130]
+
+Returns the cursor into @var{str} preceding @var{cur}. @var{cur} can
+also be an index.
+@end defun
+
+@defun string-cursor-forward @var{str} @var{cur} @var{n}
+[SRFI-130]
+
+Returns the cursor into @var{str} following @var{cur} by @var{n}
+characters. @var{cur} can also be an index.
+@end defun
+
+@defun string-cursor-back @var{str} @var{cur} @var{n}
+[SRFI-130]
+
+Returns the cursor into @var{str} preceding @var{cur} by @var{n}
+characters. @var{cur} can also be an index.
+@end defun
+
+@defun string-index->cursor @var{str} @var{index}
+[SRFI-130]
+
+Convert an @var{index} to a cursor. If @var{index} is a cursor it will
+be returned as-is.
+@end defun
+
+@defun string-cursor->index @var{str} @var{cur}
+[SRFI-130]
+
+Convert a cursor to an index. If @var{cur} is a an index it will be
+returned as-is.
+@end defun
+
+@defun string-cursor-diff @var{str} @var{start} @var{end}
+[SRFI-130]
+
+Returns the number of characters between @var{start} and @var{end}. It
+should be non-negative if @var{start} precedes @var{end}, non-positive
+otherwise. @var{start} and @var{end} also accept index.
+@end defun
+
+@defun string-cursor=? @var{cur1} @var{cur2}
+@defunx string-cursor<? @var{cur1} @var{cur2}
+@defunx string-cursor<=? @var{cur1} @var{cur2}
+@defunx string-cursor>? @var{cur1} @var{cur2}
+@defunx string-cursor>=? @var{cur1} @var{cur2}
+[SRFI-130]
+
+Compares two cursors or two indexes (but not a cursor and an index)
+and returns @code{#t} or @code{#f} accordingly.
+@end defun
+
+@node String Accessors & Modifiers, String Comparison, String Cursors, Strings
 @subsection String Accessors & Modifiers
 @c NODE 文字列のアクセスと変更
 
@@ -8938,6 +9056,8 @@ By default, an error is signaled if @code{k} is out of range
 (negative, or greater than or equal to the length of @var{cstring}).
 However, if an optional argument @var{fallback} is given,
 it is returned in such case.  This is Gauche's extension.
+
+@var{k} can also be a string cursor (also Gauche's extension).
 @c JP
 完全な文字列@var{cstring}の@var{k}番目の文字を返します。
 不完全な文字列を渡すのはエラーです。
@@ -9102,7 +9222,7 @@ R7RSでプログラミングする際に@code{(scheme char)}をインポート�
 @c NODE 文字列を扱うその他の手続き
 
 @defun substring string start end
-[R7RS base]
+[R7RS+ base]
 @c EN
 Returns a substring of @var{string}, starting from @var{start}-th
 character (inclusive) and ending at @var{end}-th character (exclusive).
@@ -9111,6 +9231,9 @@ The @var{start} and @var{end} arguments must satisfy
 @code{0 <= @var{end} <= @var{N}}, and
 @code{@var{start} <= @var{end}}, where @var{N} is the length of the
 string.
+
+@var{start} and @var{end} can also be string cursors, but this is an
+extension of Gauche.
 @c JP
 @var{string}の@var{start}番目の文字(これを含む)から、@var{end}番目の文
 字(これを含まない)までの部分文字列を返します。引数@var{start}および

--- a/doc/modsrfi.texi
+++ b/doc/modsrfi.texi
@@ -52,6 +52,7 @@ srfi N is supported by Gauche.)
 * Queues based on lists::       srfi-117
 * Simple adjustable-size strings::  srfi-118
 * Lazy sequence (srfi)::        srfi-127
+* Cursor-based string library:: srfi-130
 * Sort library::                srfi-132
 * Vector library::              srfi-133
 * Integer division::            srfi-141
@@ -5718,7 +5719,7 @@ rather than @code{string-replace}.
 @end defun
 
 @c ----------------------------------------------------------------------
-@node Lazy sequence (srfi), Sort library, Simple adjustable-size strings, Library modules - SRFIs
+@node Lazy sequence (srfi), Cursor-based string library, Simple adjustable-size strings, Library modules - SRFIs
 @section @code{srfi-127} - Lazy sequence (srfi)
 
 @deftp {Module} srfi-127
@@ -5734,7 +5735,89 @@ SRFI-127はR7RS largeに採り入れられました。
 
 
 @c ----------------------------------------------------------------------
-@node Sort library, Vector library, Lazy sequence (srfi), Library modules - SRFIs
+@node Cursor-based string library, Sort library, Lazy sequence (srfi), Library modules - SRFIs
+@section @code{srfi-130} - Cursor-based string library
+
+@deftp {Module} srfi-130
+@mdindex srfi-130
+This is an reduced version of @code{srfi-13} that supports cursors in
+addition to indexes. The consistency with R7RS and recent srfis are
+also considered.
+
+The following are built-in.  @xref{String Cursors}, for the details.
+
+@example
+string-cursor?        string-cursor-start    string-cursor-end
+string-cursor-next    strig-cursor-prev      string-cursor-forward
+string-cursor-back    string-cursor=?        string-cursor<?
+string-cursor<=?      string-cursor>?        string-cursor>=?
+string-cursor-diff    string-cursor->index   string-index->cursor
+@end example
+
+The following procedures are simply aliases of the builtin version
+without the @code{/cursor} or @code{/cursors} suffix.
+
+@example
+string->list/cursors  string->vector/cursors string-copy/cursors
+string-ref/cursor     substring/cursors
+@end example
+
+The following procedures are defined in srfi-13.  @xref{String library},
+for the details.  Note: Some of those procedures in srfi-13 accept
+only indexes (e.g. @code{string-index}).  In srfi-130, both indexes
+and cursors are accepted.  Our srfi-13 implementation shares the same
+procedure with srfi-130, so they accept both indexes and cursors but
+such code won't be portable as srfi-13.
+
+@example
+string-null?       string-any         string-every       string-tabulate
+string-unfold      string-unfold-right                   reverse-list->string
+string-take        string-drop        string-take-right  string-drop-right
+string-pad         string-pad-right   string-trim        string-trim-right
+string-trim-both   string-replace     string-prefix-length
+string-suffix-length                  string-prefix?     string-suffix
+string-concatenate string-concatenate-reverse            string-count
+string-filter      string-reverse
+@end example
+
+The following procedures are also defined in srfi-13 and redefined in
+srfi-130. However, for operations going from left to right, the
+srfi-130 version returns a cursor instead of an index when found or
+@code{(string-cursor-end)} of the input string when not found.  For
+operations going from right to left, it returns a cursor representing
+a @emph{successor} of the matching character when found, or
+@code{(string-cursor-begin)} of the input string when not found. In
+contrast, the srfi-13 version returns either an index when found or
+@code{#f} otherwise.
+
+@example
+string-fold        string-fold-right   string-index
+string-index-right string-skip         string-skip-right
+@end example
+
+@code{string-contains} is defined the same as srfi-13. However the
+srfi-130 returns a cursor when a string is found, and @code{#f}
+otherwise. In contrast, the srfi-13 version returns an index or
+@code{#f}. @code{string-contains-right} is similar to
+@code{string-contains} except that the searching start from the end of
+the string.
+
+@code{string-for-each-cursor} is similar to
+@code{string-for-each-index} from srfi-13 but @code{proc} will take
+the cursor instead of the index.
+
+@code{xsubstring} and @code{string-delete} in srfi-13 are renamed
+@code{string-replicate} and @code{string-remove} respectively in
+srfi-130. Similar to srfi-152, the @var{to} argument is required in
+@code{string-replicate}.
+
+@code{string-split} is the same as one from srfi-152 or
+@code{gauche.stringutil} module.
+
+@end deftp
+
+@c ----------------------------------------------------------------------
+@node Sort library, Vector library, Cursor-based string library, Library modules - SRFIs
 @section @code{srfi-132} - Sort library
 @c NODE ソートライブラリ, @code{srfi-133} - ソートライブラリ
 

--- a/src/srfis.scm
+++ b/src/srfis.scm
@@ -968,8 +968,9 @@ srfi-130, srfi-130
 ()
 
 Cursor-based string library
+Most of the procedures in srfi-13 accept cursors in addition to indexes.
 
-Don't challenge my JLPT N5 skills!
+Cursor-based string library (to be translated)
 
 srfi-131, gauche.record
 ()


### PR DESCRIPTION
This adds documentation for srfi-130, split in two parts: basic cursor support is documented under "Strings" section, the srfi-130 section only mentions differences compared to 130.

This basically ends the story of #567 (and I'm now back to srfi-159, hurrah!). Although there are still loose ends to take care of later:

- use string cursor for r7rs string-map and string-for-each
- maybe update more procedures to accept cursors too. Right now some take both index and cursor, some only index. Not great, but I guess if we really want cursor support across the board, we can update gradually.
   Not sure if this is the direction you want to go though because you'll also adding immutable text, the (better?) alternative for string cursors.
- i'm considering extending `<string-cursor-large>` to hold a C pointer again and make it a runtime option to always use large cursors.
   The reason for this is, it's quite hard to detect use of invalid cursors with current design. With C-pointer-as-cursor we can detect that much much better and throw an error to the user's face (or test suite if they do it right, the test suite will run with only large cursors). And since large cursors should be rare anyway, having a slighly fatter object shouldn't hurt anybody.