### PR TITLE
Change template of extension library v2

### DIFF
--- a/ext/template.Makefile.in
+++ b/ext/template.Makefile.in
@@ -44,11 +44,14 @@ GAUCHE_PKGLIBDIR  = "$(DESTDIR)@GAUCHE_PKGLIBDIR@"
 GAUCHE_PKGARCHDIR = "$(DESTDIR)@GAUCHE_PKGARCHDIR@"
 
 @@extname@@_SRCS = $(srcdir)/@@extname@@.c $(srcdir)/@@extname@@lib.stub
+@@extname@@_HDRS = $(srcdir)/@@extname@@.h
 
 all : $(TARGET)
 
-@@extname@@.$(SOEXT): $(@@extname@@_SRCS)
+@@extname@@.$(SOEXT): $(@@extname@@_SRCS) $(@@extname@@_HDRS)
 	$(GAUCHE_PACKAGE) compile \
+	  --cppflags="$(CPPFLAGS)" --cflags="$(CFLAGS)" \
+	  --ldflags="$(LDFLAGS)" --libs="$(LIBS)" \
 	  --local=$(LOCAL_PATHS) --verbose @@extname@@ $(@@extname@@_SRCS)
 
 check : all

--- a/ext/template.configure
+++ b/ext/template.configure
@@ -4,7 +4,7 @@
 
 (use gauche.configure)
 (load "configure-compat" 
-      :paths `(,(current-load-path))
+      :paths `(,(sys-dirname (current-load-path)))
       :error-if-not-found #f)
 
 ;; Here you can define handlers of configure arguments by cf-arg-enable

--- a/ext/template.configure-compat
+++ b/ext/template.configure-compat
@@ -4,26 +4,30 @@
 
 (use gauche.version)
 
-(when (version< (gauche-version) "0.9.7")
-  ;; 0.9.6 or before doesn't have cf-init-gauche-extension.
-  ;; Give the user a helpful message.
-  (define (cf-init-gauche-extension)
-    (exit 1 " Gauche 0.9.7 or later is required to use\
+;; For the compatibility to Gauche 0.9.7 - 0.9.9
+(define (cf-init-gauche-extension)
+  (when (version<? (gauche-version) "0.9.7")
+    ;; 0.9.6 or before doesn't have cf-init-gauche-extension.
+    ;; Give the user a helpful message.
+    (exit 1 " Gauche 0.9.7 or later is required to use \
               cf-init-gauche-extension."))
-  )
 
-(when (version<= (gauche-version) "0.9.9")
-  ;; The default values for these variables weren't set in older Gauche.
-  (unless (cf-have-subst? 'CFLAGS)
-    (cf-subst 'CFLAGS (gauche-config "--default-cflags")))
-  (unless (cf-have-subst? 'CPPFLAGS) (cf-subst 'CPPFLAGS ""))
-  (unless (cf-have-subst? 'LDFLAGS)  (cf-subst 'LDFLAGS  ""))
-  (unless (cf-have-subst? 'LIBS)     (cf-subst 'LIBS     ""))  
-  (unless (cf-have-subst? 'WINDOWS_UNICODE_FLAG)
-    (cf-subst 'WINDOWS_UNICODE_FLAG
-              (cond-expand
-               [(and gauche.os.windows gauche.ces.utf8) "-DUNICODE"]
-               [else ""])))
+  ;; Call original procedure
+  ((with-module gauche.configure cf-init-gauche-extension))
+
+  (when (version<=? (gauche-version) "0.9.9")
+    ;; The default values for these variables weren't set in older Gauche.
+    (unless (cf-have-subst? 'CFLAGS)
+      (cf-subst 'CFLAGS (gauche-config "--default-cflags")))
+    (unless (cf-have-subst? 'CPPFLAGS) (cf-subst 'CPPFLAGS ""))
+    (unless (cf-have-subst? 'LDFLAGS)  (cf-subst 'LDFLAGS  ""))
+    (unless (cf-have-subst? 'LIBS)     (cf-subst 'LIBS     ""))  
+    (unless (cf-have-subst? 'WINDOWS_UNICODE_FLAG)
+      (cf-subst 'WINDOWS_UNICODE_FLAG
+                (cond-expand
+                 [(and gauche.os.windows gauche.ces.utf8) "-DUNICODE"]
+                 [else ""])))
+    )
   )
 
 ;; Local variables:

--- a/ext/template.configure.ac
+++ b/ext/template.configure.ac
@@ -36,6 +36,25 @@ AC_PATH_PROG([GAUCHE_PACKAGE], gauche-package)
 AC_PATH_PROG([GAUCHE_INSTALL], gauche-install)
 AC_PATH_PROG([GAUCHE_CESCONV], gauche-cesconv)
 
+dnl C build settings
+if test -z "$CC"; then
+  CC=`"$GAUCHE_CONFIG" --cc`
+fi
+if test -z "$CFLAGS"; then
+  CFLAGS=`"$GAUCHE_CONFIG" --default-cflags`
+fi
+AC_SUBST(CC)
+AC_SUBST(CFLAGS)
+AC_SUBST(CPPFLAGS)
+AC_SUBST(LDFLAGS)
+AC_SUBST(LIBS)
+
+dnl For Windows Unicode support
+if gosh -e'(exit (cond-expand ((and gauche.os.windows gauche.ces.utf8) 0) (else 1)))'; then
+  WINDOWS_UNICODE_FLAG="-DUNICODE"
+fi
+AC_SUBST(WINDOWS_UNICODE_FLAG)
+
 dnl Usually these parameters are set by AC_PROG_CC, but we'd rather use
 dnl the same one as Gauche has been compiled with.
 SOEXT=`"$GAUCHE_CONFIG" --so-suffix`
@@ -46,6 +65,16 @@ AC_SUBST(OBJEXT)
 AC_SUBST(EXEEXT)
 
 ac_default_prefix=`"$GAUCHE_CONFIG" --prefix`
+
+dnl On MSYS2/MinGW-w64, we must overwrite 'prefix' because
+dnl /mingw64/etc/config.site sets prefix=/mingw64 .
+case "$MSYSTEM" in
+  MINGW64|MINGW32)
+    case "$prefix" in
+      /mingw64|/mingw32)
+        prefix=`"$GAUCHE_CONFIG" --prefix`;;
+    esac;;
+esac
 
 GAUCHE_PKGINCDIR=`"$GAUCHE_CONFIG" --pkgincdir`
 GAUCHE_PKGLIBDIR=`"$GAUCHE_CONFIG" --pkglibdir`

--- a/ext/template.configure.ac
+++ b/ext/template.configure.ac
@@ -37,6 +37,8 @@ AC_PATH_PROG([GAUCHE_INSTALL], gauche-install)
 AC_PATH_PROG([GAUCHE_CESCONV], gauche-cesconv)
 
 dnl C build settings
+dnl Usually these parameters are set by AC_PROG_CC, but we'd rather use
+dnl the same one as Gauche has been compiled with.
 if test -z "$CC"; then
   CC=`"$GAUCHE_CONFIG" --cc`
 fi
@@ -55,8 +57,6 @@ if gosh -e'(exit (cond-expand ((and gauche.os.windows gauche.ces.utf8) 0) (else 
 fi
 AC_SUBST(WINDOWS_UNICODE_FLAG)
 
-dnl Usually these parameters are set by AC_PROG_CC, but we'd rather use
-dnl the same one as Gauche has been compiled with.
 SOEXT=`"$GAUCHE_CONFIG" --so-suffix`
 OBJEXT=`"$GAUCHE_CONFIG" --object-suffix`
 EXEEXT=`"$GAUCHE_CONFIG" --executable-suffix`

--- a/ext/template.extensionlib.stub
+++ b/ext/template.extensionlib.stub
@@ -8,8 +8,8 @@
 ;; The following entry is a dummy one.
 ;; Replace it for your definitions.
 
-(define-cproc test-@@extname@@ () ::<const-cstring>
-  (result "@@extname@@ is working"))
+(define-cproc test-@@extname@@ ()
+  (return (test_@@extname@@)))
 
 
 ;; Local variables:

--- a/lib/gauche/configure.scm
+++ b/lib/gauche/configure.scm
@@ -338,8 +338,8 @@
 
   ;; NB: Autoconf uses AC_PROG_CC to set up CC.  However, we need
   ;; to use the same C compiler with which Gauche was compiled, so
-  ;; so we set it as the default.  We also allow env overrides for
-  ;; some common variables.  (In autoconf, AC_PROG_CC issues AC_ARG_VAR
+  ;; we set it as the default.  We also allow env overrides for some
+  ;; common variables.  (In autoconf, AC_PROG_CC issues AC_ARG_VAR
   ;; for them).
   (cf-subst 'CC (gauche-config "--cc"))
   (cf-subst 'CFLAGS (gauche-config "--default-cflags"))
@@ -349,7 +349,7 @@
   (cf-arg-var 'CFLAGS)
   (cf-arg-var 'LDFLAGS)
   (cf-arg-var 'LIBS)
-  ;; NB: Autoconf detemines these through tests, but we already
+  ;; NB: Autoconf determines these through tests, but we already
   ;; know them at the time Gauche is configured.
   (cf-subst 'SOEXT  (gauche-config "--so-suffix"))
   (cf-subst 'OBJEXT (gauche-config "--object-suffix"))


### PR DESCRIPTION
#564 の続きです。

- lib/gauche/configure.scm
  - コメント修正 (so が 2 個連続していた)

- ext/template.configure
  - load の :paths の指定を修正

- ext/template.configure-compat
  - version< → version<? に修正
  - cf-init より先に実行した cf-subst はエラーになるため、
    Gauche 0.9.9 以前では、うまく動作しなかった。
    とりあえず、cf-init-gauche-extension を再定義する方式に戻したが。。。

- ext/template.configure.ac
  - CC, CFLAGS, CPPFLAGS, LDFLAGS, LIBS の設定を追加
    (AC_PROG_CC を書くと、これらの設定が自動で追加されるようだが、
    あえて使わないようにしているようにも見えたため、手動で追加した)
  - WINDOWS_UNICODE_FLAG の設定を追加
  - MSYS2/MinGW-w64 のときは、prefix を上書きするようにした
    ( /mingw64/etc/config.site が、prefix を /mingw64 に固定してくるため)

- ext/template.Makefile.in 
  - ヘッダーファイルの依存関係の記述を追加
  - $(GAUCHE_PACKAGE) compile のオプション指定を追加
    (--cflags 等を指定しないと、設定が有効にならなかった)

- ext/template.extensionlib.stub
  - C の関数を実際に呼び出すように変更


＜テスト結果＞
(1) https://ci.appveyor.com/project/Hamayama/gauche/builds/30489116

(2) template.configure のテスト
```
gauche-package generate test_ext4
cd test_ext4
./configure
make
make install
make check
make uninstall
make clean
make maintainer-clean
```
HEAD+本変更 ==> OK
0.9.9で確認 ==> OK
0.9.8で確認 ==> OK
0.9.7で確認 ==> OK
0.9.6で確認 ==> 以下のメッセージを表示して終了
 Gauche 0.9.7 or later is required to use cf-init-gauche-extension.

(3) template.configure.ac のテスト
```
gauche-package generate --autoconf test_ext_ac4
cd test_ext_ac4
autoconf
./configure
make
make install
make check
make uninstall
make clean
make maintainer-clean
```
HEAD+本変更 ==> OK
0.9.9で確認 ==> OK
0.9.8で確認 ==> OK
0.9.7で確認 ==> OK
0.9.6で確認 ==> OK
