### PR TITLE
Import chibi.show and submodules

### DIFF
--- a/lib/chibi/show.sld
+++ b/lib/chibi/show.sld
@@ -1,0 +1,15 @@
+
+(define-library (chibi show)
+  (export
+   show fn forked with with! each each-in-list call-with-output
+   displayed written written-shared written-simply
+   numeric numeric/comma numeric/si numeric/fitted
+   nothing nl fl space-to tab-to escaped maybe-escaped
+   padded padded/left padded/right padded/both
+   trimmed trimmed/left trimmed/right trimmed/both trimmed/lazy
+   fitted fitted/left fitted/right fitted/both
+   joined joined/prefix joined/suffix joined/last joined/dot joined/range
+   upcased downcased)
+  (import (scheme base) (scheme char) (scheme write)
+          (chibi show base))
+  (include "show/show.scm"))

--- a/lib/chibi/show/base.scm
+++ b/lib/chibi/show/base.scm
@@ -1,0 +1,143 @@
+;; base.scm - base formatting monad
+;; Copyright (c) 2013 Alex Shinn.  All rights reserved.
+;; BSD-style license: http://synthcode.com/license.txt
+
+;;> The minimal base formatting combinators and show interface.
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;> The environment monad with some pre-defined fields for combinator
+;;> formatting.
+
+(define-environment-monad Show-Env
+  (sequence: sequence)
+  (bind: %fn)
+  (bind-fork: forked)
+  (local: %with)
+  (local!: with!)
+  (return: return)
+  (run: run)
+  (fields:
+   (port env-port env-port-set!)
+   (row env-row env-row-set!)
+   (col env-col env-col-set!)
+   (width env-width env-width-set!)
+   (radix env-radix env-radix-set!)
+   (precision env-precision env-precision-set!)
+   (pad-char env-pad-char env-pad-char-set!)
+   (decimal-sep env-decimal-sep env-decimal-sep-set!)
+   (decimal-align env-decimal-align env-decimal-align-set!)
+   (string-width env-string-width env-string-width-set!)
+   (ellipsis env-ellipsis env-ellipsis-set!)
+   (writer env-writer env-writer-set!)
+   (output env-output env-output-set!)))
+
+(define-syntax fn
+  (syntax-rules ()
+    ((fn vars expr ... fmt)
+     (%fn vars expr ... (displayed fmt)))))
+
+;; The base formatting handles outputting raw strings and a simple,
+;; configurable handler for formatting objects.
+
+;; Utility - default value of string-width.
+(define (substring-length str . o)
+  (let ((start (if (pair? o) (car o) 0))
+        (end (if (and (pair? o) (pair? (cdr o))) (cadr o) (string-length str))))
+    (- end start)))
+
+;; Raw output.  All primitive output should go through this operation.
+;; Overridable, defaulting to output-default.
+(define (output str)
+  (fn (output) ((or output output-default) str)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;> \procedure{(show out [args ...])}
+;;>
+;;> Run the combinators \var{args}, accumulating the output to
+;;> \var{out}, which is either an output port or a boolean, with
+;;> \scheme{#t} indicating \scheme{current-output-port} and
+;;> \scheme{#f} to collect the output as a string.
+(define (show out . args)
+  (let ((proc (each-in-list args)))
+    (cond
+     ((output-port? out)
+      (show-run out proc))
+     ((eq? #t out)
+      (show-run (current-output-port) proc))
+     ((eq? #f out)
+      (let ((out (open-output-string)))
+        (show-run out proc) 
+        (get-output-string out)))
+     (else
+      (error "unknown output to show" out)))))
+
+;; Run with an output port with initial default values.
+(define (show-run out proc)
+  (run (sequence (with! (port out)
+                        (col 0)
+                        (row 0)
+                        (width 78)
+                        (radix 10)
+                        (pad-char #\space)
+                        (output output-default)
+                        (string-width substring-length))
+                 proc)))
+
+;;> Temporarily bind the parameters in the body \var{x}.
+
+(define-syntax with
+  (syntax-rules ()
+    ((with params x ... y)
+     (%with params (each x ... y)))))
+
+;;> The noop formatter.  Generates no output and leaves the state
+;;> unmodified.
+(define nothing (fn () (with!)))
+
+;;> Formats a displayed version of x - if a string or char, outputs the
+;;> raw characters (as with `display'), if x is already a formatter
+;;> defers to that, otherwise outputs a written version of x.
+(define (displayed x)
+  (cond
+   ((procedure? x) x)
+   ((string? x) (output x))
+   ((char? x) (output (string x)))
+   (else (written x))))
+
+;;> Formats a written version of x, as with `write'.  The formatting
+;;> can be updated with the \scheme{'writer} field.
+(define (written x)
+  (fn (writer) ((or writer written-default) x)))
+
+;;> Takes a single list of formatters, combined in sequence with
+;;> \scheme{each}.
+(define (each-in-list args)
+  (if (pair? args)
+      (sequence (displayed (car args)) (each-in-list (cdr args)))
+      nothing))
+
+;;> Combines each of the formatters in a sequence using
+;;> \scheme{displayed}, so that strings and chars will be output
+;;> directly and other objects will be \scheme{written}.
+(define (each . args)
+  (each-in-list args))
+
+;;> Raw output - displays str to the formatter output port and updates
+;;> row and col.
+(define (output-default str)
+  (fn (port row col string-width)
+    (display str port)
+    (let ((nl-index (string-find-right str #\newline)))
+      (if (string-cursor>? nl-index (string-cursor-start str))
+          (with! (row (+ row (string-count str #\newline)))
+                 (col (string-width str (string-cursor->index str nl-index))))
+          (with! (col (+ col (string-width str))))))))
+
+;;> Captures the output of \var{producer} and formats the result with
+;;> \var{consumer}.
+(define (call-with-output producer consumer)
+  (let ((out (open-output-string)))
+    (forked (with ((port out) (output output-default)) producer)
+            (fn () (consumer (get-output-string out))))))

--- a/lib/chibi/show/base.sld
+++ b/lib/chibi/show/base.sld
@@ -1,0 +1,31 @@
+
+(define-library (chibi show base)
+  (export
+   show fn forked with with! each each-in-list call-with-output
+   displayed written written-shared written-simply numeric nothing
+   escaped maybe-escaped numeric/si numeric/fitted numeric/comma
+   ;; internal
+   output-default extract-shared-objects write-to-string write-with-shares
+   call-with-shared-ref call-with-shared-ref/cdr)
+  (import (scheme base) (scheme write) (scheme complex) (scheme inexact)
+          (srfi 1) (srfi 69) (chibi string) (chibi monad environment))
+  (cond-expand
+   (chibi
+    (import (only (chibi) let-optionals*)))
+   (else
+    (begin
+      (define-syntax let-optionals*
+        (syntax-rules ()
+          ((let-optionals* opt-ls () . body)
+           (begin . body))
+          ((let-optionals* (op . args) vars . body)
+           (let ((tmp (op . args)))
+             (let-optionals* tmp vars . body)))
+          ((let-optionals* tmp ((var default) . rest) . body)
+           (let ((var (if (pair? tmp) (car tmp) default))
+                 (tmp2 (if (pair? tmp) (cdr tmp) '())))
+             (let-optionals* tmp2 rest . body)))
+          ((let-optionals* tmp tail . body)
+           (let ((tail tmp)) . body)))))))
+  (include "base.scm")
+  (include "write.scm"))

--- a/lib/chibi/show/color.scm
+++ b/lib/chibi/show/color.scm
@@ -1,0 +1,43 @@
+;; color.scm -- colored output
+;; Copyright (c) 2006-2017 Alex Shinn.  All rights reserved.
+;; BSD-style license: http://synthcode.com/license.txt
+
+(define (color->ansi x)
+  (case x
+    ((bold) "1")
+    ((dark) "2")
+    ((underline) "4")
+    ((black) "30")
+    ((red) "31")
+    ((green) "32")
+    ((yellow) "33")
+    ((blue) "34")
+    ((magenta) "35")
+    ((cyan) "36")
+    ((white) "37")
+    (else "0")))
+
+(define (ansi-escape color)
+  (string-append (string (integer->char 27)) "[" (color->ansi color) "m"))
+
+(define (colored new-color . args)
+  (fn (color)
+    (with ((color new-color))
+      (each (ansi-escape new-color)
+            (each-in-list args)
+            (if (or (memq new-color '(bold underline))
+                    (memq color '(bold underline)))
+                (ansi-escape 'reset)
+                nothing)
+            (ansi-escape color)))))
+
+(define (as-red . args) (colored 'red (each-in-list args)))
+(define (as-blue . args) (colored 'blue (each-in-list args)))
+(define (as-green . args) (colored 'green (each-in-list args)))
+(define (as-cyan . args) (colored 'cyan (each-in-list args)))
+(define (as-yellow . args) (colored 'yellow (each-in-list args)))
+(define (as-magenta . args) (colored 'magenta (each-in-list args)))
+(define (as-white . args) (colored 'white (each-in-list args)))
+(define (as-black . args) (colored 'black (each-in-list args)))
+(define (as-bold . args) (colored 'bold (each-in-list args)))
+(define (as-underline . args) (colored 'underline (each-in-list args)))

--- a/lib/chibi/show/color.sld
+++ b/lib/chibi/show/color.sld
@@ -1,0 +1,7 @@
+
+(define-library (chibi show color)
+  (import (scheme base) (chibi show base))
+  (export as-red as-blue as-green as-cyan as-yellow
+          as-magenta as-white as-black
+          as-bold as-underline)
+  (include "color.scm"))

--- a/lib/chibi/show/column.scm
+++ b/lib/chibi/show/column.scm
@@ -1,0 +1,480 @@
+;; column.scm -- formatting columns and tables
+;; Copyright (c) 2006-2017 Alex Shinn.  All rights reserved.
+;; BSD-style license: http://synthcode.com/license.txt
+
+(define (string-split-words str separator?)
+  (let ((start (string-cursor-start str))
+        (end (string-cursor-end str)))
+    (let lp ((sc start) (res '()))
+      (cond
+       ((string-cursor>=? sc end)
+        (reverse res))
+       (else
+        (let ((sc2 (string-index str separator? sc)))
+          (lp (string-cursor-next str sc2)
+              (if (string-cursor=? sc sc2)
+                  res
+                  (cons (substring/cursors str sc sc2) res)))))))))
+
+(define (call-with-output-generator producer consumer)
+  (fn ()
+    (let ((out (open-output-string))
+          (queue (list-queue))
+          (return #f)
+          (resume #f))
+      (define eof (read-char (open-input-string "")))
+      (define (output* str)
+        (fn (row col string-width)
+          (list-queue-add-back! queue str)
+          (each
+           (let ((nl-index
+                  (string-index-right str (lambda (ch) (eqv? ch #\newline)))))
+             (if (string-cursor>? nl-index (string-cursor-start str))
+                 (with!
+                  (row (+ row (string-count str (lambda (ch) (eqv? ch #\newline)))))
+                  (col (string-width str (string-cursor->index str nl-index))))
+                 (with! (col (+ col (string-width str))))))
+           (call-with-current-continuation
+            (lambda (cc)
+              (set! resume cc)
+              (return nothing))))
+          nothing))
+      (define (generate)
+        (when (and resume (list-queue-empty? queue))
+          (call-with-current-continuation
+           (lambda (cc)
+             (set! return cc)
+             (resume nothing))))
+        (if (list-queue-empty? queue)
+            eof
+            (list-queue-remove-front! queue)))
+      (forked (fn () (with ((port out) (output output*))
+                       (call-with-current-continuation
+                        (lambda (cc)
+                          (set! return cc)
+                          (each producer
+                                (fn (output)
+                                  (set! resume #f)
+                                  (fn () (return nothing) nothing)))))))
+               (consumer generate)))))
+
+(define (call-with-output-generators producers consumer)
+  (let lp ((ls producers) (generators '()))
+    (if (null? ls)
+        (consumer (reverse generators))
+        (call-with-output-generator
+         (car ls)
+         (lambda (generator)
+           (lp (cdr ls) (cons generator generators)))))))
+
+(define (string->line-generator source)
+  (let ((str '())
+        (scanned? #f))
+    (define (gen)
+      (if (pair? str)
+          (if scanned?
+              (let ((res (source)))
+                (cond
+                 ((eof-object? res)
+                  (let ((res (string-concatenate (reverse str))))
+                    (set! str '())
+                    res))
+                 ((equal? res "")
+                  (gen))
+                 (else
+                  (set! str (cons res str))
+                  (set! scanned? #f)
+                  (gen))))
+              (let ((nl (string-index (car str) #\newline))
+                    (end (string-cursor-end (car str))))
+                (cond
+                 ((string-cursor<? nl end)
+                  (let* ((left (substring/cursors
+                                (car str)
+                                (string-cursor-start (car str))
+                                nl))
+                         (right (substring/cursors
+                                 (car str)
+                                 (string-cursor-next (car str) nl)
+                                 end))
+                         (res (string-concatenate
+                               (reverse (cons left (cdr str))))))
+                    (set! str (if (equal? right "") '() (list right)))
+                    res))
+                 (else
+                  (set! scanned? #t)
+                  (gen)))))
+          (let ((res (source)))
+            (cond
+             ((eof-object? res)
+              res)
+             ((equal? res "")
+              (gen))
+             (else
+              (set! str (cons res str))
+              (set! scanned? #f)
+              (gen))))))
+    gen))
+
+(define-record-type Column
+  (make-column format generate infinite?)
+  column?
+  (format column-format)
+  (generate column-generate)
+  (infinite? column-infinite?))
+
+;; (show-columns (fmt gen [infinite?]) ...)
+(define (show-columns . ls)
+  (fn ()
+    (let* ((cols (map (lambda (x)
+                        (make-column (or (car x) displayed)
+                                     (displayed (cadr x))
+                                     (and (pair? (cddr x)) (car (cddr x)))))
+                      ls))
+           (num-infinite (count column-infinite? cols)))
+      (call-with-output-generators
+       (map column-generate cols)
+       (lambda (gens)
+         (let ((gens (map string->line-generator gens)))
+           (let lp ()
+             (let* ((lines (map (lambda (gen) (gen)) gens))
+                    (num-present (count string? lines)))
+               (if (<= num-present num-infinite)
+                   nothing
+                   (each
+                    (each-in-list
+                     (map (lambda (col line)
+                            ((column-format col)
+                             (if (eof-object? line) "" line)))
+                          cols
+                          lines))
+                    "\n"
+                    (fn () (lp))))))))))))
+
+;; (columnar ['infinite|'right|'left|'center|width] string-or-formatter ...)
+(define (columnar . ls)
+  (define (proportional-width? w)
+    (and (number? w)
+         (or (< 0 w 1)
+             (and (inexact? w) (= w 1.0)))))
+  (define (build-column ls)
+    (let-optionals* ls ((fixed-width #f)
+                        (col-width #f)
+                        (last? #t)
+                        (tail '())
+                        (gen #f)
+                        (prefix '())
+                        (align 'left)
+                        (infinite? #f))
+      (define (scale-width width)
+        (max 1 (exact (truncate (* col-width (- width fixed-width))))))
+      (define (padder)
+        (if (proportional-width? col-width)
+            (case align
+              ((right)
+               (lambda (str) (fn (width) (padded/left (scale-width width) str))))
+              ((center)
+               (lambda (str) (fn (width) (padded/both (scale-width width) str))))
+              (else
+               (lambda (str) (fn (width) (padded/right (scale-width width) str)))))
+            (case align
+              ((right) (lambda (str) (padded/left col-width str)))
+              ((center) (lambda (str) (padded/both col-width str)))
+              (else (lambda (str) (padded/right col-width str))))))
+      (define (affix x)
+        (cond
+         ((pair? tail)
+          (lambda (str)
+            (each (each-in-list prefix)
+                  (x str)
+                  (each-in-list tail))))
+         ((pair? prefix)
+          (lambda (str) (each (each-in-list prefix) (x str))))
+         (else (displayed x))))
+      (list
+       ;; line formatter
+       (affix
+        (let ((pad (padder)))
+          (if (and last? (not (pair? tail)) (eq? align 'left))
+              (lambda (str)
+                (fn (pad-char)
+                  ((if (or (not pad-char) (char-whitespace? pad-char))
+                       displayed
+                       pad)
+                   str)))
+              pad)))
+       ;; generator
+       (if (proportional-width? col-width)
+           (fn (width)
+             (with ((width (scale-width width)))
+               gen))
+           (with ((width col-width)) gen))
+       infinite?)))
+  (define (adjust-widths ls border-width)
+    (let* ((fixed-ls
+            (filter (lambda (x) (and (number? (car x)) (>= (car x) 1))) ls))
+           (fixed-total (fold + border-width (map car fixed-ls)))
+           (scaled-ls (filter (lambda (x) (proportional-width? (car x))) ls))
+           (denom (- (length ls) (+ (length fixed-ls) (length scaled-ls))))
+           (rest (if (zero? denom)
+                     0
+                     (inexact
+                      (/ (- 1 (fold + 0 (map car scaled-ls))) denom)))))
+      (if (negative? rest)
+          (error "fractional widths must sum to less than 1"
+                 (map car scaled-ls)))
+      (map
+       (lambda (col)
+         (cons fixed-total
+               (if (not (number? (car col)))
+                   (cons rest (cdr col))
+                   col)))
+       ls)))
+  (define (finish ls border-width)
+    (apply show-columns
+           (map build-column (adjust-widths (reverse ls) border-width))))
+  (let lp ((ls ls) (strs '()) (align 'left) (infinite? #f)
+           (width #t) (border-width 0) (res '()))
+    (cond
+     ((null? ls)
+      (if (pair? strs)
+          (finish (cons (cons (caar res)
+                              (cons #t (cons (append (reverse strs)
+                                                     (cadr (cdar res)))
+                                             (cddr (cdar res)))))
+                        (cdr res))
+                  border-width)
+          (finish (cons (cons (caar res) (cons #t (cddr (car res)))) (cdr res))
+                  border-width)))
+     ((char? (car ls))
+      (lp (cons (string (car ls)) (cdr ls)) strs align infinite?
+          width border-width res))
+     ((string? (car ls))
+      (if (string-contains "\n" (car ls))
+          (error "column string literals can't contain newlines")
+          (lp (cdr ls) (cons (car ls) strs) align infinite?
+              width (+ border-width (string-length (car ls))) res)))
+     ((number? (car ls))
+      (lp (cdr ls) strs align infinite? (car ls) border-width res))
+     ((eq? (car ls) 'infinite)
+      (lp (cdr ls) strs align #t width border-width res))
+     ((symbol? (car ls))
+      (lp (cdr ls) strs (car ls) infinite? width border-width res))
+     ((procedure? (car ls))
+      (lp (cdr ls) '() 'left #f #t border-width
+          (cons (list width #f '() (car ls) (reverse strs) align infinite?)
+                res)))
+     (else
+      (error "invalid column" (car ls))))))
+
+(define (max-line-width string-width str)
+  (let ((end (string-cursor-end str)))
+    (let lp ((i (string-cursor-start str)) (hi 0))
+      (let ((j (string-index str #\newline i)))
+        (if (string-cursor<? j end)
+            (lp (string-cursor-next str j)
+                (max hi (string-width (substring/cursors str i j))))
+            (max hi (string-width (substring/cursors str i end))))))))
+
+(define (pad-finite proc width string-width k)
+  (call-with-output
+   proc
+   (lambda (str)
+     (let ((w (max-line-width (or string-width string-length) str)))
+       (k (displayed str)
+          (if (and (integer? width) (exact? width))
+              (max width w)
+              w))))))
+
+(define (tabular . ls)
+  (fn (string-width)
+    (let lp ((ls ls) (infinite? #f) (width #t) (res '()))
+      (cond
+       ((null? ls)
+        (apply columnar (reverse res)))
+       ((number? (car ls))
+        (lp (cdr ls) infinite? (car ls) res))
+       ((eq? 'infinite (car ls))
+        (lp (cdr ls) #t width (cons (car ls) res)))
+       ((procedure? (car ls))
+        (if infinite?
+            (if width
+                (lp (cdr ls) #f #t (cons (car ls) (cons width res)))
+                (lp (cdr ls) #f #t (cons (car ls) res)))
+            (pad-finite (car ls) width string-width
+                        (lambda (gen width)
+                          (lp (cdr ls) #f #t (cons gen (cons width res)))))))
+       (else
+        (lp (cdr ls) infinite? width (cons (car ls) res)))))))
+
+;; break lines only, don't join short lines or justify
+(define (wrapped/char . ls)
+  (fn (output width string-width)
+    (define (kons-in-line str)
+      (fn (col)
+        (let ((len ((or string-width string-length) str))
+              (space (- width col)))
+          (cond
+           ((equal? "" str)
+            nothing)
+           ((or (<= len space) (not (positive? space)))
+            (each (output str) (output "\n")))
+           (else
+            (each
+             ;; TODO: when splitting by string-width, substring needs
+             ;; to be provided
+             (output (substring str 0 space))
+             (output "\n")
+             (fn () (kons-in-line (substring str space len)))))))))
+    (with ((output
+            (lambda (str)
+              (let ((end (string-cursor-end str)))
+                (let lp ((i (string-cursor-start str)))
+                  (let ((nli (string-index str #\newline i)))
+                    (cond
+                     ((string-cursor>=? i end)
+                      nothing)
+                     ((string-cursor>=? nli end)
+                      (kons-in-line (substring/cursors str i end)))
+                     (else
+                      (each
+                       (fn () (kons-in-line (substring/cursors str i nli)))
+                       (fn () (lp (string-cursor-next str nli))))))))))))
+      (each-in-list ls))))
+
+;; `seq' is a list or vector of pre-tokenized words.  `line' is called
+;; on each wrapped line and the accumulator, starting with `knil'.
+;; The optional `last-line' is used instead on the last line of the
+;; paragraph.
+(define (wrap-fold-words seq knil max-width get-width line . o)
+  (let* ((last-line (if (pair? o) (car o) line))
+         (vec (if (list? seq) (list->vector seq) seq))
+         (len (vector-length vec))
+         (len-1 (- len 1))
+         (breaks (make-vector len #f))
+         (penalties (make-vector len #f))
+         (widths
+          (list->vector
+           (map get-width (if (list? seq) seq (vector->list vec))))))
+    (define (largest-fit i)
+      (let lp ((j (+ i 1)) (width (vector-ref widths i)))
+        (let ((width (+ width 1 (vector-ref widths j))))
+          (cond
+            ((>= width max-width) (- j 1))
+            ((>= j len-1) len-1)
+            (else (lp (+ j 1) width))))))
+    (define (min-penalty! i)
+      (cond
+        ((>= i len-1) 0)
+        ((vector-ref penalties i))
+        (else
+         (vector-set! penalties i (expt (+ max-width 1) 3))
+         (vector-set! breaks i i)
+         (let ((k (largest-fit i)))
+           (let lp ((j i) (width 0))
+             (if (<= j k)
+                 (let* ((width (+ width (vector-ref widths j)))
+                        (break-penalty
+                         (+ (max 0 (expt (- max-width (+ width (- j i))) 3))
+                            (min-penalty! (+ j 1)))))
+                   (cond
+                     ((< break-penalty (vector-ref penalties i))
+                      (vector-set! breaks i j)
+                      (vector-set! penalties i break-penalty)))
+                   (lp (+ j 1) width)))))
+         (if (>= (vector-ref breaks i) len-1)
+             (vector-set! penalties i 0))
+         (vector-ref penalties i))))
+    (define (sub-list i j)
+      (let lp ((i i) (res '()))
+        (if (> i j)
+            (reverse res)
+            (lp (+ i 1) (cons (vector-ref vec i) res)))))
+    (cond
+     ((zero? len)
+      ;; degenerate case
+      (last-line '() knil))
+     (else
+      ;; compute optimum breaks
+      (vector-set! breaks len-1 len-1)
+      (vector-set! penalties len-1 0)
+      (min-penalty! 0)
+      ;; fold
+      (let lp ((i 0) (acc knil))
+        (let ((break (vector-ref breaks i)))
+          (if (>= break len-1)
+              (last-line (sub-list i len-1) acc)
+              (lp (+ break 1) (line (sub-list i break) acc)))))))))
+
+(define (wrapped/list ls)
+  (fn (width string-width pad-char)
+    (joined/suffix
+     (lambda (ls) (joined displayed ls pad-char))
+     (reverse
+      (wrap-fold-words ls '() width (or string-width string-length) cons))
+     "\n")))
+
+(define (wrapped . ls)
+  (call-with-output
+   (each-in-list ls)
+   (lambda (str)
+     (fn (word-separator?)
+       (wrapped/list
+        (string-split-words str (or word-separator? char-whitespace?)))))))
+
+(define (justified . ls)
+  (fn (output width string-width)
+    (define (justify-line ls)
+      (if (null? ls)
+          nl
+          (let* ((sum (fold (lambda (s n)
+                              (+ n ((or string-width string-length) s)))
+                            0 ls))
+                 (len (length ls))
+                 (diff (max 0 (- width sum)))
+                 (sep (make-string (if (= len 1)
+                                       0
+                                       (quotient diff (- len 1)))
+                                   #\space))
+                 (rem (if (= len 1)
+                          diff
+                          (remainder diff (- len 1))))
+                 (p (open-output-string)))
+            (display (car ls) p)
+            (let lp ((ls (cdr ls)) (i 1))
+              (when (pair? ls)
+                (display sep p)
+                (if (<= i rem) (write-char #\space p))
+                (display (car ls) p)
+                (lp (cdr ls) (+ i 1))))
+            (displayed (get-output-string p)))))
+    (define (justify-last ls)
+      (each (joined displayed ls " ") "\n"))
+    (call-with-output
+     (each-in-list ls)
+     (lambda (str)
+       (fn (word-separator?)
+         (joined/last
+          justify-line
+          justify-last
+          (reverse
+           (wrap-fold-words
+            (string-split-words str (or word-separator? char-whitespace?))
+            '() width (or string-width string-length)
+            cons))
+          "\n"))))))
+
+(define (from-file path . ls)
+  (let-optionals* ls ((sep nl))
+    (fn ()
+      (let ((in (open-input-file path)))
+        (let lp ()
+          (let ((line (read-line in)))
+            (if (eof-object? line)
+                (begin (close-input-port in) nothing)
+                (each line sep
+                      (fn () (lp))))))))))
+
+(define (line-numbers . o)
+  (let ((start (if (pair? o) (car o) 1)))
+    (joined/range displayed start #f "\n")))

--- a/lib/chibi/show/column.sld
+++ b/lib/chibi/show/column.sld
@@ -1,0 +1,11 @@
+
+(define-library (chibi show column)
+  (import (scheme base) (scheme char) (scheme file) (scheme write)
+          (srfi 1) (srfi 117) (srfi 130)
+          (chibi optional) (chibi show))
+  (export
+   call-with-output-generator call-with-output-generators
+   string->line-generator
+   tabular columnar show-columns wrapped wrapped/list wrapped/char
+   justified line-numbers from-file)
+  (include "column.scm"))

--- a/lib/chibi/show/pretty.scm
+++ b/lib/chibi/show/pretty.scm
@@ -1,0 +1,368 @@
+;; pretty.scm -- pretty printing format combinator
+;; Copyright (c) 2006-2018 Alex Shinn.  All rights reserved.
+;; BSD-style license: http://synthcode.com/license.txt
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; utilities
+
+(define (take* ls n)   ; handles dotted lists and n > length
+  (cond ((zero? n) '())
+        ((pair? ls) (cons (car ls) (take* (cdr ls) (- n 1))))
+        (else '())))
+
+(define (drop* ls n)   ; may return the dot
+  (cond ((zero? n) ls)
+        ((pair? ls) (drop* (cdr ls) (- n 1)))
+        (else ls)))
+
+(define (make-space n) (make-string n #\space))
+(define (make-nl-space n) (string-append "\n" (make-string n #\space)))
+
+(define (joined/shares fmt ls shares . o)
+  (let ((sep (displayed (if (pair? o) (car o) " "))))
+    (fn ()
+      (if (null? ls)
+          nothing
+          (let lp ((ls ls))
+            (each
+             (fmt (car ls))
+             (let ((rest (cdr ls)))
+               (cond
+                ((null? rest) nothing)
+                ((pair? rest)
+                 (call-with-shared-ref/cdr rest
+                                           shares
+                                           (fn () (lp rest))
+                                           sep))
+                (else (each sep ". " (fmt rest)))))))))))
+
+(define (string-find/index str pred i)
+  (string-cursor->index
+   str
+   (string-find str pred (string-index->cursor str i))))
+
+(define (try-fitted2 proc fail)
+  (fn (width output)
+    (let ((out (open-output-string)))
+      (call-with-current-continuation
+       (lambda (abort)
+         ;; Modify output to accumulate to an output string port,
+         ;; and escape immediately with failure if we exceed the
+         ;; column width.
+         (define (output* str)
+           (fn (col)
+             (let lp ((i 0) (col col))
+               (let ((nli (string-find/index str #\newline i))
+                     (len (string-length str)))
+                 (if (< nli len)
+                     (if (> (+ (- nli i) col) width)
+                         (abort fail)
+                         (lp (+ nli 1) 0))
+                     (let ((col (+ (- len i) col)))
+                       (cond
+                        ((> col width)
+                         (abort fail))
+                        (else
+                         (output-default str)))))))))
+         (forked
+          (with ((output output*)
+                 (port out))
+            proc)
+          ;; fitted successfully
+          (output (get-output-string out))))))))
+
+(define (try-fitted proc . fail)
+  (if (null? fail)
+      proc
+      (try-fitted2 proc (apply try-fitted fail))))
+
+(define (fits-in-width width proc)
+  (call-with-current-continuation
+   (lambda (abort)
+     (show
+      #f
+      (fn (output)
+        (define (output* str)
+          (each (output str)
+                (fn (col)
+                  (if (>= col width)
+                      (abort #f)
+                      nothing))))
+        (with ((output output*))
+          proc))))))
+
+(define (fits-in-columns width ls writer)
+  (let ((max-w (quotient width 2)))
+    (let lp ((ls ls) (res '()) (widest 0))
+      (cond
+       ((pair? ls)
+        (let ((str (fits-in-width max-w (writer (car ls)))))
+          (and str
+               (lp (cdr ls)
+                   (cons str res)
+                   (max (string-length str) widest)))))
+       ((null? ls) (cons widest (reverse res)))
+       (else #f)))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; style
+
+(define syntax-abbrevs
+  '((quote . "'") (quasiquote . "`")
+    (unquote . ",") (unquote-splicing . ",@")
+    ))
+
+(define (pp-let ls pp shares)
+  (if (and (pair? (cdr ls)) (symbol? (cadr ls)))
+      (pp-with-indent 2 ls pp shares)
+      (pp-with-indent 1 ls pp shares)))
+
+(define indent-rules
+  `((lambda . 1) (define . 1)
+    (let . ,pp-let) (loop . ,pp-let)
+    (let* . 1) (letrec . 1) (letrec* . 1) (and-let* . 1) (let1 . 2)
+    (let-values . 1) (let*-values . 1) (receive . 2) (parameterize . 1)
+    (let-syntax . 1) (letrec-syntax . 1) (syntax-rules . 1) (syntax-case . 2)
+    (match . 1) (match-let . 1) (match-let* . 1)
+    (if . 3) (when . 1) (unless . 1) (case . 1) (while . 1) (until . 1)
+    (do . 2) (dotimes . 1) (dolist . 1) (test . 1)
+    (condition-case . 1) (guard . 1) (rec . 1)
+    (call-with-current-continuation . 0)
+    ))
+
+(define indent-prefix-rules
+  `(("with-" . -1) ("call-with-" . -1) ("define-" . 1))
+  )
+
+(define indent-suffix-rules
+  `(("-case" . 1))
+  )
+
+(define (pp-indentation form)
+  (let ((indent
+         (cond
+          ((assq (car form) indent-rules) => cdr)
+          ((and (symbol? (car form))
+                (let ((str (symbol->string (car form))))
+                  (or (find (lambda (rx) (string-prefix? (car rx) str))
+                            indent-prefix-rules)
+                      (find (lambda (rx) (string-suffix? (car rx) str))
+                            indent-suffix-rules))))
+           => cdr)
+          (else #f))))
+    (if (and (number? indent) (negative? indent))
+        (max 0 (- (+ (or (length+ form) +inf.0) indent) 1))
+        indent)))
+
+(define (with-reset-shares shares proc)
+  (let ((orig-count (cdr shares)))
+    (fn ()
+      (let ((new-count (cdr shares)))
+        (cond
+         ((> new-count orig-count)
+          (hash-table-walk
+           (car shares)
+           (lambda (k v)
+             (if (and (cdr v) (>= (car v) orig-count))
+                 (set-cdr! v #f))))
+          (set-cdr! shares orig-count)))
+        proc))))
+
+(define (pp-with-indent indent-rule ls pp shares)
+  (fn ((col1 col))
+    (each
+     "("
+     (pp (car ls))
+     (fn ((col2 col) width string-width)
+       (let ((fixed (take* (cdr ls) (or indent-rule 1)))
+             (tail (drop* (cdr ls) (or indent-rule 1)))
+             (default
+               (let ((sep (make-nl-space (+ col1 1))))
+                 (each sep (joined/shares pp (cdr ls) shares sep))))
+             ;; reset in case we don't fit on the first line
+             (reset-shares (with-reset-shares shares nothing)))
+         (call-with-output
+          (trimmed/lazy (- width col2)
+                        (each " "
+                              (joined/shares
+                               (lambda (x) (pp-flat x pp shares)) fixed shares " "))
+                        )
+          (lambda (first-line)
+            (cond
+             ((< (+ col2 (string-width first-line)) width)
+              ;; fixed values on first line
+              (let ((sep (make-nl-space
+                          (if indent-rule (+ col1 2) (+ col2 1)))))
+                (each first-line
+                      (cond
+                       ((not (or (null? tail) (pair? tail)))
+                        (each ". " (pp tail)))
+                       ((> (or (length+ (cdr ls)) +inf.0) (or indent-rule 1))
+                        (each sep (joined/shares pp tail shares sep)))
+                       (else
+                        nothing)))))
+             (indent-rule
+              ;; fixed values lined up, body indented two spaces
+              (try-fitted
+               (each
+                reset-shares
+                " "
+                (joined/shares pp fixed shares (make-nl-space (+ col2 1)))
+                (if (pair? tail)
+                    (let ((sep (make-nl-space (+ col1 2))))
+                      (each sep (joined/shares pp tail shares sep)))
+                    nothing))
+               (each reset-shares default)))
+             (else
+              ;; all on separate lines
+              (each reset-shares default)))))))
+     ")")))
+
+(define (pp-app ls pp shares)
+  (let ((indent-rule (pp-indentation ls)))
+    (if (procedure? indent-rule)
+        (indent-rule ls pp shares)
+        (pp-with-indent indent-rule ls pp shares))))
+
+;; the elements may be shared, just checking the top level list
+;; structure
+(define (proper-non-shared-list? ls shares)
+  (let ((tab (car shares)))
+    (let lp ((ls ls))
+      (or (null? ls)
+          (and (pair? ls)
+               (not (hash-table-ref/default tab ls #f))
+               (lp (cdr ls)))))))
+
+(define (non-app? x)
+  (if (pair? x)
+      (or (not (or (null? (cdr x)) (pair? (cdr x))))
+          (non-app? (car x)))
+      (not (symbol? x))))
+
+(define (pp-data-list ls pp shares)
+  (each
+   "("
+   (fn (col width string-width)
+     (let ((avail (- width col)))
+       (cond
+        ((and (pair? (cdr ls)) (pair? (cddr ls)) (pair? (cdr (cddr ls)))
+              (fits-in-columns width ls (lambda (x) (pp-flat x pp shares))))
+         => (lambda (ls)
+              ;; at least four elements which can be broken into columns
+              (let* ((prefix (make-nl-space col))
+                     (widest (+ 1 (car ls)))
+                     (columns (quotient width widest))) ; always >= 2
+                (let lp ((ls (cdr ls)) (i 1))
+                  (cond
+                   ((null? ls)
+                    nothing)
+                   ((null? (cdr ls))
+                    (displayed (car ls)))
+                   ((>= i columns)
+                    (each (car ls)
+                          prefix
+                          (fn () (lp (cdr ls) 1))))
+                   (else
+                    (let ((pad (- widest (string-width (car ls)))))
+                      (each (car ls)
+                            (make-space pad)
+                            (lp (cdr ls) (+ i 1))))))))))
+        (else
+         ;; no room, print one per line
+         (joined/shares pp ls shares (make-nl-space col))))))
+   ")"))
+
+(define (pp-flat x pp shares)
+  (cond
+   ((pair? x)
+    (cond
+     ((and (pair? (cdr x)) (null? (cddr x))
+           (assq (car x) syntax-abbrevs))
+      => (lambda (abbrev)
+           (each (cdr abbrev)
+                 (call-with-shared-ref
+                  (cadr x)
+                  shares
+                  (pp-flat (cadr x) pp shares)))))
+     (else
+      (each "("
+            (joined/shares (lambda (x) (pp-flat x pp shares)) x shares " ")
+            ")"))))
+   ((vector? x)
+    (each "#("
+          (joined/shares
+           (lambda (x) (pp-flat x pp shares)) (vector->list x) shares " ")
+          ")"))
+   (else
+    (pp x))))
+
+(define (pp-pair ls pp shares)
+  (cond
+   ;; one element list, no lines to break
+   ((null? (cdr ls))
+    (each "(" (pp (car ls)) ")"))
+   ;; quote or other abbrev
+   ((and (pair? (cdr ls)) (null? (cddr ls))
+         (assq (car ls) syntax-abbrevs))
+    => (lambda (abbrev)
+         (each (cdr abbrev) (pp (cadr ls)))))
+   (else
+    (try-fitted
+     (fn () (pp-flat ls pp shares))
+     (with-reset-shares
+      shares
+      (fn ()
+        (if (and (non-app? ls)
+                 (proper-non-shared-list? ls shares))
+            (pp-data-list ls pp shares)
+            (pp-app ls pp shares))))))))
+
+(define (pp-vector vec pp shares)
+  (each "#" (pp-data-list (vector->list vec) pp shares)))
+
+;; adapted from `write-with-shares'
+(define (pp obj shares)
+  (fn (radix precision)
+    (let ((write-number
+           (cond
+            ((and (not precision)
+                  (assv radix '((16 . "#x") (10 . "") (8 . "#o") (2 . "#b"))))
+             => (lambda (cell)
+                  (lambda (n)
+                    (if (or (exact? n) (eqv? radix 10))
+                        (each (cdr cell) (number->string n (car cell)))
+                        (with ((radix 10)) (numeric n))))))
+            (else (lambda (n) (with ((radix 10)) (numeric n)))))))
+      (let pp ((obj obj))
+        (call-with-shared-ref
+         obj shares
+         (fn ()
+           (cond
+            ((pair? obj)
+             (pp-pair obj pp shares))
+            ((vector? obj)
+             (pp-vector obj pp shares))
+            ((number? obj)
+             (write-number obj))
+            (else
+             (write-with-shares obj shares)))))))))
+
+(define (pretty obj)
+  (fn ()
+    (call-with-output
+     (each (pp obj (extract-shared-objects obj #t))
+           fl)
+     displayed)))
+
+(define (pretty-shared obj)
+  (fn ()
+    (call-with-output
+     (each (pp obj (extract-shared-objects obj #f))
+           fl)
+     displayed)))
+
+(define (pretty-simply obj)
+  (fn ()
+    (each (pp obj (extract-shared-objects #f #f))
+          fl)))

--- a/lib/chibi/show/pretty.sld
+++ b/lib/chibi/show/pretty.sld
@@ -1,0 +1,8 @@
+
+(define-library (chibi show pretty)
+  (export pretty pretty-shared pretty-simply
+          joined/shares try-fitted
+          )
+  (import (scheme base) (scheme write) (chibi show) (chibi show base)
+          (srfi 1) (srfi 69) (chibi string))
+  (include "pretty.scm"))

--- a/lib/chibi/show/show.scm
+++ b/lib/chibi/show/show.scm
@@ -1,0 +1,313 @@
+;; show.scm -- additional combinator formatters
+;; Copyright (c) 2013-2017 Alex Shinn.  All rights reserved.
+;; BSD-style license: http://synthcode.com/license.txt
+
+;;> A library of procedures for formatting Scheme objects to text in
+;;> various ways, and for easily concatenating, composing and
+;;> extending these formatters.
+
+;;> \section{Background}
+;;>
+;;> There are several approaches to text formatting.  Building strings
+;;> to \scheme{display} is not acceptable, since it doesn't scale to
+;;> very large output.  The simplest realistic idea, and what people
+;;> resort to in typical portable Scheme, is to interleave
+;;> \scheme{display} and \scheme{write} and manual loops, but this is
+;;> both extremely verbose and doesn't compose well.  A simple concept
+;;> such as padding space can't be achieved directly without somehow
+;;> capturing intermediate output.
+;;>
+;;> The traditional approach is to use templates - typically strings,
+;;> though in theory any object could be used and indeed Emacs'
+;;> mode-line format templates allow arbitrary sexps.  Templates can
+;;> use either escape sequences (as in C's \cfun{printf} and
+;;> \hyperlink["http://en.wikipedia.org/wiki/Format_(Common_Lisp)"]{CL's}
+;;> \scheme{format}) or pattern matching (as in Visual Basic's
+;;> \cfun{Format},
+;;> \hyperlink["http://search.cpan.org/~dconway/Perl6-Form-0.04/Form.pm"}{Perl6's}
+;;> \cfun{form}, and SQL date formats).  The primary disadvantage of
+;;> templates is the relative difficulty (usually impossibility) of
+;;> extending them, their opaqueness, and the unreadability that
+;;> arises with complex formats.  Templates are not without their
+;;> advantages, but they are already addressed by other libraries such
+;;> as
+;;> \hyperlink["http://srfi.schemers.org/srfi-28/srfi-28.html"]{SRFI-28}
+;;> and
+;;> \hyperlink["http://srfi.schemers.org/srfi-48/srfi-48.html"]{SRFI-48}.
+;;>
+;;> This library takes a combinator approach.  Formats are nested chains
+;;> of closures, which are called to produce their output as needed.
+;;> The primary goal of this library is to have, first and foremost, a
+;;> maximally expressive and extensible formatting library.  The next
+;;> most important goal is scalability - to be able to handle
+;;> arbitrarily large output and not build intermediate results except
+;;> where necessary.  The third goal is brevity and ease of use.
+
+;;> \section{Interface}
+
+;;> \procedure{(show out [args ...])}
+;;>
+;;> The primary interface.  Analogous to CL's \scheme{format}, the first
+;;> argument is either an output port or a boolean, with \scheme{#t}
+;;> indicating \scheme{current-output-port} and \scheme{#f} indicating a
+;;> string port.  The remaining arguments are formatters, combined as with
+;;> \scheme{each}, run with output to the given destination.  If \var{out}
+;;> is \scheme{#f} then the accumulated output is returned, otherwise
+;;> the result is unspecified.
+
+;;> \section{Formatters}
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Spacing
+
+;;> Output a single newline.
+(define nl (displayed "\n"))
+
+;;> "Fresh line" - output a newline iff we're not at the start of a
+;;> fresh line.
+(define fl
+  (fn (col) (if (zero? col) nothing nl)))
+
+;;> Move to a given tab-stop (using spaces, not tabs).
+(define (tab-to . o)
+  (fn (col pad-char)
+    (let* ((tab-width (if (pair? o) (car o) 8))
+           (rem (modulo col tab-width)))
+      (if (positive? rem)
+          (displayed (make-string (- tab-width rem) pad-char))
+          nothing))))
+
+;;> Move to an explicit column.
+(define (space-to where)
+  (fn (col pad-char)
+    (displayed (make-string (max 0 (- where col)) pad-char))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; String transformations
+
+(define (with-string-transformer proc . ls)
+  (fn (output)
+    (let ((output* (lambda (str) (fn () (output (proc str))))))
+      (with ((output output*)) (each-in-list ls)))))
+
+;;> Show each of \var{ls}, uppercasing all generated text.
+(define (upcased . ls) (apply with-string-transformer string-upcase ls))
+
+;;> Show each of \var{ls}, lowercasing all generated text.
+(define (downcased . ls) (apply with-string-transformer string-downcase ls))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Padding and trimming
+
+;;> Pad the result of \scheme{(each-in-list ls)} to at least
+;;> \var{width} characters, equally applied to the left and right,
+;;> with any extra odd padding applied to the right.  Uses the value
+;;> of \scheme{pad-char} for padding, defaulting to \scheme{#\\space}.
+(define (padded/both width . ls)
+  (call-with-output
+   (each-in-list ls)
+   (lambda (str)
+     (fn (string-width pad-char)
+       (let ((diff (- width (string-width str))))
+         (if (positive? diff)
+             (let* ((diff/2 (quotient diff 2))
+                    (left (make-string diff/2 pad-char))
+                    (right (if (even? diff)
+                               left
+                               (make-string (+ 1 diff/2) pad-char))))
+               (each left str right))
+             (displayed str)))))))
+
+;;> As \scheme{padded/both} but only applies padding on the right.
+(define (padded/right width . ls)
+  (fn ((col1 col))
+    (each (each-in-list ls)
+          (fn ((col2 col) pad-char)
+            (displayed (make-string (max 0 (- width (- col2 col1)))
+                                    pad-char))))))
+
+;;> As \scheme{padded/both} but only applies padding on the left.
+(define (padded/left width . ls)
+  (call-with-output
+   (each-in-list ls)
+   (lambda (str)
+     (fn (string-width pad-char)
+       (let ((diff (- width (string-width str))))
+         (each (make-string (max 0 diff) pad-char) str))))))
+
+;;> An alias for \scheme{padded/left}.
+(define padded padded/left)
+
+;; General buffered trim - capture the output apply a trimmer.
+(define (trimmed/buffered width producer proc)
+  (call-with-output
+   producer
+   (lambda (str)
+     (fn (string-width)
+       (let* ((str-width (string-width str))
+              (diff (- str-width width)))
+         (displayed (if (positive? diff)
+                        (proc str str-width diff)
+                        str)))))))
+
+;;> Trims the result of \scheme{(each-in-list ls)} to at most
+;;> \var{width} characters, removed from the right.  If any characters
+;;> are removed, then the value of \scheme{ellipsis} (default empty)
+;;> is used in its place (trimming additional characters as needed to
+;;> be sure the final output doesn't exceed \var{width}).
+(define (trimmed/right width . ls)
+  (trimmed/buffered
+   width
+   (each-in-list ls)
+   (lambda (str str-width diff)
+     (fn (ellipsis string-width col)
+       (let* ((ell (if (char? ellipsis) (string ellipsis) (or ellipsis "")))
+              (ell-len (string-width ell))
+              (diff (- (+ str-width ell-len) width)))
+         (each (if (negative? diff)
+                   nothing
+                   (substring str 0 (- width ell-len)))
+               ell))))))
+
+;;> As \scheme{trimmed} but removes from the left.
+(define (trimmed/left width . ls)
+  (trimmed/buffered
+   width
+   (each-in-list ls)
+   (lambda (str str-width diff)
+     (fn (ellipsis string-width)
+       (let* ((ell (if (char? ellipsis) (string ellipsis) (or ellipsis "")))
+              (ell-len (string-width ell))
+              (diff (- (+ str-width ell-len) width)))
+         (each ell
+               (if (negative? diff)
+                   nothing
+                   (substring str diff))))))))
+
+;;> An alias for \scheme{trimmed/left}.
+(define trimmed trimmed/left)
+
+;;> As \scheme{trimmed} but removes equally from both the left and the
+;;> right, removing extra odd characters from the right, and inserting
+;;> \scheme{ellipsis} on both sides.
+(define (trimmed/both width . ls)
+  (trimmed/buffered
+   width
+   (each-in-list ls)
+   (lambda (str str-width diff)
+     (fn (ellipsis string-width)
+       (let* ((ell (if (char? ellipsis) (string ellipsis) (or ellipsis "")))
+              (ell-len (string-width ell))
+              (diff (- (+ str-width ell-len ell-len) width))
+              (left (quotient diff 2))
+              (right (- (string-width str) (quotient (+ diff 1) 2))))
+         (if (negative? diff)
+             ell
+             (each ell (substring str left right) ell)))))))
+
+;;> A \scheme{trimmed}, but truncates and terminates immediately if
+;;> more than \var{width} characters are generated by \var{ls}.  Thus
+;;> \var{ls} may lazily generate an infinite amount of output safely
+;;> (e.g. \scheme{write-simple} on an infinite list).  The nature of
+;;> this procedure means only truncating on the right is meaningful.
+(define (trimmed/lazy width . ls)
+  (fn ((orig-output output) string-width)
+    (call-with-current-continuation
+     (lambda (return)
+       (let ((chars-written 0)
+             (output (or orig-output output-default)))
+         (define (output* str)
+           (let ((len (string-width str)))
+             (set! chars-written (+ chars-written len))
+             (if (> chars-written width)
+                 (let* ((end (max 0 (- len (- chars-written width))))
+                        (s (substring str 0 end)))
+                   (each (output s)
+                         (with! (output orig-output))
+                         (fn () (return nothing))))
+                 (output str))))
+         (with ((output output*))
+           (each-in-list ls)))))))
+
+;;> Fits the result of \scheme{(each-in-list ls)} to exactly
+;;> \var{width} characters, padding or trimming on the right as
+;;> needed.
+(define (fitted/right width . ls)
+  (padded/right width (trimmed/right width (each-in-list ls))))
+
+;;> As \scheme{fitted} but pads/trims from the left.
+(define (fitted/left width . ls)
+  (padded/left width (trimmed/left width (each-in-list ls))))
+
+;;> An alias for \scheme{fitted/left}.
+(define fitted fitted/left)
+
+;;> As \scheme{fitted} but pads/trims equally from both the left and
+;;> the right.
+(define (fitted/both width . ls)
+  (padded/both width (trimmed/both width (each-in-list ls))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Joining and interspersing
+
+(define (joined/general elt-f last-f dot-f init-ls sep)
+  (fn ()
+    (let lp ((ls init-ls))
+      (cond
+       ((pair? ls)
+        (each (if (eq? ls init-ls) nothing sep)
+              ((if (and last-f (null? (cdr ls))) last-f elt-f) (car ls))
+              (lp (cdr ls))))
+       ((and dot-f (not (null? ls)))
+        (each (if (eq? ls init-ls) nothing sep) (dot-f ls)))
+       (else
+        nothing)))))
+
+;;> \procedure{(joined elt-f ls [sep])}
+;;>
+;;> Joins the result of applying \var{elt-f} to each element of the
+;;> list \var{ls} together with \var{sep}, which defaults to the empty
+;;> string.
+(define (joined elt-f ls . o)
+  (joined/general elt-f #f #f ls (if (pair? o) (car o) "")))
+
+;;> As \scheme{joined} but treats the separator as a prefix, inserting
+;;> before every element instead of between.
+(define (joined/prefix elt-f ls . o)
+  (if (null? ls)
+      nothing
+      (let ((sep (if (pair? o) (car o) "")))
+        (each sep (joined elt-f ls sep)))))
+
+;;> As \scheme{joined} but treats the separator as a suffix, inserting
+;;> after every element instead of between.
+(define (joined/suffix elt-f ls . o)
+  (if (null? ls)
+      nothing
+      (let ((sep (if (pair? o) (car o) "")))
+        (each (joined elt-f ls sep) sep))))
+
+;;> As \scheme{joined} but applies \var{last-f}, instead of
+;;> \var{elt-f}, to the last element of \var{ls}, useful for
+;;> e.g. commas separating a list with "and" before the final element.
+(define (joined/last elt-f last-f ls . o)
+  (joined/general elt-f last-f #f ls (if (pair? o) (car o) "")))
+
+;;> As \scheme{joined} but if \var{ls} is a dotted list applies
+;;> \var{dot-f} to the dotted tail as a final element.
+(define (joined/dot elt-f dot-f ls . o)
+  (joined/general elt-f #f dot-f ls (if (pair? o) (car o) "")))
+
+;;> As \scheme{joined} but counts from \var{start} to \var{end}
+;;> (exclusive), formatting each integer in the range.  If \var{end}
+;;> is \scheme{#f} or unspecified, produces an infinite stream of
+;;> output.
+(define (joined/range elt-f start . o)
+  (let ((end (and (pair? o) (car o)))
+        (sep (if (and (pair? o) (pair? (cdr o))) (cadr o) "")))
+    (let lp ((i start))
+      (if (and end (>= i end))
+          nothing
+          (each (if (> i start) sep nothing)
+                (elt-f i)
+                (fn () (lp (+ i 1))))))))

--- a/lib/chibi/show/unicode.scm
+++ b/lib/chibi/show/unicode.scm
@@ -1,0 +1,134 @@
+;; unicode.scm -- Unicode character width and ANSI escape support
+;; Copyright (c) 2006-2017 Alex Shinn.  All rights reserved.
+;; BSD-style license: http://synthcode.com/license.txt
+
+;; a condensed non-spacing mark range from UnicodeData.txt (chars with
+;; the Mn property) - generated partially by hand, should automate
+;; this better
+
+(define low-non-spacing-chars
+  (bytevector
+#xff #xff #xff #xff #xff #xff #xff #xff #xff #xff #xff #xff #xff #xff    0    0
+   0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
+   0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
+#x78    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
+   0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
+   0    0 #xfe #xff #xff #xff #xff #xff #x1f    0    0    0    0    0    0    0
+   0    0 #x3f    0    0    0    0    0    0 #xf8 #xff #x01    0    0 #x01    0
+   0    0    0    0    0    0    0    0    0    0 #xc0 #xff #xff #x3f    0    0
+   0    0 #x02    0    0    0 #xff #xff #xff #x07    0    0    0    0    0    0
+   0    0    0    0 #xc0 #xff #x01    0    0    0    0    0    0    0    0    0
+   0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
+   0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
+#x06    0    0    0    0    0    0 #x10 #xfe #x21 #x1e    0 #x0c    0    0    0
+#x02    0    0    0    0    0    0 #x10 #x1e #x20    0    0 #x0c    0    0    0
+#x06    0    0    0    0    0    0 #x10 #xfe #x3f    0    0    0    0 #x03    0
+#x06    0    0    0    0    0    0 #x30 #xfe #x21    0    0 #x0c    0    0    0
+#x02    0    0    0    0    0    0 #x90 #x0e #x20 #x40    0    0    0    0    0
+#x04    0    0    0    0    0    0    0    0 #x20    0    0    0    0    0    0
+   0    0    0    0    0    0    0 #xc0 #xc1 #xff #x7f    0    0    0    0    0
+   0    0    0    0    0    0    0 #x10 #x40 #x30    0    0    0    0    0    0
+   0    0    0    0    0    0    0    0 #x0e #x20    0    0    0    0    0    0
+   0    0    0    0    0    0    0    0    0 #x04 #x7c    0    0    0    0    0
+   0    0    0    0    0    0 #xf2 #x07 #x80 #x7f    0    0    0    0    0    0
+   0    0    0    0    0    0 #xf2 #x1f    0 #x3f    0    0    0    0    0    0
+   0    0    0 #x03    0    0 #xa0 #x02    0    0    0    0    0    0 #xfe #x7f
+#xdf    0 #xff #xff #xff #xff #xff #x1f #x40    0    0    0    0    0    0    0
+   0    0    0    0    0 #xe0 #xfd #x02    0    0    0 #x03    0    0    0    0
+   0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
+   0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
+   0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
+   0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
+   0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
+   0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
+   0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
+   0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
+   0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
+   0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
+   0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
+   0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
+   0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
+   0    0 #x1c    0    0    0 #x1c    0    0    0 #x0c    0    0    0 #x0c    0
+   0    0    0    0    0    0 #x80 #x3f #x40 #xfe #x0f #x20    0    0    0    0
+   0 #x38    0    0    0    0    0    0    0    0    0    0    0    0    0    0
+   0    0    0    0    0 #x02    0    0    0    0    0    0    0    0    0    0
+   0    0    0    0 #x87 #x01 #x04 #x0e    0    0    0    0    0    0    0    0
+   0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
+   0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
+   0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
+   0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
+   0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
+   0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
+   0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
+   0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
+   0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
+   0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
+   0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
+   0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
+   0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
+   0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
+   0    0    0    0    0    0    0    0    0    0 #xff #x1f #xe2 #x07
+       ))
+
+(define (unicode-char-width c)
+  (let ((ci (char->integer c)))
+    (cond
+      ;; hand-checked ranges from EastAsianWidth.txt
+      ((<= #x1100 ci #x115F) 2) ; Hangul
+      ((<= #x2E80 ci #x4DB5) 2) ; CJK
+      ((<= #x4E00 ci #xA4C6) 2)
+      ((<= #xAC00 ci #xD7A3) 2) ; Hangul
+      ((<= #xF900 ci #xFAD9) 2) ; CJK compat
+      ((<= #xFE10 ci #xFE6B) 2)
+      ((<= #xFF01 ci #xFF60) 2)
+      ((<= #xFFE0 ci #xFFE6) 2)
+      ((<= #x20000 ci #x30000) 2)
+      ;; non-spacing mark (Mn) ranges from UnicodeData.txt
+      ((<= #x0300 ci #x3029)
+       ;; inlined bit-vector-ref for portability
+       (let* ((i (- ci #x0300))
+              (byte (quotient i 8))
+              (off (remainder i 8)))
+         (if (zero? (bitwise-and (bytevector-u8-ref low-non-spacing-chars byte)
+                                 (arithmetic-shift 1 off)))
+             1
+             0)))
+      ((<= #x302A ci #x302F) 0)
+      ((<= #x3099 ci #x309A) 0)
+      ((= #xFB1E ci) 0)
+      ((<= #xFE00 ci #xFE23) 0)
+      ((<= #x1D167 ci #x1D169) 0)
+      ((<= #x1D17B ci #x1D182) 0)
+      ((<= #x1D185 ci #x1D18B) 0)
+      ((<= #x1D1AA ci #x1D1AD) 0)
+      ((<= #xE0100 ci #xE01EF) 0)
+      (else 1))))
+
+(define (unicode-terminal-width str . o)
+  (let ((start (if (pair? o) (car o) 0))
+        (end (if (and (pair? o) (pair? (cdr o)))
+                 (cadr o)
+                 (string-length str))))
+    (let lp1 ((i start) (width 0))
+      (if (>= i end)
+          width
+          (let ((c (string-ref str i)))
+            (cond
+              ;; ANSI escapes
+              ((and (= 27 (char->integer c)) ; esc
+                    (< (+ i 1) end)
+                    (eqv? #\[ (string-ref str (+ i 1))))
+               (let lp2 ((i (+ i 2)))
+                 (cond ((>= i end) width)
+                       ((memv (string-ref str i) '(#\m #\newline))
+                        (lp1 (+ i 1) width))
+                       (else (lp2 (+ i 1))))))
+              ;; unicode characters
+              ((>= (char->integer c) #x80)
+               (lp1 (+ i 1) (+ width (unicode-char-width c))))
+              ;; normal ASCII
+              (else (lp1 (+ i 1) (+ width 1)))))))))
+
+(define (as-unicode . args)
+  (with ((string-width unicode-terminal-width))
+    (each-in-list args)))

--- a/lib/chibi/show/unicode.sld
+++ b/lib/chibi/show/unicode.sld
@@ -1,0 +1,5 @@
+
+(define-library (chibi show unicode)
+  (import (scheme base) (chibi show base) (srfi 151))
+  (export as-unicode unicode-terminal-width)
+  (include "unicode.scm"))

--- a/lib/chibi/show/write.scm
+++ b/lib/chibi/show/write.scm
@@ -1,0 +1,568 @@
+;; write.scm - written formatting, the default displayed for non-string/chars
+;; Copyright (c) 2006-2019 Alex Shinn.  All rights reserved.
+;; BSD-style license: http://synthcode.com/license.txt
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;> \section{String utilities}
+
+(define (write-to-string x)
+  (let ((out (open-output-string)))
+    (write x out)
+    (get-output-string out)))
+
+(define (string-replace-all str ch1 ch2)
+  (let ((out (open-output-string)))
+    (string-for-each
+     (lambda (ch) (display (if (eqv? ch ch1) ch2 ch) out))
+     str)
+    (get-output-string out)))
+
+(define (string-intersperse-right str sep rule)
+  (let ((start (string-cursor-start str)))
+    (let lp ((i (string-cursor-end str))
+             (rule rule)
+             (res '()))
+      (let* ((offset (if (pair? rule) (car rule) rule))
+             (i2 (if offset (string-cursor-back str i offset) start)))
+        (if (string-cursor<=? i2 start)
+            (apply string-append (cons (substring-cursor str start i) res))
+            (lp i2
+                (if (and (pair? rule) (not (null? (cdr rule)))) (cdr rule) rule)
+                (cons sep (cons (substring-cursor str i2 i) res))))))))
+
+;;> Outputs the string str, escaping any quote or escape characters.
+;;> If esc-ch, which defaults to #\\, is #f, escapes only the
+;;> quote-ch, which defaults to #\", by doubling it, as in SQL strings
+;;> and CSV values.  If renamer is provided, it should be a procedure
+;;> of one character which maps that character to its escape value,
+;;> e.g. #\newline => #\n, or #f if there is no escape value.
+
+(define (escaped fmt . o)
+  (let-optionals* o ((quot #\")
+                     (esc #\\)
+                     (rename (lambda (x) #f)))
+    (let ((esc-str (cond ((char? esc) (string esc))
+                         ((not esc) (string quot))
+                         (else esc))))
+      (fn (output)
+        (define (output* str)
+          (let ((start (string-cursor-start str))
+                (end (string-cursor-end str)))
+            (let lp ((i start) (j start))
+              (define (collect)
+                (if (eq? i j) "" (substring-cursor str i j)))
+              (if (string-cursor>=? j end)
+                  (output (collect))
+                  (let ((c (string-cursor-ref str j))
+                        (j2 (string-cursor-next str j)))
+                    (cond
+                     ((or (eqv? c quot) (eqv? c esc))
+                      (each (output (collect))
+                            (output esc-str)
+                            (fn () (lp j j2))))
+                     ((rename c)
+                      => (lambda (c2)
+                           (each (output (collect))
+                                 (output esc-str)
+                                 (output (if (char? c2) (string c2) c2))
+                                 (fn () (lp j2 j2)))))
+                     (else
+                      (lp i j2))))))))
+        (with ((output output*))
+          fmt)))))
+
+;;> Only escape if there are special characters, in which case also
+;;> wrap in quotes.  For writing symbols in |...| escapes, or CSV
+;;> fields, etc.  The predicate indicates which characters cause
+;;> slashification - this is in addition to automatic slashifying when
+;;> either the quote or escape char is present.
+
+(define (maybe-escaped fmt pred . o)
+  (let-optionals* o ((quot #\")
+                     (esc #\\)
+                     (rename (lambda (x) #f)))
+    (define (esc? c) (or (eqv? c quot) (eqv? c esc) (rename c) (pred c)))
+    (call-with-output
+     fmt
+     (lambda (str)
+       (if (string-cursor<? (string-find str esc?) (string-cursor-end str))
+           (each quot (escaped str quot esc rename) quot)
+           (displayed str))))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; numeric formatting
+
+(define (char-mirror c)
+  (case c ((#\() #\)) ((#\[) #\]) ((#\{) #\}) ((#\<) #\>) (else c)))
+
+(define (integer-log a base)
+  (if (zero? a)
+      0
+      ;; (exact (ceiling (/ (log (+ a 1)) (log base))))
+      (do ((ndigits 1 (+ ndigits 1))
+           (p base (* p base)))
+          ((> p a) ndigits))))
+
+;; The original fmt algorithm was based on "Printing Floating-Point
+;; Numbers Quickly and Accurately" by Burger and Dybvig
+;; (FP-Printing-PLDI96.pdf).  It had grown unwieldy with formatting
+;; special cases, so the below is a simplification which tries to rely
+;; on number->string for common cases.
+
+(define unspec (list 'unspecified))
+
+(define-syntax default
+  (syntax-rules ()
+    ((default var dflt) (if (eq? var unspec) dflt var))))
+
+(define (numeric n . o)
+  (let-optionals* o ((rad unspec) (prec unspec) (sgn unspec)
+                     (comma unspec) (commasep unspec) (decsep unspec))
+    (fn (radix precision sign-rule
+               comma-rule comma-sep decimal-sep decimal-align)
+      (let* ((radix (default rad radix))
+             (precision (default prec precision))
+             (sign-rule (default sgn sign-rule))
+             (comma-rule (default comma comma-rule))
+             (comma-sep (default commasep comma-sep))
+             (dec-sep (default decsep
+                        (or decimal-sep (if (eqv? comma-sep #\.) #\, #\.))))
+             (dec-ls (if (char? dec-sep)
+                         (list dec-sep)
+                         (reverse (string->list dec-sep)))))
+        ;; General formatting utilities.
+        (define (get-scale q)
+          (expt radix (- (integer-log q radix) 1)))
+        (define (char-digit d)
+          (cond ((char? d) d)
+                ((< d 10) (integer->char (+ d (char->integer #\0))))
+                (else (integer->char (+ (- d 10) (char->integer #\a))))))
+        (define (digit-value ch)
+          (let ((res (- (char->integer ch) (char->integer #\0))))
+            (if (<= 0 res 9)
+                res
+                ch)))
+        (define (round-up ls)
+          (let lp ((ls ls) (res '()))
+            (cond
+             ((null? ls)
+              (cons 1 res))
+             ((not (number? (car ls)))
+              (lp (cdr ls) (cons (car ls) res)))
+             ((= (car ls) (- radix 1))
+              (lp (cdr ls) (cons 0 res)))
+             (else
+              (append (reverse res) (cons (+ 1 (car ls)) (cdr ls)))))))
+        (define (maybe-round n d ls)
+          (let* ((q (quotient n d))
+                 (digit (* 2 (if (>= q radix) (quotient q (get-scale q)) q))))
+            (if (or (> digit radix)
+                    (and (= digit radix)
+                         (let ((prev (find integer? ls)))
+                           (and prev (odd? prev)))))
+                (round-up ls)
+                ls)))
+        (define (maybe-trim-zeros i res inexact?)
+          (if (and (not precision) (positive? i))
+              (let lp ((res res))
+                (cond
+                 ((and (pair? res) (eqv? 0 (car res))) (lp (cdr res)))
+                 ((and (pair? res)
+                       (eqv? (car dec-ls) (car res))
+                       (null? (cdr dec-ls)))
+                  (if inexact?
+                      (cons 0 res)      ; "1.0"
+                      (cdr res)))       ; "1"
+                 (else res)))
+              res))
+        ;; General slow loop to generate digits one at a time, for
+        ;; non-standard radixes or writing rationals with a fixed
+        ;; precision.
+        (define (gen-general n-orig)
+          (let* ((p (exact n-orig))
+                 (n (numerator p))
+                 (d (denominator p)))
+            (let lp ((n n)
+                     (i (if (zero? p) -1 (- (integer-log p radix))))
+                     (res '()))
+              (cond
+               ;; Use a fixed precision if specified, otherwise generate
+               ;; 15 decimals.
+               ((if precision (< i precision) (< i 16))
+                (let ((res (if (zero? i)
+                               (append dec-ls (if (null? res) (cons 0 res) res))
+                               res))
+                      (q (quotient n d)))
+                  (cond
+                   ((< i -1)
+                    (let* ((scale (expt radix (- -1 i)))
+                           (digit (quotient q scale))
+                           (n2 (- n (* d digit scale))))
+                      (lp n2 (+ i 1) (cons digit res))))
+                   (else
+                    (lp (* (remainder n d) radix)
+                        (+ i 1)
+                        (cons q res))))))
+               (else
+                (list->string
+                 (map char-digit
+                      (reverse (maybe-trim-zeros i (maybe-round n d res) (inexact? n-orig))))))))))
+        ;; Generate a fixed precision decimal result by post-editing the
+        ;; result of string->number.
+        (define (gen-fixed n)
+          (cond
+           ((and (eqv? radix 10) (zero? precision) (inexact? n))
+            (number->string (exact (round n))))
+           ((and (eqv? radix 10) (or (integer? n) (inexact? n)))
+            (let* ((s (number->string n))
+                   (end (string-cursor-end s))
+                   (dec (string-find s #\.))
+                   (digits (- (string-cursor->index s end)
+                              (string-cursor->index s dec))))
+              (cond
+               ((string-cursor<? (string-find s #\e) end)
+                (gen-general n))
+               ((string-cursor=? dec end)
+                (string-append s (if (char? dec-sep) (string dec-sep) dec-sep)
+                               (make-string precision #\0)))
+               ((<= digits precision)
+                (string-append s (make-string (- precision digits -1) #\0)))
+               (else
+                (let* ((last
+                        (string-cursor-back s end (- digits precision 1)))
+                       (res (substring-cursor s (string-cursor-start s) last)))
+                  (if (and
+                       (string-cursor<? last end)
+                       (let ((next (digit-value (string-cursor-ref s last))))
+                         (or (> next 5)
+                             (and (= next 5)
+                                  (string-cursor>? last (string-cursor-start s))
+                                  (memv (digit-value
+                                         (string-cursor-ref
+                                          s (string-cursor-prev s last)))
+                                        '(1 3 5 7 9))))))
+                      (list->string
+                       (reverse
+                        (map char-digit
+                             (round-up
+                              (reverse (map digit-value (string->list res)))))))
+                      res))))))
+           (else
+            (gen-general n))))
+        ;; Generate any unsigned real number.
+        (define (gen-positive-real n)
+          (cond
+           (precision
+            (gen-fixed n))
+           ((memv radix (if (exact? n) '(2 8 10 16) '(10)))
+            (number->string n radix))
+           (else
+            (gen-general n))))
+        ;; Insert commas according to the current comma-rule.
+        (define (insert-commas str)
+          (let* ((dec-pos (if (string? dec-sep)
+                              (or (string-contains str dec-sep)
+                                  (string-cursor-end str))
+                              (string-find str dec-sep)))
+                 (left (substring-cursor str (string-cursor-start str) dec-pos))
+                 (right (substring-cursor str dec-pos))
+                 (sep (cond ((char? comma-sep) (string comma-sep))
+                            ((string? comma-sep) comma-sep)
+                            ((eqv? #\, dec-sep) ".")
+                            (else ","))))
+            (string-append
+             (string-intersperse-right left sep comma-rule)
+             right)))
+        ;; Post-process a positive real number with decimal char fixup
+        ;; and commas as needed.
+        (define (wrap-comma n)
+          (if (and (not precision) (exact? n) (not (integer? n)))
+              (string-append (wrap-comma (numerator n))
+                             "/"
+                             (wrap-comma (denominator n)))
+              (let* ((s0 (gen-positive-real n))
+                     (s1 (if (or (eqv? #\. dec-sep)
+                                 (equal? "." dec-sep))
+                             s0
+                             (string-replace-all s0 #\. dec-sep))))
+                (if comma-rule (insert-commas s1) s1))))
+        ;; Wrap the sign of a real number, forcing a + prefix or using
+        ;; parentheses (n) for negatives according to sign-rule.
+
+        (define-syntax is-neg-zero?
+          (syntax-rules ()
+            ((_ n)
+             (is-neg-zero? (-0.0) n))
+            ((_ (0.0) n)                ; -0.0 is not distinguished?
+             #f)
+            ((_ (-0.0) n)
+             (eqv? -0.0 n))))
+        (define (negative?* n)
+          (or (negative? n)
+              (is-neg-zero? n)))
+        (define (wrap-sign n sign-rule)
+          (cond
+           ((negative?* n)
+            (cond
+             ((char? sign-rule)
+              (string-append (string sign-rule)
+                             (wrap-comma (- n))
+                             (string (char-mirror sign-rule))))
+             ((pair? sign-rule)
+              (string-append (car sign-rule)
+                             (wrap-comma (- n))
+                             (cdr sign-rule)))
+             (else
+              (string-append "-" (wrap-comma (- n))))))
+           ((eq? #t sign-rule)
+            (string-append "+" (wrap-comma n)))
+           (else
+            (wrap-comma n))))
+        ;; Format a single real number with padding as necessary.
+        (define (format n sign-rule)
+          (cond
+           ((finite? n)
+            (let* ((s (wrap-sign n sign-rule))
+                   (dec-pos (if decimal-align
+                                (string-cursor->index
+                                 s
+                                 (if (char? dec-sep)
+                                     (string-find s dec-sep)
+                                     (or (string-contains s dec-sep)
+                                         (string-cursor-end s))))
+                                0))
+                   (diff (- (or decimal-align 0) dec-pos 1)))
+              (if (positive? diff)
+                  (string-append (make-string diff #\space) s)
+                  s)))
+           (else
+            (number->string n))))
+        ;; Write any number.
+        (define (write-complex n)
+          (cond
+           ((and radix (not (and (integer? radix) (<= 2 radix 36))))
+            (error "invalid radix for numeric formatting" radix))
+           ((zero? (imag-part n))
+            (displayed (format (real-part n) sign-rule)))
+           (else
+            (each (format (real-part n) sign-rule)
+                  (format (imag-part n) #t)
+                  "i"))))
+        (write-complex n)))))
+
+(define numeric/si
+  (let* ((names10 '#("" "k" "M" "G" "T" "E" "P" "Z" "Y"))
+         (names-10 '#("" "m" "µ" "n" "p" "f" "a" "z" "y"))
+         (names2 (list->vector
+                  (cons ""
+                        (cons "Ki" (map (lambda (s) (string-append s "i"))
+                                        (cddr (vector->list names10)))))))
+         (names-2 (list->vector
+                   (cons ""
+                         (map (lambda (s) (string-append s "i"))
+                              (cdr (vector->list names-10)))))))
+    (define (round-to n k)
+      (/ (round (* n k)) k))
+    (lambda (n . o)
+      (let-optionals* o ((base 1024)
+                         (separator ""))
+        (let* ((log-n (log n))
+               (names  (if (negative? log-n)
+                           (if (= base 1024) names-2 names-10)
+                           (if (= base 1024) names2 names10)))
+               (k (min (exact ((if (negative? log-n) ceiling floor)
+                               (/ (abs log-n) (log base))))
+                       (- (vector-length names) 1)))
+               (n2 (round-to (/ n (expt base (if (negative? log-n) (- k) k)))
+                             10)))
+          (each (if (integer? n2)
+                    (number->string (exact n2))
+                    (inexact n2))
+                ;; (if (zero? k) "" separator)
+                separator
+                (vector-ref names k)))))))
+
+;; Force a number into a fixed width, print as #'s if doesn't fit.
+;; Needs to be wrapped in PADDED if you want to expand to the width.
+
+(define (numeric/fitted width n . args)
+  (call-with-output
+   (apply numeric n args)
+   (lambda (str)
+     (if (> (string-length str) width)
+         (fn (precision decimal-sep comma-sep)
+           (let ((prec (if (and (pair? args) (pair? (cdr args)))
+                           (cadr args)
+                           precision)))
+             (if (and prec (not (zero? prec)))
+                 (let* ((dec-sep
+                         (or decimal-sep
+                             (if (eqv? #\. comma-sep) #\, #\.)))
+                        (diff (- width (+ prec
+                                          (if (char? dec-sep)
+                                              1
+                                              (string-length dec-sep))))))
+                   (each (if (positive? diff) (make-string diff #\#) "")
+                         dec-sep (make-string prec #\#)))
+                 (displayed (make-string width #\#)))))
+         (displayed str)))))
+
+(define (numeric/comma n . o)
+  (fn (comma-rule)
+    (with ((comma-rule (or comma-rule 3)))
+      (apply numeric n o))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; shared structure utilities
+
+(define (extract-shared-objects x cyclic-only?)
+  (let ((seen (make-hash-table eq?)))
+    ;; find shared references
+    (let find ((x x))
+      (cond ;; only interested in pairs and vectors (and records later)
+       ((or (pair? x) (vector? x))
+        ;; increment the count
+        (hash-table-update!/default seen x (lambda (n) (+ n 1)) 0)
+        ;; walk if this is the first time
+        (cond
+         ((> (hash-table-ref seen x) 1))
+         ((pair? x)
+          (find (car x))
+          (find (cdr x)))
+         ((vector? x)
+          (do ((i 0 (+ i 1)))
+              ((= i (vector-length x)))
+            (find (vector-ref x i)))))
+        ;; delete if this shouldn't count as a shared reference
+        (if (and cyclic-only? (<= (hash-table-ref/default seen x 0) 1))
+            (hash-table-delete! seen x)))))
+    ;; extract shared references
+    (let ((res (make-hash-table eq?))
+          (count 0))
+      (hash-table-walk
+       seen
+       (lambda (k v)
+         (cond
+          ((> v 1)
+           (hash-table-set! res k (cons count #f))
+           (set! count (+ count 1))))))
+      (cons res 0))))
+
+(define (maybe-gen-shared-ref cell shares)
+  (cond
+    ((pair? cell)
+     (set-car! cell (cdr shares))
+     (set-cdr! cell #t)
+     (set-cdr! shares (+ (cdr shares) 1))
+     (each "#" (number->string (car cell)) "="))
+    (else nothing)))
+
+(define (call-with-shared-ref obj shares proc)
+  (let ((cell (hash-table-ref/default (car shares) obj #f)))
+    (if (and (pair? cell) (cdr cell))
+        (each "#" (number->string (car cell)) "#")
+        (each (maybe-gen-shared-ref cell shares) proc))))
+
+(define (call-with-shared-ref/cdr obj shares proc . o)
+  (let ((sep (displayed (if (pair? o) (car o) "")))
+        (cell (hash-table-ref/default (car shares) obj #f)))
+    (cond
+      ((and (pair? cell) (cdr cell))
+       (each sep ". #" (number->string (car cell)) "#"))
+      ((pair? cell)
+       (each sep ". " (maybe-gen-shared-ref cell shares) "(" proc ")"))
+      (else
+       (each sep proc)))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; written
+
+(define (write-with-shares obj shares)
+  (fn (radix precision)
+    (let ((write-number
+           ;; Shortcut for numeric values.  Try to rely on
+           ;; number->string for standard radixes and no precision,
+           ;; otherwise fall back on numeric but resetting to a usable
+           ;; radix.
+           (cond
+            ((and (not precision)
+                  (assv radix '((16 . "#x") (10 . "") (8 . "#o") (2 . "#b"))))
+             => (lambda (cell)
+                  (lambda (n)
+                    (cond
+                     ((eqv? radix 10)
+                      (displayed (number->string n (car cell))))
+                     ((exact? n)
+                      (each (cdr cell) (number->string n (car cell))))
+                     (else
+                      (with ((radix 10)) (numeric n)))))))
+            (else (lambda (n) (with ((radix 10)) (numeric n)))))))
+      ;; `wr' is the recursive writer closing over the shares.
+      (let wr ((obj obj))
+        (call-with-shared-ref
+         obj shares
+         (fn ()
+           (cond
+            ((pair? obj)
+             (each "("
+                   (fn ()
+                     (let lp ((ls obj))
+                       (let ((rest (cdr ls)))
+                         (each (wr (car ls))
+                               (cond
+                                ((null? rest)
+                                 nothing)
+                                ((pair? rest)
+                                 (each
+                                  " "
+                                  (call-with-shared-ref/cdr
+                                   rest shares
+                                   (fn () (lp rest)))))
+                                (else
+                                 (each " . " (wr rest))))))))
+                   ")"))
+            ((vector? obj)
+             (let ((len (vector-length obj)))
+               (if (zero? len)
+                   (displayed "#()")
+                   (each "#("
+                         (wr (vector-ref obj 0))
+                         (fn ()
+                           (let lp ((i 1))
+                             (if (>= i len)
+                                 nothing
+                                 (each " " (wr (vector-ref obj i))
+                                       (fn () (lp (+ i 1)))))))
+                         ")"))))
+            ((number? obj)
+             (write-number obj))
+            (else
+             (displayed (write-to-string obj))))))))))
+
+;; The default formatter for `written', overriden with the `writer'
+;; variable.  Intended to be equivalent to `write', using datum labels
+;; for shared notation iff there are cycles in the object.
+
+(define (written-default obj)
+  (fn ()
+    (write-with-shares obj (extract-shared-objects obj #t))))
+
+;; Writes the object showing the full shared structure.
+
+(define (written-shared obj)
+  (fn ()
+    (write-with-shares obj (extract-shared-objects obj #f))))
+
+;; The only expensive part, in both time and memory, of handling
+;; shared structures when writing is building the initial table, so
+;; for the efficient version we just skip that and re-use the writing
+;; code.
+
+(define (written-simply obj)
+  (fn ()
+    (write-with-shares obj (extract-shared-objects #f #f))))
+
+;; Local variables:
+;; eval: (put 'fn 'scheme-indent-function 1)
+;; End:

--- a/test/include/srfi-159-tests.scm
+++ b/test/include/srfi-159-tests.scm
@@ -1,0 +1,759 @@
+(define-library (chibi show-test)
+  (export run-tests)
+  (import (scheme base) (scheme char) (scheme read) (scheme file)
+          (only (srfi 1) circular-list)
+          (chibi test)
+          (chibi show) (chibi show base) (chibi show color)
+          (chibi show column) (chibi show pretty)
+          (chibi show unicode))
+  (begin
+    (define-syntax test-pretty
+      (syntax-rules ()
+        ((test-pretty str)
+         (let ((sexp (read (open-input-string str))))
+           (test str (show #f (pretty sexp)))))))
+    (define (run-tests)
+      (test-begin "show")
+
+      ;; basic data types
+
+      (test "hi" (show #f "hi"))
+      (test "\"hi\"" (show #f (written "hi")))
+      (test "\"hi \\\"bob\\\"\"" (show #f (written "hi \"bob\"")))
+      (test "\"hello\\nworld\"" (show #f (written "hello\nworld")))
+      (test "#(1 2 3)" (show #f (written '#(1 2 3))))
+      (test "(1 2 3)" (show #f (written '(1 2 3))))
+      (test "(1 2 . 3)" (show #f (written '(1 2 . 3))))
+      (test "ABC" (show #f (upcased "abc")))
+      (test "abc" (show #f (downcased "ABC")))
+
+      (test "a    b" (show #f "a" (space-to 5) "b"))
+      (test "ab" (show #f "a" (space-to 0) "b"))
+
+      (test "abc     def" (show #f "abc" (tab-to) "def"))
+      (test "abc  def" (show #f "abc" (tab-to 5) "def"))
+      (test "abcdef" (show #f "abc" (tab-to 3) "def"))
+      (test "abc\ndef\n" (show #f "abc" nl "def" nl))
+      (test "abc\ndef\n" (show #f "abc" fl "def" nl fl))
+      (test "abc\ndef\n" (show #f "abc" fl "def" fl fl))
+
+      (test "ab" (show #f "a" nothing "b"))
+
+      ;; numbers
+
+      (test "-1" (show #f -1))
+      (test "0" (show #f 0))
+      (test "1" (show #f 1))
+      (test "10" (show #f 10))
+      (test "100" (show #f 100))
+      (test "-1" (show #f (numeric -1)))
+      (test "0" (show #f (numeric 0)))
+      (test "1" (show #f (numeric 1)))
+      (test "10" (show #f (numeric 10)))
+      (test "100" (show #f (numeric 100)))
+      (test "57005" (show #f #xDEAD))
+      (test "#xdead" (show #f (with ((radix 16)) #xDEAD)))
+      (test "#xdead1234" (show #f (with ((radix 16)) #xDEAD) 1234))
+      (test "de.ad"
+          (show #f (with ((radix 16) (precision 2)) (numeric (/ #xDEAD #x100)))))
+      (test "d.ead"
+          (show #f (with ((radix 16) (precision 3)) (numeric (/ #xDEAD #x1000)))))
+      (test "0.dead"
+          (show #f (with ((radix 16) (precision 4)) (numeric (/ #xDEAD #x10000)))))
+      (test "1g"
+          (show #f (with ((radix 17)) (numeric 33))))
+
+      (test "3.14159" (show #f 3.14159))
+      (test "3.14" (show #f (with ((precision 2)) 3.14159)))
+      (test "3.14" (show #f (with ((precision 2)) 3.14)))
+      (test "3.00" (show #f (with ((precision 2)) 3.)))
+      (test "1.10" (show #f (with ((precision 2)) 1.099)))
+      (test "0.00" (show #f (with ((precision 2)) 1e-17)))
+      (test "0.0000000010" (show #f (with ((precision 10)) 1e-9)))
+      (test "0.0000000000" (show #f (with ((precision 10)) 1e-17)))
+      (test "0.000004" (show #f (with ((precision 6)) 0.000004)))
+      (test "0.0000040" (show #f (with ((precision 7)) 0.000004)))
+      (test "0.00000400" (show #f (with ((precision 8)) 0.000004)))
+      (test "1.00" (show #f (with ((precision 2)) .997554209949891)))
+      (test "1.00" (show #f (with ((precision 2)) .99755420)))
+      (test "1.00" (show #f (with ((precision 2)) .99755)))
+      (test "1.00" (show #f (with ((precision 2)) .997)))
+      (test "0.99" (show #f (with ((precision 2)) .99)))
+      (test "-15" (show #f (with ((precision 0)) -14.99995999999362)))
+
+      (test "   3.14159" (show #f (with ((decimal-align 5)) (numeric 3.14159))))
+      (test "  31.4159" (show #f (with ((decimal-align 5)) (numeric 31.4159))))
+      (test " 314.159" (show #f (with ((decimal-align 5)) (numeric 314.159))))
+      (test "3141.59" (show #f (with ((decimal-align 5)) (numeric 3141.59))))
+      (test "31415.9" (show #f (with ((decimal-align 5)) (numeric 31415.9))))
+      (test "  -3.14159" (show #f (with ((decimal-align 5)) (numeric -3.14159))))
+      (test " -31.4159" (show #f (with ((decimal-align 5)) (numeric -31.4159))))
+      (test "-314.159" (show #f (with ((decimal-align 5)) (numeric -314.159))))
+      (test "-3141.59" (show #f (with ((decimal-align 5)) (numeric -3141.59))))
+      (test "-31415.9" (show #f (with ((decimal-align 5)) (numeric -31415.9))))
+
+      (test "+inf.0" (show #f +inf.0))
+      (test "-inf.0" (show #f -inf.0))
+      (test "+nan.0" (show #f +nan.0))
+      (test "+inf.0" (show #f (numeric +inf.0)))
+      (test "-inf.0" (show #f (numeric -inf.0)))
+      (test "+nan.0" (show #f (numeric +nan.0)))
+
+      (cond
+       ((exact? (/ 1 3)) ;; exact rationals
+        (test "333.333333333333333333333333333333"
+            (show #f (with ((precision 30)) (numeric 1000/3))))
+        (test  "33.333333333333333333333333333333"
+            (show #f (with ((precision 30)) (numeric 100/3))))
+        (test   "3.333333333333333333333333333333"
+            (show #f (with ((precision 30)) (numeric 10/3))))
+        (test   "0.333333333333333333333333333333"
+            (show #f (with ((precision 30)) (numeric 1/3))))
+        (test   "0.033333333333333333333333333333"
+            (show #f (with ((precision 30)) (numeric 1/30))))
+        (test   "0.003333333333333333333333333333"
+            (show #f (with ((precision 30)) (numeric 1/300))))
+        (test   "0.000333333333333333333333333333"
+            (show #f (with ((precision 30)) (numeric 1/3000))))
+        (test   "0.666666666666666666666666666667"
+            (show #f (with ((precision 30)) (numeric 2/3))))
+        (test   "0.090909090909090909090909090909"
+            (show #f (with ((precision 30)) (numeric 1/11))))
+        (test   "1.428571428571428571428571428571"
+            (show #f (with ((precision 30)) (numeric 10/7))))
+        (test "0.123456789012345678901234567890"
+            (show #f (with ((precision 30))
+                       (numeric (/  123456789012345678901234567890
+                                    1000000000000000000000000000000)))))
+        (test  " 333.333333333333333333333333333333"
+            (show #f (with ((precision 30) (decimal-align 5)) (numeric 1000/3))))
+        (test  "  33.333333333333333333333333333333"
+            (show #f (with ((precision 30) (decimal-align 5)) (numeric 100/3))))
+        (test  "   3.333333333333333333333333333333"
+            (show #f (with ((precision 30) (decimal-align 5)) (numeric 10/3))))
+        (test  "   0.333333333333333333333333333333"
+            (show #f (with ((precision 30) (decimal-align 5)) (numeric 1/3))))
+        ))
+
+      (test "11.75" (show #f (with ((precision 2)) (/ 47 4))))
+      (test "-11.75" (show #f (with ((precision 2)) (/ -47 4))))
+
+      (test "(#x11 #x22 #x33)" (show #f (with ((radix 16)) '(#x11 #x22 #x33))))
+
+      (test "299792458" (show #f (with ((comma-rule 3)) 299792458)))
+      (test "299,792,458" (show #f (with ((comma-rule 3)) (numeric 299792458))))
+      (test "-29,97,92,458"
+          (show #f (with ((comma-rule '(3 2))) (numeric -299792458))))
+      (test "299.792.458"
+          (show #f (with ((comma-rule 3) (comma-sep #\.)) (numeric 299792458))))
+      (test "299.792.458,0"
+          (show #f (with ((comma-rule 3) (decimal-sep #\,)) (numeric 299792458.0))))
+
+      (test "100,000" (show #f (with ((comma-rule 3)) (numeric 100000))))
+      (test "100,000.0"
+          (show #f (with ((comma-rule 3) (precision 1)) (numeric 100000))))
+      (test "100,000.00"
+          (show #f (with ((comma-rule 3) (precision 2)) (numeric 100000))))
+
+      ;; radix argument:
+      (test "0" (show #f (numeric 0 2)))
+      (test "0" (show #f (numeric 0 10)))
+      (test "0" (show #f (numeric 0 36)))
+
+      (test "0.0" (show #f (numeric 0.0 2)))
+      (test "0.0" (show #f (numeric 0.0 10)))
+      (test "0.0" (show #f (numeric 0.0 36)))
+
+      (test "1" (show #f (numeric 1 2)))
+      (test "1" (show #f (numeric 1 10)))
+      (test "1" (show #f (numeric 1 36)))
+
+      (test "1.0" (show #f (numeric 1.0 2)))
+      (test "1.0" (show #f (numeric 1.0 10)))
+      (test "1.0" (show #f (numeric 1.0 36)))
+
+      (test "0" (show #f (numeric 0.0 10 0)))
+      (test "0" (show #f (numeric 0.0 9 0)))
+      (test "3/4" (show #f (numeric #e.75)))
+
+      (test "0.0000000000000001" (show #f (numeric 1e-25 36)))
+      (test "100000000000000000000000000000000000000000000000000000000000000000000000000000000.0"
+            (show #f (numeric (expt 2.0 80) 2)))
+
+      ;; numeric, radix=2
+      (test "10" (show #f (numeric 2 2)))
+      (test "10.0" (show #f (numeric 2.0 2)))
+      (test "11/10" (show #f (numeric 3/2 2)))
+      (test "1001" (show #f (numeric 9 2)))
+      (test "1001.0" (show #f (numeric 9.0 2)))
+      (test "1001.01" (show #f (numeric 9.25 2)))
+
+      ;; numeric, radix=3
+      (test "11" (show #f (numeric 4 3)))
+      (test "10.0" (show #f (numeric 3.0 3)))
+      (test "11/10" (show #f (numeric 4/3 3)))
+      (test "1001" (show #f (numeric 28 3)))
+      (test "1001.0" (show #f (numeric 28.0 3)))
+      (test "1001.01" (show #f (numeric #i253/9 3 2)))
+
+      ;; radix 36
+      (test "zzz" (show #f (numeric (- (* 36 36 36) 1) 36)))
+
+      ;; Precision:
+      (test "1.1250" (show #f (numeric 9/8 10 4)))
+      (test "1.125" (show #f (numeric 9/8 10 3)))
+      (test "1.12" (show #f (numeric 9/8 10 2)))
+      (test "1.1" (show #f (numeric 9/8 10 1)))
+      (test "1" (show #f (numeric 9/8 10 0)))
+
+      (test "1.1250" (show #f (numeric #i9/8 10 4)))
+      (test "1.125" (show #f (numeric #i9/8 10 3)))
+      (test "1.12" (show #f (numeric #i9/8 10 2)))
+      (test "1.1" (show #f (numeric #i9/8 10 1)))
+      (test "1" (show #f (numeric #i9/8 10 0)))
+
+      ;; precision-show, base-4
+      (test "1.1230" (show #f (numeric 91/64 4 4)))
+      (test "1.123" (show #f (numeric 91/64 4 3)))
+      (test "1.13" (show #f (numeric 91/64 4 2)))
+      (test "1.2" (show #f (numeric 91/64 4 1)))
+      (test "1" (show #f (numeric 91/64 4 0)))
+
+      (test "1.1230" (show #f (numeric #i91/64 4 4)))
+      (test "1.123" (show #f (numeric #i91/64 4 3)))
+      (test "1.13" (show #f (numeric #i91/64 4 2)))
+      (test "1.2" (show #f (numeric #i91/64 4 1)))
+      (test "1" (show #f (numeric #i91/64 4 0)))
+
+      ;; sign
+      (test "+1" (show #f (numeric 1 10 #f #t)))
+      (test "+1" (show #f (with ((sign-rule #t)) (numeric 1))))
+      (test "(1)" (show #f (with ((sign-rule '("(" . ")"))) (numeric -1))))
+      (test "-1" (show #f (with ((sign-rule '("-" . ""))) (numeric -1))))
+      (test "−1" (show #f (with ((sign-rule '("−" . ""))) (numeric -1))))
+      (test "-0.0" (show #f (with ((sign-rule #t)) (numeric -0.0))))
+      (test "+0.0" (show #f (with ((sign-rule #t)) (numeric +0.0))))
+
+      ;; comma
+      (test "1,234,567" (show #f (numeric 1234567 10 #f #f 3)))
+      (test "567" (show #f (numeric 567 10 #f #f 3)))
+      (test "1,23,45,67" (show #f (numeric 1234567 10 #f #f 2)))
+      (test "12,34,567" (show #f (numeric 1234567 10 #f #f '(3 2))))
+
+      ;; comma-sep
+      (test "1|234|567" (show #f (numeric 1234567 10 #f #f 3 #\|)))
+      (test "1&234&567" (show #f (with ((comma-sep #\&)) (numeric 1234567 10 #f #f 3))))
+      (test "1*234*567" (show #f (with ((comma-sep #\&)) (numeric 1234567 10 #f #f 3 #\*))))
+      (test "567" (show #f (numeric 567 10 #f #f 3 #\|)))
+      (test "1,23,45,67" (show #f (numeric 1234567 10 #f #f 2)))
+
+      ;; decimal
+      (test "1_5" (show #f (with ((decimal-sep #\_)) (numeric 1.5))))
+      (test "1,5" (show #f (with ((comma-sep #\.)) (numeric 1.5))))
+      (test "1,5" (show #f (numeric 1.5 10 #f #f #f #\.)))
+      (test "1%5" (show #f (numeric 1.5 10 #f #f #f #\. #\%)))
+
+      (cond-expand
+       (complex
+        (test "1+2i" (show #f (string->number "1+2i")))
+        (test "1.00+2.00i"
+            (show #f (with ((precision 2)) (string->number "1+2i"))))
+        (test "3.14+2.00i"
+            (show #f (with ((precision 2)) (string->number "3.14159+2i"))))))
+
+      (test "608" (show #f (numeric/si 608)))
+      (test "608 B" (show #f (numeric/si 608 1000 " ") "B"))
+      (test "3.9Ki" (show #f (numeric/si 3986)))
+      (test "4kB" (show #f (numeric/si 3986 1000) "B"))
+      (test "1.2Mm" (show #f (numeric/si 1.23e6 1000) "m"))
+      (test "123km" (show #f (numeric/si 1.23e5 1000) "m"))
+      (test "12.3km" (show #f (numeric/si 1.23e4 1000) "m"))
+      (test "1.2km" (show #f (numeric/si 1.23e3 1000) "m"))
+      (test "123m" (show #f (numeric/si 1.23e2 1000) "m"))
+      (test "12.3m" (show #f (numeric/si 1.23e1 1000) "m"))
+      (test "1.2m" (show #f (numeric/si 1.23 1000) "m"))
+      (test "1.2 m" (show #f (numeric/si 1.23 1000 " ") "m"))
+      (test "123mm" (show #f (numeric/si 0.123 1000) "m"))
+      (test "12.3mm" (show #f (numeric/si 1.23e-2 1000) "m")) ;?
+      (test "1.2mm" (show #f (numeric/si 1.23e-3 1000) "m"))
+      (test "123µm" (show #f (numeric/si 1.23e-4 1000) "m"))  ;?
+      (test "12.3µm" (show #f (numeric/si 1.23e-5 1000) "m")) ;?
+      (test "1.2µm" (show #f (numeric/si 1.23e-6 1000) "m"))
+      (test "1.2 µm" (show #f (numeric/si 1.23e-6 1000 " ") "m"))
+
+      (test "1,234,567" (show #f (numeric/comma 1234567)))
+
+      (test "1.23" (show #f (numeric/fitted 4 1.2345 10 2)))
+      (test "1.00" (show #f (numeric/fitted 4 1 10 2)))
+      (test "#.##" (show #f (numeric/fitted 4 12.345 10 2)))
+      (test "#" (show #f (numeric/fitted 1 12.345 10 0)))
+
+      ;; padding/trimming
+
+      (test "abc  " (show #f (padded/right 5 "abc")))
+      (test "  abc" (show #f (padded 5 "abc")))
+      (test "abcdefghi" (show #f (padded 5 "abcdefghi")))
+      (test " abc " (show #f (padded/both 5 "abc")))
+      (test " abc  " (show #f (padded/both 6 "abc")))
+      (test "abcde" (show #f (padded/right 5 "abcde")))
+      (test "abcdef" (show #f (padded/right 5 "abcdef")))
+
+      (test "abc" (show #f (trimmed/right 3 "abcde")))
+      (test "abc" (show #f (trimmed/right 3 "abcd")))
+      (test "abc" (show #f (trimmed/right 3 "abc")))
+      (test "ab" (show #f (trimmed/right 3 "ab")))
+      (test "a" (show #f (trimmed/right 3 "a")))
+      (test "cde" (show #f (trimmed 3 "abcde")))
+      (test "bcd" (show #f (trimmed/both 3 "abcde")))
+      (test "bcdef" (show #f (trimmed/both 5 "abcdefgh")))
+      (test "abc" (show #f (trimmed/lazy 3 "abcde")))
+      (test "abc" (show #f (trimmed/lazy 3 "abc\nde")))
+
+      (test "prefix: abc" (show #f "prefix: " (trimmed/right 3 "abcde")))
+      (test "prefix: cde" (show #f "prefix: " (trimmed 3 "abcde")))
+      (test "prefix: bcd" (show #f "prefix: " (trimmed/both 3 "abcde")))
+      (test "prefix: abc" (show #f "prefix: " (trimmed/lazy 3 "abcde")))
+      (test "prefix: abc" (show #f "prefix: " (trimmed/lazy 3 "abc\nde")))
+
+      (test "abc :suffix" (show #f (trimmed/right 3 "abcde") " :suffix"))
+      (test "cde :suffix" (show #f (trimmed 3 "abcde") " :suffix"))
+      (test "bcd :suffix" (show #f (trimmed/both 3 "abcde") " :suffix"))
+      (test "abc :suffix" (show #f (trimmed/lazy 3 "abcde") " :suffix"))
+      (test "abc :suffix" (show #f (trimmed/lazy 3 "abc\nde") " :suffix"))
+
+      (test "abc" (show #f (trimmed/lazy 10 (trimmed/lazy 3 "abcdefghijklmnopqrstuvwxyz"))))
+      (test "abc" (show #f (trimmed/lazy 3 (trimmed/lazy 10 "abcdefghijklmnopqrstuvwxyz"))))
+
+      (test "abcde"
+          (show #f (with ((ellipsis "...")) (trimmed/right 5 "abcde"))))
+      (test "ab..."
+          (show #f (with ((ellipsis "...")) (trimmed/right 5 "abcdef"))))
+      (test "abc..."
+          (show #f (with ((ellipsis "...")) (trimmed/right 6 "abcdefg"))))
+      (test "abcde"
+          (show #f (with ((ellipsis "...")) (trimmed 5 "abcde"))))
+      (test "...ef"
+          (show #f (with ((ellipsis "...")) (trimmed 5 "abcdef"))))
+      (test "...efg"
+          (show #f (with ((ellipsis "...")) (trimmed 6 "abcdefg"))))
+      (test "abcdefg"
+          (show #f (with ((ellipsis "...")) (trimmed/both 7 "abcdefg"))))
+      (test "...d..."
+          (show #f (with ((ellipsis "...")) (trimmed/both 7 "abcdefgh"))))
+      (test "...e..."
+          (show #f (with ((ellipsis "...")) (trimmed/both 7 "abcdefghi"))))
+
+      (test "abc  " (show #f (fitted/right 5 "abc")))
+      (test "  abc" (show #f (fitted 5 "abc")))
+      (test " abc " (show #f (fitted/both 5 "abc")))
+      (test "abcde" (show #f (fitted/right 5 "abcde")))
+      (test "abcde" (show #f (fitted 5 "abcde")))
+      (test "abcde" (show #f (fitted/both 5 "abcde")))
+      (test "abcde" (show #f (fitted/right 5 "abcdefgh")))
+      (test "defgh" (show #f (fitted 5 "abcdefgh")))
+      (test "bcdef" (show #f (fitted/both 5 "abcdefgh")))
+
+      (test "prefix: abc   :suffix"
+          (show #f "prefix: " (fitted/right 5 "abc") " :suffix"))
+      (test "prefix:   abc :suffix"
+          (show #f "prefix: " (fitted 5 "abc") " :suffix"))
+      (test "prefix:  abc  :suffix"
+          (show #f "prefix: " (fitted/both 5 "abc") " :suffix"))
+      (test "prefix: abcde :suffix"
+          (show #f "prefix: " (fitted/right 5 "abcde") " :suffix"))
+      (test "prefix: abcde :suffix"
+          (show #f "prefix: " (fitted 5 "abcde") " :suffix"))
+      (test "prefix: abcde :suffix"
+          (show #f "prefix: " (fitted/both 5 "abcde") " :suffix"))
+      (test "prefix: abcde :suffix"
+          (show #f "prefix: " (fitted/right 5 "abcdefgh") " :suffix"))
+      (test "prefix: defgh :suffix"
+          (show #f "prefix: " (fitted 5 "abcdefgh") " :suffix"))
+      (test "prefix: bcdef :suffix"
+          (show #f "prefix: " (fitted/both 5 "abcdefgh") " :suffix"))
+
+      ;; joining
+
+      (test "1 2 3" (show #f (joined each '(1 2 3) " ")))
+
+      (test ":abc:123"
+          (show #f (joined/prefix
+                    (lambda (x) (trimmed/right 3 x))
+                    '("abcdef" "123456")
+                    ":")))
+
+      (test "abc\n123\n"
+          (show #f (joined/suffix
+                    (lambda (x) (trimmed/right 3 x))
+                    '("abcdef" "123456")
+                    nl)))
+
+      (test "lions, tigers, and bears"
+          (show #f (joined/last
+                    each
+                    (lambda (x) (each "and " x))
+                    '(lions tigers bears)
+                    ", ")))
+
+      (test "lions, tigers, or bears"
+          (show #f (joined/dot
+                    each
+                    (lambda (x) (each "or " x))
+                    '(lions tigers . bears)
+                    ", ")))
+
+      ;; escaping
+
+      (test "hi, bob!" (show #f (escaped "hi, bob!")))
+      (test "hi, \\\"bob!\\\"" (show #f (escaped "hi, \"bob!\"")))
+      (test "hi, \\'bob\\'" (show #f (escaped "hi, 'bob'" #\')))
+      (test "hi, ''bob''" (show #f (escaped "hi, 'bob'" #\' #\')))
+      (test "hi, ''bob''" (show #f (escaped "hi, 'bob'" #\' #f)))
+      (test "line1\\nline2\\nkapow\\a\\n"
+            (show #f (escaped "line1\nline2\nkapow\a\n"
+                              #\" #\\
+                              (lambda (c) (case c ((#\newline) #\n) ((#\alarm) #\a) (else #f))))))
+
+      (test "bob" (show #f (maybe-escaped "bob" char-whitespace?)))
+      (test "\"hi, bob!\""
+            (show #f (maybe-escaped "hi, bob!" char-whitespace?)))
+      (test "\"foo\\\"bar\\\"baz\"" (show #f (maybe-escaped "foo\"bar\"baz" char-whitespace?)))
+      (test "'hi, ''bob'''" (show #f (maybe-escaped "hi, 'bob'" (lambda (c) #f) #\' #f)))
+      (test "\\" (show #f (maybe-escaped "\\" (lambda (c) #f) #\' #f)))
+      (test "''''" (show #f (maybe-escaped "'" (lambda (c) #f) #\' #f)))
+
+      ;; shared structures
+
+      (test "#0=(1 . #0#)"
+          (show #f (written (let ((ones (list 1))) (set-cdr! ones ones) ones))))
+      (test "(0 . #0=(1 . #0#))"
+          (show #f (written (let ((ones (list 1)))
+                              (set-cdr! ones ones)
+                              (cons 0 ones)))))
+      (test "(sym . #0=(sym . #0#))"
+          (show #f (written (let ((syms (list 'sym)))
+                              (set-cdr! syms syms)
+                              (cons 'sym syms)))))
+      (test "(#0=(1 . #0#) #1=(2 . #1#))"
+          (show #f (written (let ((ones (list 1))
+                                  (twos (list 2)))
+                              (set-cdr! ones ones)
+                              (set-cdr! twos twos)
+                              (list ones twos)))))
+      (test "(#0=(1 . #0#) #0#)"
+          (show #f (written (let ((ones (list 1)))
+                              (set-cdr! ones ones)
+                              (list ones ones)))))
+      (test "((1) (1))"
+          (show #f (written (let ((ones (list 1)))
+                              (list ones ones)))))
+
+      (test "(#0=(1) #0#)"
+          (show #f (written-shared (let ((ones (list 1)))
+                                     (list ones ones)))))
+
+      ;; cycles without shared detection
+
+      (test "(1 1 1 1 1"
+          (show #f (trimmed/lazy
+                    10
+                    (written-simply
+                     (let ((ones (list 1))) (set-cdr! ones ones) ones)))))
+
+      (test "(1 1 1 1 1 "
+          (show #f (trimmed/lazy
+                    11
+                    (written-simply
+                     (let ((ones (list 1))) (set-cdr! ones ones) ones)))))
+
+      ;; pretty printing
+
+      (test-pretty "(foo bar)\n")
+
+      (test-pretty
+       "((self . aquanet-paper-1991)
+ (type . paper)
+ (title . \"Aquanet: a hypertext tool to hold your\"))
+")
+
+      (test-pretty
+       "(abracadabra xylophone
+             bananarama
+             yellowstonepark
+             cryptoanalysis
+             zebramania
+             delightful
+             wubbleflubbery)\n")
+
+      (test-pretty
+       "#(0  1  2  3  4  5  6  7  8  9  10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25
+  26 27 28 29 30 31 32 33 34 35 36 37)\n")
+
+      (test-pretty
+       "(0  1  2  3  4  5  6  7  8  9  10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25
+ 26 27 28 29 30 31 32 33 34 35 36 37)\n")
+
+      (test-pretty
+       "(#(0 1)   #(2 3)   #(4 5)   #(6 7)   #(8 9)   #(10 11) #(12 13) #(14 15)
+ #(16 17) #(18 19))\n")
+
+      (test-pretty
+       "(define (fold kons knil ls)
+  (define (loop ls acc)
+    (if (null? ls) acc (loop (cdr ls) (kons (car ls) acc))))
+  (loop ls knil))\n")
+
+      (test-pretty
+       "(do ((vec (make-vector 5)) (i 0 (+ i 1))) ((= i 5) vec) (vector-set! vec i i))\n")
+
+      (test-pretty
+       "(do ((vec (make-vector 5)) (i 0 (+ i 1))) ((= i 5) vec)
+  (vector-set! vec i 'supercalifrajalisticexpialidocious))\n")
+
+      (test-pretty
+       "(do ((my-vector (make-vector 5)) (index 0 (+ index 1)))
+    ((= index 5) my-vector)
+  (vector-set! my-vector index index))\n")
+
+      (test-pretty
+       "(define (fold kons knil ls)
+  (let loop ((ls ls) (acc knil))
+    (if (null? ls) acc (loop (cdr ls) (kons (car ls) acc)))))\n")
+
+      (test-pretty
+       "(define (file->sexp-list pathname)
+  (call-with-input-file pathname
+    (lambda (port)
+      (let loop ((res '()))
+        (let ((line (read port)))
+          (if (eof-object? line) (reverse res) (loop (cons line res))))))))\n")
+
+      (test-pretty
+       "(design
+ (module (name \"\\\\testshiftregister\") (attributes (attribute (name \"\\\\src\"))))
+ (wire (name \"\\\\shreg\") (attributes (attribute (name \"\\\\src\")))))\n")
+
+      (test-pretty
+       "(design
+ (module (name \"\\\\testshiftregister\")
+         (attributes
+          (attribute (name \"\\\\src\") (value \"testshiftregister.v:10\"))))
+ (wire (name \"\\\\shreg\")
+       (attributes
+        (attribute (name \"\\\\src\") (value \"testshiftregister.v:15\")))))\n")
+
+      (test "(let ((ones '#0=(1 . #0#))) ones)\n"
+          (show #f (pretty (let ((ones (list 1)))
+                             (set-cdr! ones ones)
+                             `(let ((ones ',ones)) ones)))))
+
+      '(test
+           "(let ((zeros '(0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0))
+      (ones '#0=(1 . #0#)))
+  (append zeros ones))\n"
+           (show #f (pretty
+                     (let ((ones (list 1)))
+                       (set-cdr! ones ones)
+                       `(let ((zeros '(0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0))
+                              (ones ',ones))
+                          (append zeros ones))))))
+
+      ;; pretty-simply
+      (let* ((d (let ((d (list 'a 'b #f)))
+                  (list-set! d 2 d)
+                  (list d)))
+             (ca (circular-list 'a)))
+        (test "((a b (a b (a b" (show #f (trimmed/lazy 15 (pretty-simply '((a b (a b (a b (a b)))))))))
+        (test "((a b\n    (a b\n" (show #f (trimmed/lazy 15 (pretty-simply d))))
+        (test "'(a a\n    a\n   " (show #f (trimmed/lazy 15 (pretty-simply `(quote ,ca)))))
+        (test "(foo\n (a a\n    " (show #f (trimmed/lazy 15 (pretty-simply `(foo ,ca)))))
+        (test "(with-x \n  (a a" (show #f (trimmed/lazy 15 (pretty-simply `(with-x ,ca)))))
+        )
+
+      ;; columns
+
+      (test "abc\ndef\n"
+          (show #f (show-columns (list displayed "abc\ndef\n"))))
+      (test "abc123\ndef456\n"
+          (show #f (show-columns (list displayed "abc\ndef\n")
+                                 (list displayed "123\n456\n"))))
+      (test "abc123\ndef456\n"
+          (show #f (show-columns (list displayed "abc\ndef\n")
+                                 (list displayed "123\n456"))))
+      (test "abc123\ndef456\n"
+          (show #f (show-columns (list displayed "abc\ndef")
+                                 (list displayed "123\n456\n"))))
+      (test "abc123\ndef456\nghi789\n"
+          (show #f (show-columns (list displayed "abc\ndef\nghi\n")
+                                 (list displayed "123\n456\n789\n"))))
+      (test "abc123wuv\ndef456xyz\n"
+          (show #f (show-columns (list displayed "abc\ndef\n")
+                                 (list displayed "123\n456\n")
+                                 (list displayed "wuv\nxyz\n"))))
+      (test "abc  123\ndef  456\n"
+          (show #f (show-columns (list (lambda (x) (padded/right 5 x))
+                                       "abc\ndef\n")
+                                 (list displayed "123\n456\n"))))
+      (test "ABC  123\nDEF  456\n"
+          (show #f (show-columns (list (lambda (x) (upcased (padded/right 5 x)))
+                                       "abc\ndef\n")
+                                 (list displayed "123\n456\n"))))
+      (test "ABC  123\nDEF  456\n"
+          (show #f (show-columns (list (lambda (x) (padded/right 5 (upcased x)))
+                                       "abc\ndef\n")
+                                 (list displayed "123\n456\n"))))
+
+      (test "hello\nworld\n"
+          (show #f (with ((width 8)) (wrapped "hello world"))))
+      (test "\n" (show #f (wrapped "    ")))
+
+      (test
+          "The  quick
+brown  fox
+jumped
+over   the
+lazy dog
+"
+          (show #f
+                (with ((width 10))
+                  (justified "The quick brown fox jumped over the lazy dog"))))
+
+      (test
+          "The fundamental list iterator.
+Applies KONS to each element of
+LS and the result of the previous
+application, beginning with KNIL.
+With KONS as CONS and KNIL as '(),
+equivalent to REVERSE.
+"
+          (show #f
+                (with ((width 36))
+                  (wrapped "The fundamental list iterator.  Applies KONS to each element of LS and the result of the previous application, beginning with KNIL.  With KONS as CONS and KNIL as '(), equivalent to REVERSE."))))
+
+      (test
+          "(define (fold kons knil ls)
+  (let lp ((ls ls) (acc knil))
+    (if (null? ls)
+        acc
+        (lp (cdr ls)
+            (kons (car ls) acc)))))
+"
+          (show #f
+                (with ((width 36))
+                  (pretty '(define (fold kons knil ls)
+                             (let lp ((ls ls) (acc knil))
+                               (if (null? ls)
+                                   acc
+                                   (lp (cdr ls)
+                                       (kons (car ls) acc)))))))))
+
+      (test
+           "(define (fold kons knil ls)          ; The fundamental list iterator.
+  (let lp ((ls ls) (acc knil))       ; Applies KONS to each element of
+    (if (null? ls)                   ; LS and the result of the previous
+        acc                          ; application, beginning with KNIL.
+        (lp (cdr ls)                 ; With KONS as CONS and KNIL as '(),
+            (kons (car ls) acc)))))  ; equivalent to REVERSE.
+"
+           (show #f
+                 (show-columns
+                  (list
+                   (lambda (x) (padded/right 36 x))
+                   (with ((width 36))
+                     (pretty '(define (fold kons knil ls)
+                                (let lp ((ls ls) (acc knil))
+                                  (if (null? ls)
+                                      acc
+                                      (lp (cdr ls)
+                                          (kons (car ls) acc))))))))
+                  (list
+                   (lambda (x) (each " ; " x))
+                   (with ((width 36))
+                     (wrapped "The fundamental list iterator.  Applies KONS to each element of LS and the result of the previous application, beginning with KNIL.  With KONS as CONS and KNIL as '(), equivalent to REVERSE."))))))
+
+      (test
+           "(define (fold kons knil ls)          ; The fundamental list iterator.
+  (let lp ((ls ls) (acc knil))       ; Applies KONS to each element of
+    (if (null? ls)                   ; LS and the result of the previous
+        acc                          ; application, beginning with KNIL.
+        (lp (cdr ls)                 ; With KONS as CONS and KNIL as '(),
+            (kons (car ls) acc)))))  ; equivalent to REVERSE.
+"
+           (show #f (with ((width 76))
+                      (columnar
+                       (pretty '(define (fold kons knil ls)
+                                  (let lp ((ls ls) (acc knil))
+                                    (if (null? ls)
+                                        acc
+                                        (lp (cdr ls)
+                                            (kons (car ls) acc))))))
+                       " ; "
+                       (wrapped "The fundamental list iterator.  Applies KONS to each element of LS and the result of the previous application, beginning with KNIL.  With KONS as CONS and KNIL as '(), equivalent to REVERSE.")))))
+
+      (test
+          "- Item 1: The text here is
+          indented according
+          to the space \"Item
+          1\" takes, and one
+          does not known what
+          goes here.
+"
+          (show #f (columnar 9 (each "- Item 1:") " " (with ((width 20)) (wrapped "The text here is indented according to the space \"Item 1\" takes, and one does not known what goes here.")))))
+
+      (test
+          "- Item 1: The text here is
+          indented according
+          to the space \"Item
+          1\" takes, and one
+          does not known what
+          goes here.
+"
+          (show #f (columnar 9 (each "- Item 1:\n") " " (with ((width 20)) (wrapped "The text here is indented according to the space \"Item 1\" takes, and one does not known what goes here.")))))
+
+      (test
+          "- Item 1: The-text-here-is----------------------------------------------------
+--------- indented-according--------------------------------------------------
+--------- to-the-space-\"Item--------------------------------------------------
+--------- 1\"-takes,-and-one---------------------------------------------------
+--------- does-not-known-what-------------------------------------------------
+--------- goes-here.----------------------------------------------------------
+"
+          (show #f (with ((pad-char #\-)) (columnar 9 (each "- Item 1:\n") " " (with ((width 20)) (wrapped "The text here is indented according to the space \"Item 1\" takes, and one does not known what goes here."))))))
+
+      (test
+          "a   | 123
+bc  | 45
+def | 6
+"
+          (show #f (with ((width 20))
+                    (tabular (each "a\nbc\ndef\n") " | "
+                             (each "123\n45\n6\n")))))
+
+      ;; color
+      (test "\x1B;[31mred\x1B;[0m" (show #f (as-red "red")))
+      (test "\x1B;[31mred\x1B;[34mblue\x1B;[31mred\x1B;[0m"
+          (show #f (as-red "red" (as-blue "blue") "red")))
+      (test "\x1b;[31m1234567\x1b;[0m col: 7"
+            (show #f (as-unicode (as-red "1234567") (fn ((col)) (each " col: " col)))))
+
+      ;; unicode
+      (test "〜日本語〜"
+          (show #f (with ((pad-char #\〜)) (padded/both 5 "日本語"))))
+      (test "日本語"
+            (show #f (as-unicode (with ((pad-char #\〜)) (padded/both 5 "日本語")))))
+      (test "日本語 col: 6"
+            (show #f (as-unicode "日本語" (fn ((col)) (each " col: " col)))))
+
+      ;; from-file
+      ;; for reference, filesystem-test relies on creating files under /tmp
+      (let* ((tmp-file "chibi-show-test-0123456789")
+             (content-string "first line\nsecond line\nthird line"))
+        (with-output-to-file tmp-file (lambda () (write-string content-string)))
+        (test (string-append content-string "\n")
+              (show #f (from-file tmp-file)))
+        (test
+         "   1 first line\n   2 second line\n   3 third line\n"
+         (show #f (columnar 4 'right 'infinite (line-numbers) " " (from-file tmp-file))))
+        (delete-file tmp-file))
+
+      (test-end))))


### PR DESCRIPTION
(this is the first step of supporting srfi-159, I make this a separate PR so that it's easier to see changes made on top of this one later. Those changes are on the update-chibi-show in my fork)

This is from commit 5c43ca77 (move the col+ansi test to color section, 2019-11-07). '(chibi show c)' is excluded because that's for generating C code from sexp.

All these code will NOT run. The code will be fixed up in the following commits. Then tests added in the end.

Eventually the plan is to rename this to srfi-159 and '(scheme show)'. '(chibi show)' only exists temporarily in Gauche code base.