### PR TITLE
Avoid string-cursor-start for optional arguments

### DIFF
--- a/lib/srfi-130.scm
+++ b/lib/srfi-130.scm
@@ -99,7 +99,7 @@
   (car (apply (with-module srfi-13 %string-skip-right) args)))
 
 (define (string-for-each-cursor proc s :optional
-                                (start (string-cursor-start s))
+                                (start 0)
                                 (end (string-cursor-end s)))
   (assume-type s <string>)
   (let ([end (string-index->cursor s end)])
@@ -108,7 +108,7 @@
         (proc cur)
         (loop (string-cursor-next s cur))))))
 
-(define (string-contains s1 s2 :optional (start1 (string-cursor-start s1)) end1 start2 end2)
+(define (string-contains s1 s2 :optional (start1 0) end1 start2 end2)
   (assume-type s1 <string>)
   (assume-type s2 <string>)
   (let* ((str1 (%maybe-substring s1 start1 end1))
@@ -119,7 +119,7 @@
                                 (string-index->cursor s1 start1)
                                 (string-cursor->index str1 res)))))
 
-(define (string-contains-right s1 s2 :optional (start1 (string-cursor-start s1)) end1 start2 end2)
+(define (string-contains-right s1 s2 :optional (start1 0) end1 start2 end2)
   (assume-type s1 <string>)
   (assume-type s2 <string>)
   (let* ((str1 (%maybe-substring s1 start1 end1))

--- a/lib/srfi-152.scm
+++ b/lib/srfi-152.scm
@@ -50,24 +50,24 @@
     (not (pred x))))
 
 (define (string-take-while s pred :optional
-                           (start (string-cursor-start s))
+                           (start 0)
                            (end (string-cursor-end s)))
   (substring s start (%string-index s (%negate pred) start end)))
 
 (define (string-take-while-right s pred :optional
-                                 (start (string-cursor-start s))
+                                 (start 0)
                                  (end (string-cursor-end s)))
   (substring s (%string-index-right s (%negate pred) start end) end))
 
 (define (string-span s pred :optional
-                     (start (string-cursor-start s))
+                     (start 0)
                      (end (string-cursor-end s)))
   (let ([cur (%string-index s (%negate pred) start end)])
     (values (substring s start cur)
             (substring s cur end))))
 
 (define (string-break s pred :optional
-                      (start (string-cursor-start s))
+                      (start 0)
                       (end (string-cursor-end s)))
   (let ([cur (%string-index s pred start end)])
     (values (substring s start cur)

--- a/libsrc/srfi-13.scm
+++ b/libsrc/srfi-13.scm
@@ -204,19 +204,19 @@
 
 (define (string-trim s :optional
                      (c/s/p #[\s])
-                     (start (string-cursor-start s))
+                     (start 0)
                      (end (string-cursor-end s)))
   (substring s (car (%string-skip s c/s/p start end)) end))
 
 (define (string-trim-right s :optional
                            (c/s/p #[\s])
-                           (start (string-cursor-start s))
+                           (start 0)
                            (end (string-cursor-end s)))
   (substring s start (car (%string-skip-right s c/s/p start end))))
 
 (define (string-trim-both s :optional
                           (c/s/p #[\s])
-                          (start (string-cursor-start s))
+                          (start 0)
                           (end (string-cursor-end s)))
   (let ([new-start (car (%string-skip s c/s/p start end))])
     (substring s new-start (car (%string-skip-right s c/s/p new-start end)))))
@@ -461,7 +461,7 @@
 ;; these % variants return a pair of result and end cursor
 (define (%string-index s c/s/p
                        :optional
-                       (start (string-cursor-start s))
+                       (start 0)
                        (end (string-cursor-end s)))
   (assume-type s <string>)
   (let ([pred (%get-char-pred c/s/p)]
@@ -474,7 +474,7 @@
 
 (define (%string-index-right s c/s/p
                              :optional
-                             (start (string-cursor-start s))
+                             (start 0)
                              (end (string-cursor-end s)))
   (assume-type s <string>)
   (let ([pred (%get-char-pred c/s/p)]
@@ -489,7 +489,7 @@
 
 (define (%string-skip s c/s/p
                       :optional
-                      (start (string-cursor-start s))
+                      (start 0)
                       (end (string-cursor-end s)))
   (assume-type s <string>)
   (let ([pred (%get-char-pred c/s/p)]
@@ -502,7 +502,7 @@
 
 (define (%string-skip-right s c/s/p
                             :optional
-                            (start (string-cursor-start s))
+                            (start 0)
                             (end (string-cursor-end s)))
   (assume-type s <string>)
   (let ([pred (%get-char-pred c/s/p)]
@@ -541,7 +541,7 @@
 
 (define (string-count s c/s/p
                       :optional
-                      (start (string-cursor-start s))
+                      (start 0)
                       (end (string-cursor-end s)))
   (assume-type s <string>)
   (let ((pred (%get-char-pred c/s/p))
@@ -627,7 +627,7 @@
 ;;;
 
 (define (string-reverse s :optional
-                        (start (string-cursor-start s))
+                        (start 0)
                         (end (string-cursor-end s)))
   (let ((start (string-index->cursor s start))
         (dst (open-output-string)))
@@ -685,7 +685,7 @@
 ;;;
 
 (define (string-map proc s :optional
-                    (start (string-cursor-start s))
+                    (start 0)
                     (end (string-cursor-end s)))
   (assume-type s <string>)
   (let ((end  (string-index->cursor s end))
@@ -704,7 +704,7 @@
 
 (define (string-fold kons knil s
                      :optional
-                     (start (string-cursor-start s))
+                     (start 0)
                      (end (string-cursor-end s)))
   (assume-type s <string>)
   (let ([end (string-index->cursor s end)])
@@ -717,7 +717,7 @@
 
 (define (string-fold-right kons knil s
                            :optional
-                           (start (string-cursor-start s))
+                           (start 0)
                            (end (string-cursor-end s)))
   (assume-type s <string>)
   (let ([start (string-index->cursor s start)])
@@ -753,7 +753,7 @@
 
 (define (string-for-each proc s
                          :optional
-                         (start (string-cursor-start s))
+                         (start 0)
                          (end (string-cursor-end s)))
   (assume-type s <string>)
   (let ([end (string-index->cursor s end)])


### PR DESCRIPTION
"0" is a perfectly good value as the start of the string because all the
procedures must deal with both index and cursor and must call
string-index->cursor first. This reduces one procedure call for the
normal case where start/end are not specified.