### PR TITLE
Introduce -fsafe-string-cursors

### DIFF
--- a/doc/corelib.texi
+++ b/doc/corelib.texi
@@ -8915,8 +8915,8 @@ character, it's usually used to determine if nothing is found.
 A string cursor is associated with a specific string and should not be
 used with another string. A string cursor also becomes invalid when
 the associated string is modified. Accessing an invalid cursor does
-not always fail though. You just have to be careful and make sure you
-don't use invalid cursors.
+not always fail though. Running @code{gosh} with @code{-fsafe-string-cursors}
+could help catch these issues. @xref{Invoking Gosh}.
 
 Most procedures that take indexes in Gauche can also take
 cursors. Relying on this though is unportable. For example, the

--- a/doc/program.texi
+++ b/doc/program.texi
@@ -276,6 +276,10 @@ Don't keep source information for debugging.  Consumes less memory.
 @item case-fold
 Ignore case for symbols.
 @xref{Case-sensitivity}.
+@item safe-string-cursors
+String cursors used on wrong strings will raise an error. This may
+cause performance problems because all cursors will be allocated on
+heap. @xref{String Cursors}.
 @item test
 Adds "@code{../src}" and "@code{../lib}" to the load path before loading
 initialization file.  This is useful when you want to test the

--- a/src/gauche/priv/stringP.h
+++ b/src/gauche/priv/stringP.h
@@ -46,6 +46,7 @@
 
 struct ScmStringCursorLargeRec {
     SCM_HEADER;
+    const char *start;
     ScmSmallInt offset;	 /* in bytes, relative to string body start
                             offset is non-negative. */
 };
@@ -60,6 +61,8 @@ struct ScmStringCursorLargeRec {
     (SCM_STRING_CURSOR_LARGE(obj)->offset)
 #define SCM_STRING_CURSOR_LARGE_POINTER(sb, obj) \
     (SCM_STRING_BODY_START(sb) + SCM_STRING_CURSOR_LARGE_OFFSET(obj))
+#define SCM_STRING_CURSOR_LARGE_START(obj)       \
+    (SCM_STRING_CURSOR_LARGE(obj)->start)
 
 #define SCM_MAKE_STRING_CURSOR_SMALL(obj) \
     SCM_OBJ(((uintptr_t)(obj) << 8) + 0x1b)

--- a/src/gauche/vm.h
+++ b/src/gauche/vm.h
@@ -631,8 +631,10 @@ enum {
     SCM_COMPILE_NOINLINE_SETTERS = (1L<<10), /* Do not inline setters */
     SCM_COMPILE_NODISSOLVE_APPLY = (1L<<11),/* Do not dissolve APPLY
                                               (pass2/dissolve-apply) */
-    SCM_COMPILE_LEGACY_DEFINE = (1L<<12)   /* Do not insert toplevel binding 
+    SCM_COMPILE_LEGACY_DEFINE = (1L<<12),  /* Do not insert toplevel binding
                                               at compile-time. */
+    SCM_SAFE_STRING_CURSORS = (1L<<13)     /* Always use large cursors for
+                                              extra validation. */
 };
 
 #define SCM_VM_COMPILER_FLAG_IS_SET(vm, flag) ((vm)->compilerFlags & (flag))

--- a/src/main.c
+++ b/src/main.c
@@ -288,6 +288,9 @@ void further_options(const char *optarg)
     else if (strcmp(optarg, "test") == 0) {
         test_mode = TRUE;
     }
+    else if (strcmp(optarg, "safe-string-cursors") == 0) {
+        SCM_VM_COMPILER_FLAG_SET(vm, SCM_SAFE_STRING_CURSORS);
+    }
     /* For development; not for public use */
     else if (strcmp(optarg, "collect-stats") == 0) {
         stats_mode = TRUE;

--- a/src/string.c
+++ b/src/string.c
@@ -206,6 +206,10 @@ static inline const char *string_cursor_ptr(const ScmStringBody *sb, ScmObj sc)
 {
     const char *ptr = NULL;
     if (SCM_STRING_CURSOR_LARGE_P(sc)) {
+        if (SCM_STRING_BODY_START(sb) != SCM_STRING_CURSOR_LARGE_START(sc)) {
+            Scm_Error("invalid cursor (made for string '%s'): %S",
+                      SCM_STRING_CURSOR_LARGE_START(sc), sc);
+        }
         ptr = SCM_STRING_CURSOR_LARGE_POINTER(sb, sc);
     } else if (SCM_STRING_CURSOR_SMALL_P(sc)) {
         ptr = SCM_STRING_CURSOR_SMALL_POINTER(sb, sc);
@@ -1703,13 +1707,15 @@ static ScmObj make_string_cursor(ScmString *src, const char *ptr)
     }
 
     ScmSmallInt offset = (ScmSmallInt)(ptr - SCM_STRING_BODY_START(srcb));
-    if (SCM_STRING_CURSOR_FITS_SMALL_P(offset)) {
+    if (!SCM_VM_COMPILER_FLAG_IS_SET(Scm_VM(), SCM_SAFE_STRING_CURSORS) &&
+        SCM_STRING_CURSOR_FITS_SMALL_P(offset)) {
         return SCM_MAKE_STRING_CURSOR_SMALL(offset);
     }
 
     ScmStringCursorLarge *sc = SCM_NEW(ScmStringCursorLarge);
     SCM_SET_CLASS(sc, SCM_CLASS_STRING_CURSOR_LARGE);
     sc->offset = offset;
+    sc->start = SCM_STRING_BODY_START(srcb);
     return SCM_OBJ(sc);
 }
 
@@ -1730,12 +1736,14 @@ ScmObj Scm_MakeStringCursorEnd(ScmString *src)
     const ScmStringBody *srcb = SCM_STRING_BODY(src);
 
     ScmSmallInt offset = SCM_STRING_BODY_END(srcb) - SCM_STRING_BODY_START(srcb);
-    if (SCM_STRING_CURSOR_FITS_SMALL_P(offset)) {
+    if (!SCM_VM_COMPILER_FLAG_IS_SET(Scm_VM(), SCM_SAFE_STRING_CURSORS) &&
+        SCM_STRING_CURSOR_FITS_SMALL_P(offset)) {
         return SCM_MAKE_STRING_CURSOR_SMALL(offset);
     }
     ScmStringCursorLarge *sc = SCM_NEW(ScmStringCursorLarge);
     SCM_SET_CLASS(sc, SCM_CLASS_STRING_CURSOR_LARGE);
     sc->offset = offset;
+    sc->start = SCM_STRING_BODY_START(srcb);
     return SCM_OBJ(sc);
 }
 


### PR DESCRIPTION
This is similar to Chibi's -Dsafe-string-cursors. This option forces all
cursors to be large. The large cursor is also slightly larger because it
keeps string body's start pointer in it so that we can check if the
right string is used with it.

This mode is obviously not meant for normal use. Only when you want to
make sure your code does not use invalid cursors.

This can also be used by Gauche devs to make sure large cursor code
works well because usually only small cursors are used (and also the
reason that making large cursors larger does not affect anything).