### PR TITLE
Update chibi.show code to work on Gauche

### DIFF
--- a/lib/chibi/show/base.scm
+++ b/lib/chibi/show/base.scm
@@ -91,7 +91,7 @@
 (define (output-default str)
   (fn (port row col string-width)
     (display str port)
-    (let ((nl-index (string-find-right str #\newline)))
+    (let ((nl-index (string-index-right str #\newline)))
       (if (string-cursor>? nl-index (string-cursor-start str))
           (with! (row (+ row (string-count str #\newline)))
                  (col (string-width str (string-cursor->index str nl-index))))

--- a/lib/chibi/show/base.scm
+++ b/lib/chibi/show/base.scm
@@ -6,37 +6,6 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;;> The environment monad with some pre-defined fields for combinator
-;;> formatting.
-
-(define-environment-monad Show-Env
-  (sequence: sequence)
-  (bind: %fn)
-  (bind-fork: forked)
-  (local: %with)
-  (local!: with!)
-  (return: return)
-  (run: run)
-  (fields:
-   (port env-port env-port-set!)
-   (row env-row env-row-set!)
-   (col env-col env-col-set!)
-   (width env-width env-width-set!)
-   (radix env-radix env-radix-set!)
-   (precision env-precision env-precision-set!)
-   (pad-char env-pad-char env-pad-char-set!)
-   (decimal-sep env-decimal-sep env-decimal-sep-set!)
-   (decimal-align env-decimal-align env-decimal-align-set!)
-   (string-width env-string-width env-string-width-set!)
-   (ellipsis env-ellipsis env-ellipsis-set!)
-   (writer env-writer env-writer-set!)
-   (output env-output env-output-set!)))
-
-(define-syntax fn
-  (syntax-rules ()
-    ((fn vars expr ... fmt)
-     (%fn vars expr ... (displayed fmt)))))
-
 ;; The base formatting handles outputting raw strings and a simple,
 ;; configurable handler for formatting objects.
 
@@ -84,13 +53,6 @@
                         (output output-default)
                         (string-width substring-length))
                  proc)))
-
-;;> Temporarily bind the parameters in the body \var{x}.
-
-(define-syntax with
-  (syntax-rules ()
-    ((with params x ... y)
-     (%with params (each x ... y)))))
 
 ;;> The noop formatter.  Generates no output and leaves the state
 ;;> unmodified.

--- a/lib/chibi/show/base.sld
+++ b/lib/chibi/show/base.sld
@@ -9,6 +9,7 @@
    call-with-shared-ref call-with-shared-ref/cdr)
   (import (scheme base) (scheme write) (scheme complex) (scheme inexact)
           (only (gauche base) let-optionals*)
-          (srfi 1) (srfi 69) (srfi 130) (chibi monad environment))
+          (srfi 1) (srfi 69) (srfi 130))
+  (include "monad.scm")
   (include "base.scm")
   (include "write.scm"))

--- a/lib/chibi/show/base.sld
+++ b/lib/chibi/show/base.sld
@@ -8,24 +8,7 @@
    output-default extract-shared-objects write-to-string write-with-shares
    call-with-shared-ref call-with-shared-ref/cdr)
   (import (scheme base) (scheme write) (scheme complex) (scheme inexact)
+          (only (gauche base) let-optionals*)
           (srfi 1) (srfi 69) (chibi string) (chibi monad environment))
-  (cond-expand
-   (chibi
-    (import (only (chibi) let-optionals*)))
-   (else
-    (begin
-      (define-syntax let-optionals*
-        (syntax-rules ()
-          ((let-optionals* opt-ls () . body)
-           (begin . body))
-          ((let-optionals* (op . args) vars . body)
-           (let ((tmp (op . args)))
-             (let-optionals* tmp vars . body)))
-          ((let-optionals* tmp ((var default) . rest) . body)
-           (let ((var (if (pair? tmp) (car tmp) default))
-                 (tmp2 (if (pair? tmp) (cdr tmp) '())))
-             (let-optionals* tmp2 rest . body)))
-          ((let-optionals* tmp tail . body)
-           (let ((tail tmp)) . body)))))))
   (include "base.scm")
   (include "write.scm"))

--- a/lib/chibi/show/base.sld
+++ b/lib/chibi/show/base.sld
@@ -9,6 +9,6 @@
    call-with-shared-ref call-with-shared-ref/cdr)
   (import (scheme base) (scheme write) (scheme complex) (scheme inexact)
           (only (gauche base) let-optionals*)
-          (srfi 1) (srfi 69) (chibi string) (chibi monad environment))
+          (srfi 1) (srfi 69) (srfi 130) (chibi monad environment))
   (include "base.scm")
   (include "write.scm"))

--- a/lib/chibi/show/column.scm
+++ b/lib/chibi/show/column.scm
@@ -11,7 +11,7 @@
         (reverse res))
        (else
         (let ((sc2 (string-index str separator? sc)))
-          (lp (string-cursor-next str sc2)
+          (lp (if (string-cursor=? sc2 end) sc2 (string-cursor-next str sc2))
               (if (string-cursor=? sc sc2)
                   res
                   (cons (substring/cursors str sc sc2) res)))))))))

--- a/lib/chibi/show/column.sld
+++ b/lib/chibi/show/column.sld
@@ -2,7 +2,8 @@
 (define-library (chibi show column)
   (import (scheme base) (scheme char) (scheme file) (scheme write)
           (srfi 1) (srfi 117) (srfi 130)
-          (chibi optional) (chibi show))
+          (only (gauche base) let-optionals*)
+          (chibi show))
   (export
    call-with-output-generator call-with-output-generators
    string->line-generator

--- a/lib/chibi/show/monad.scm
+++ b/lib/chibi/show/monad.scm
@@ -1,0 +1,155 @@
+;;> The environment monad with some pre-defined fields for combinator
+;;> formatting.
+
+(define-record-type Show-Env
+    (make-state port row col width radix precision
+                pad-char decimal-sep decimal-align
+                string-width ellipsis writer output
+                %props)
+    state?
+  (port env-port env-port-set!)
+  (row env-row env-row-set!)
+  (col env-col env-col-set!)
+  (width env-width env-width-set!)
+  (radix env-radix env-radix-set!)
+  (precision env-precision env-precision-set!)
+  (pad-char env-pad-char env-pad-char-set!)
+  (decimal-sep env-decimal-sep env-decimal-sep-set!)
+  (decimal-align env-decimal-align env-decimal-align-set!)
+  (string-width env-string-width env-string-width-set!)
+  (ellipsis env-ellipsis env-ellipsis-set!)
+  (writer env-writer env-writer-set!)
+  (output env-output env-output-set!)
+  (%props get-props set-props!))
+
+(define (ask st x)
+  (case x
+    ((port) (env-port st))
+    ((row) (env-row st))
+    ((col) (env-col st))
+    ((width) (env-width st))
+    ((radix) (env-radix st))
+    ((precision) (env-precision st))
+    ((pad-char) (env-pad-char st))
+    ((decimal-sep) (env-decimal-sep st))
+    ((decimal-align) (env-decimal-align st))
+    ((string-width) (env-string-width st))
+    ((ellipsis) (env-ellipsis st))
+    ((writer) (env-writer st))
+    ((output) (env-output st))
+    (else (cond ((assq x (get-props st)) => cdr) (else #f)))))
+
+(define (tell st x val)
+  (case x
+    ((port) (env-port-set! st val))
+    ((row) (env-row-set! st val))
+    ((col) (env-col-set! st val))
+    ((width) (env-width-set! st val))
+    ((radix) (env-radix-set! st val))
+    ((precision) (env-precision-set! st val))
+    ((pad-char) (env-pad-char-set! st val))
+    ((decimal-sep) (env-decimal-sep-set! st val))
+    ((decimal-align) (env-decimal-align-set! st val))
+    ((string-width) (env-string-width-set! st val))
+    ((ellipsis) (env-ellipsis-set! st val))
+    ((writer) (env-writer-set! st val))
+    ((output) (env-output-set! st val))
+    (else
+     (cond
+      ((assq x (get-props st))
+       => (lambda (cell) (set-cdr! cell val)))
+      (else
+       (set-props! st (cons (cons x val) (get-props st))))))))
+
+;; External API
+;;
+;; copy
+(define (c st)
+  (make-state
+   (env-port st)
+   (env-row st)
+   (env-col st)
+   (env-width st)
+   (env-radix st)
+   (env-precision st)
+   (env-pad-char st)
+   (env-decimal-sep st)
+   (env-decimal-align st)
+   (env-string-width st)
+   (env-ellipsis st)
+   (env-writer st)
+   (env-output st)
+   (map (lambda (x)
+          (cons (car x) (cdr x)))
+        (get-props st))))
+
+;; bind - a function
+(define-syntax %fn
+  (syntax-rules ()
+    ((%fn ("step") (params ...) ((p param) . rest) . body)
+     (%fn ("step") (params ... (p param)) rest . body))
+    ((%fn ("step") (params ...) ((param) . rest) . body)
+     (%fn ("step") (params ... (param param)) rest . body))
+    ((%fn ("step") (params ...) (param . rest) . body)
+     (%fn ("step") (params ... (param param)) rest . body))
+    ((%fn ("step") ((p param) ...) () . body)
+     (lambda (st)
+       (let ((p (ask st 'param)) ...)
+         ((let () . body) st))))
+    ((%fn params . body)
+     (%fn ("step") () params . body))))
+
+(define-syntax fn
+  (syntax-rules ()
+    ((fn vars expr ... fmt)
+     (%fn vars expr ... (displayed fmt)))))
+
+;; fork - run on a copy of the state
+(define-syntax forked
+  (syntax-rules ()
+    ((forked a) a)
+    ((forked a b) (lambda (st) (a (c st)) (b st)))
+    ((forked a b . c) (forked a (forked b . c)))))
+
+;; sequence
+(define-syntax sequence
+  (syntax-rules ()
+    ((sequence f) f)
+    ((sequence f . g) (lambda (st) ((sequence . g) (f st))))))
+
+;; update in place
+(define-syntax with!
+  (syntax-rules ()
+    ((with! (prop value) ...)
+     (lambda (st)
+       (tell st 'prop value) ...
+       st))))
+
+;; local binding - update temporarily
+(define-syntax %with
+  (syntax-rules ()
+    ((%with ("step") ((p tmp v) ...) () . b)
+     (lambda (st)
+       (let ((tmp (ask st 'p)) ...)
+         (dynamic-wind
+           (lambda () (tell st 'p v) ...)
+           (lambda () ((begin . b) st))
+           (lambda () (tell st 'p tmp) ...)))))
+    ((%with ("step") (props ...) ((p v) . rest) . b)
+     (%with ("step") (props ... (p tmp v)) rest . b))
+    ((%with ((prop value) ...) . body)
+     (%with ("step") () ((prop value) ...) . body))))
+
+;;> Temporarily bind the parameters in the body \var{x}.
+(define-syntax with
+  (syntax-rules ()
+    ((with params x ... y)
+     (%with params (each x ... y)))))
+
+;; run
+(define (run proc)
+  (proc (make-state #f #f #f #f #f #f #f #f #f #f #f #f #f '())))
+
+;; return
+(define (return x)
+  (lambda (st) x))

--- a/lib/chibi/show/pretty.scm
+++ b/lib/chibi/show/pretty.scm
@@ -39,7 +39,7 @@
 (define (string-find/index str pred i)
   (string-cursor->index
    str
-   (string-find str pred (string-index->cursor str i))))
+   (string-index str pred (string-index->cursor str i))))
 
 (define (try-fitted2 proc fail)
   (fn (width output)

--- a/lib/chibi/show/pretty.sld
+++ b/lib/chibi/show/pretty.sld
@@ -4,5 +4,5 @@
           joined/shares try-fitted
           )
   (import (scheme base) (scheme write) (chibi show) (chibi show base)
-          (srfi 1) (srfi 69) (chibi string))
+          (srfi 1) (srfi 69) (srfi 130))
   (include "pretty.scm"))

--- a/lib/chibi/show/show.scm
+++ b/lib/chibi/show/show.scm
@@ -182,7 +182,7 @@
          (each ell
                (if (negative? diff)
                    nothing
-                   (substring str diff))))))))
+                   (string-copy str diff))))))))
 
 ;;> An alias for \scheme{trimmed/left}.
 (define trimmed trimmed/left)

--- a/lib/chibi/show/write.scm
+++ b/lib/chibi/show/write.scm
@@ -54,7 +54,7 @@
                 (if (eq? i j) "" (substring/cursors str i j)))
               (if (string-cursor>=? j end)
                   (output (collect))
-                  (let ((c (string-cursor-ref str j))
+                  (let ((c (string-ref/cursor str j))
                         (j2 (string-cursor-next str j)))
                     (cond
                      ((or (eqv? c quot) (eqv? c esc))
@@ -234,12 +234,12 @@
                        (res (substring/cursors s (string-cursor-start s) last)))
                   (if (and
                        (string-cursor<? last end)
-                       (let ((next (digit-value (string-cursor-ref s last))))
+                       (let ((next (digit-value (string-ref/cursor s last))))
                          (or (> next 5)
                              (and (= next 5)
                                   (string-cursor>? last (string-cursor-start s))
                                   (memv (digit-value
-                                         (string-cursor-ref
+                                         (string-ref/cursor
                                           s (string-cursor-prev s last)))
                                         '(1 3 5 7 9))))))
                       (list->string

--- a/lib/chibi/show/write.scm
+++ b/lib/chibi/show/write.scm
@@ -294,18 +294,9 @@
                 (if comma-rule (insert-commas s1) s1))))
         ;; Wrap the sign of a real number, forcing a + prefix or using
         ;; parentheses (n) for negatives according to sign-rule.
-
-        (define-syntax is-neg-zero?
-          (syntax-rules ()
-            ((_ n)
-             (is-neg-zero? (-0.0) n))
-            ((_ (0.0) n)                ; -0.0 is not distinguished?
-             #f)
-            ((_ (-0.0) n)
-             (eqv? -0.0 n))))
         (define (negative?* n)
           (or (negative? n)
-              (is-neg-zero? n)))
+              (and (zero? n) (string=? (number->string n) "-0.0"))))
         (define (wrap-sign n sign-rule)
           (cond
            ((negative?* n)

--- a/lib/chibi/show/write.scm
+++ b/lib/chibi/show/write.scm
@@ -19,12 +19,17 @@
     (get-output-string out)))
 
 (define (string-intersperse-right str sep rule)
+  (define (cursor-back str i offset)    ; safe version
+    (if (or (zero? offset)
+            (string-cursor=? i (string-cursor-start str)))
+        i
+        (cursor-back str (string-cursor-prev str i) (- offset 1))))
   (let ((start (string-cursor-start str)))
     (let lp ((i (string-cursor-end str))
              (rule rule)
              (res '()))
       (let* ((offset (if (pair? rule) (car rule) rule))
-             (i2 (if offset (string-cursor-back str i offset) start)))
+             (i2 (if offset (cursor-back str i offset) start)))
         (if (string-cursor<=? i2 start)
             (apply string-append (cons (substring/cursors str start i) res))
             (lp i2

--- a/lib/chibi/show/write.scm
+++ b/lib/chibi/show/write.scm
@@ -26,10 +26,10 @@
       (let* ((offset (if (pair? rule) (car rule) rule))
              (i2 (if offset (string-cursor-back str i offset) start)))
         (if (string-cursor<=? i2 start)
-            (apply string-append (cons (substring-cursor str start i) res))
+            (apply string-append (cons (substring/cursors str start i) res))
             (lp i2
                 (if (and (pair? rule) (not (null? (cdr rule)))) (cdr rule) rule)
-                (cons sep (cons (substring-cursor str i2 i) res))))))))
+                (cons sep (cons (substring/cursors str i2 i) res))))))))
 
 ;;> Outputs the string str, escaping any quote or escape characters.
 ;;> If esc-ch, which defaults to #\\, is #f, escapes only the
@@ -51,7 +51,7 @@
                 (end (string-cursor-end str)))
             (let lp ((i start) (j start))
               (define (collect)
-                (if (eq? i j) "" (substring-cursor str i j)))
+                (if (eq? i j) "" (substring/cursors str i j)))
               (if (string-cursor>=? j end)
                   (output (collect))
                   (let ((c (string-cursor-ref str j))
@@ -231,7 +231,7 @@
                (else
                 (let* ((last
                         (string-cursor-back s end (- digits precision 1)))
-                       (res (substring-cursor s (string-cursor-start s) last)))
+                       (res (substring/cursors s (string-cursor-start s) last)))
                   (if (and
                        (string-cursor<? last end)
                        (let ((next (digit-value (string-cursor-ref s last))))
@@ -265,8 +265,8 @@
                               (or (string-contains str dec-sep)
                                   (string-cursor-end str))
                               (string-index str dec-sep)))
-                 (left (substring-cursor str (string-cursor-start str) dec-pos))
-                 (right (substring-cursor str dec-pos))
+                 (left (substring/cursors str (string-cursor-start str) dec-pos))
+                 (right (substring/cursors str dec-pos))
                  (sep (cond ((char? comma-sep) (string comma-sep))
                             ((string? comma-sep) comma-sep)
                             ((eqv? #\, dec-sep) ".")

--- a/lib/chibi/show/write.scm
+++ b/lib/chibi/show/write.scm
@@ -86,7 +86,7 @@
     (call-with-output
      fmt
      (lambda (str)
-       (if (string-cursor<? (string-find str esc?) (string-cursor-end str))
+       (if (string-cursor<? (string-index str esc?) (string-cursor-end str))
            (each quot (escaped str quot esc rename) quot)
            (displayed str))))))
 
@@ -217,11 +217,11 @@
            ((and (eqv? radix 10) (or (integer? n) (inexact? n)))
             (let* ((s (number->string n))
                    (end (string-cursor-end s))
-                   (dec (string-find s #\.))
+                   (dec (string-index s #\.))
                    (digits (- (string-cursor->index s end)
                               (string-cursor->index s dec))))
               (cond
-               ((string-cursor<? (string-find s #\e) end)
+               ((string-cursor<? (string-index s #\e) end)
                 (gen-general n))
                ((string-cursor=? dec end)
                 (string-append s (if (char? dec-sep) (string dec-sep) dec-sep)
@@ -264,7 +264,7 @@
           (let* ((dec-pos (if (string? dec-sep)
                               (or (string-contains str dec-sep)
                                   (string-cursor-end str))
-                              (string-find str dec-sep)))
+                              (string-index str dec-sep)))
                  (left (substring-cursor str (string-cursor-start str) dec-pos))
                  (right (substring-cursor str dec-pos))
                  (sep (cond ((char? comma-sep) (string comma-sep))
@@ -328,7 +328,7 @@
                                 (string-cursor->index
                                  s
                                  (if (char? dec-sep)
-                                     (string-find s dec-sep)
+                                     (string-index s dec-sep)
                                      (or (string-contains s dec-sep)
                                          (string-cursor-end s))))
                                 0))

--- a/lib/chibi/show/write.scm
+++ b/lib/chibi/show/write.scm
@@ -266,7 +266,7 @@
                                   (string-cursor-end str))
                               (string-index str dec-sep)))
                  (left (substring/cursors str (string-cursor-start str) dec-pos))
-                 (right (substring/cursors str dec-pos))
+                 (right (string-copy/cursors str dec-pos))
                  (sep (cond ((char? comma-sep) (string comma-sep))
                             ((string? comma-sep) comma-sep)
                             ((eqv? #\, dec-sep) ".")

--- a/test/include/srfi-159-tests.scm
+++ b/test/include/srfi-159-tests.scm
@@ -1,19 +1,19 @@
-(define-library (chibi show-test)
-  (export run-tests)
-  (import (scheme base) (scheme char) (scheme read) (scheme file)
-          (only (srfi 1) circular-list)
-          (chibi test)
-          (chibi show) (chibi show base) (chibi show color)
-          (chibi show column) (chibi show pretty)
-          (chibi show unicode))
-  (begin
+;(define-library (chibi show-test)
+;  (export run-tests)
+;  (import (scheme base) (scheme char) (scheme read) (scheme file)
+;          (only (srfi 1) circular-list)
+;          (chibi test)
+;          (chibi show) (chibi show base) (chibi show color)
+;          (chibi show column) (chibi show pretty)
+;          (chibi show unicode))
+;  (begin
     (define-syntax test-pretty
       (syntax-rules ()
         ((test-pretty str)
          (let ((sexp (read (open-input-string str))))
            (test str (show #f (pretty sexp)))))))
-    (define (run-tests)
-      (test-begin "show")
+;    (define (run-tests)
+;      (test-begin "show")
 
       ;; basic data types
 
@@ -253,14 +253,12 @@
       (test "1,5" (show #f (numeric 1.5 10 #f #f #f #\.)))
       (test "1%5" (show #f (numeric 1.5 10 #f #f #f #\. #\%)))
 
-      (cond-expand
-       (complex
-        ;(test "1+2i" (show #f (string->number "1+2i")))
-        (test "1.0+2.0i" (show #f (string->number "1+2i")))
-        (test "1.00+2.00i"
+      ;(test "1+2i" (show #f (string->number "1+2i")))
+      (test "1.0+2.0i" (show #f (string->number "1+2i")))
+      (test "1.00+2.00i"
             (show #f (with ((precision 2)) (string->number "1+2i"))))
-        (test "3.14+2.00i"
-            (show #f (with ((precision 2)) (string->number "3.14159+2i"))))))
+      (test "3.14+2.00i"
+            (show #f (with ((precision 2)) (string->number "3.14159+2i"))))
 
       (test "608" (show #f (numeric/si 608)))
       (test "608 B" (show #f (numeric/si 608 1000 " ") "B"))
@@ -757,4 +755,4 @@ def | 6
          (show #f (columnar 4 'right 'infinite (line-numbers) " " (from-file tmp-file))))
         (delete-file tmp-file))
 
-      (test-end))))
+;      (test-end))))

--- a/test/include/srfi-159-tests.scm
+++ b/test/include/srfi-159-tests.scm
@@ -255,7 +255,8 @@
 
       (cond-expand
        (complex
-        (test "1+2i" (show #f (string->number "1+2i")))
+        ;(test "1+2i" (show #f (string->number "1+2i")))
+        (test "1.0+2.0i" (show #f (string->number "1+2i")))
         (test "1.00+2.00i"
             (show #f (with ((precision 2)) (string->number "1+2i"))))
         (test "3.14+2.00i"

--- a/test/srfi.scm
+++ b/test/srfi.scm
@@ -2550,6 +2550,24 @@
    (include "include/srfi-158-tests.scm")))
 
 ;;-----------------------------------------------------------------------
+(test-section "srfi-159")
+;(use srfi-159)
+;(test-module 'srfi-159)
+
+(define-module srfi-159-test
+  (use compat.chibi-test)
+  (use scheme.list)
+  (use scheme.file)
+  (use chibi.show)
+  (use chibi.show.base)
+  (use chibi.show.color)
+  (use chibi.show.column)
+  (use chibi.show.pretty)
+  (use chibi.show.unicode)
+  (chibi-test
+   (include "include/srfi-159-tests.scm")))
+
+;;-----------------------------------------------------------------------
 (test-section "srfi-160")
 (use srfi-160)
 (test-module 'srfi-160)


### PR DESCRIPTION
> Are you going to modify these code directly to port to Gauche?

yes, at least that was the plan

> When we incorporate a certain amount of third-party code, keeping up to the updates of upstream is an issue. If possible, I prefer having original code separate from the "adapter" to make it work in Gauche. Can you do that way, so that later we can just swap the original code portion to catch up.

You can be the judge for this. This is a final srfi so I don't expect updates from upstream except bug fixes maybe, which still happened as late as november last year. So yeah we might need to keep up with upstream.

Most changes are relatively simple and some sort of wrapper should work. The outstanding ones are

- the environment monad thing (commit 7198781). In theory it should work but I'm not sure I have the competence to find and fix bugs in syntax-rules
- some chibi code produces out-of-range cursors which is tolerable by chibi but not scheme (commits  7baa174 and d31ec5d). Not sure if I could convince upstream to tighten up
- the "-0.0" thing (commit e00d3a8), I have absolutely no idea how we should deal with it. I'm not used to the numeric tower thing.