### PR TITLE
doc: add a note about using #?= in r7rs

### DIFF
--- a/doc/program.texi
+++ b/doc/program.texi
@@ -1681,6 +1681,13 @@ extra parenthesis, and
 (2)デバッグスタブをエディタで探したり取り除いたりするのが極めて簡単、というものです。
 @c COMMON
 
+Note that because @code{debug-print} is not available in r7rs
+environment, to use @code{#?=} you need to import it, e.g.
+
+@example
+(import (only (gauche base) debug-print))
+@end example
+
 @c ----------------------------------------------------------------------
 @node Platform-dependent features, Profiling and tuning, Debugging, Programming in Gauche
 @section Using platform-dependent features


### PR DESCRIPTION
Perhaps it's a good idea to mention it. "debug-print" is obvious from the error message, the problem i usually had was with the "gauche base" part.

Maybe it's even better to auto import debug-print when `#?=` is used. Should not affect program portability because `#?=` is not supposed to stay in the code anyway.