### PR TITLE
More string-cursor adaptation

### DIFF
--- a/libsrc/srfi-13.scm
+++ b/libsrc/srfi-13.scm
@@ -614,7 +614,8 @@
 
 (define (%string-*case! converter)
   (lambda (s :optional (start 0) (end (string-length s)))
-    (if (and (= start 0) (= end (string-length s)))
+    (if (and (= (string-cursor->index s start) 0)
+             (= (string-cursor->index s end) (string-length s)))
       (%string-replace-body! s (converter s))
       (string-copy! s start (converter s start end)))))
 

--- a/libsrc/srfi-13.scm
+++ b/libsrc/srfi-13.scm
@@ -924,6 +924,7 @@
 ;; contains multibyte characters.  So the programs using these functions
 ;; may not be very efficient, in spite of the efforts for efficiency put
 ;; in the original SRFI design.
+;; TODO: see if cursors can be used instead of index.
 
 (define (make-kmp-restart-vector s :optional (c= char=?) start end)
   (let* ((pat (%maybe-substring s start end))

--- a/src/libstr.scm
+++ b/src/libstr.scm
@@ -214,19 +214,19 @@
 (define-in-module scheme (string-fill! str c
                                        :optional (start 0)
                                                  (end (string-length str)))
-  (let1 len (string-length str)
-    (when (or (< start 0) (< len start))
-      (error "start index out of range:" start))
-    (when (or (< end 0) (< len end))
-      (error "end index out of range:" end))
-    (when (< end start)
-      (errorf "end index ~s is smaller than start index ~s" end start))
-    (if (and (= start 0) (= end len))
+  (let ([start  (string-index->cursor str start)]
+        [end    (string-index->cursor str end)]
+        [istart (string-cursor->index str start)]
+        [iend   (string-cursor->index str end)]
+        [len    (string-length str)])
+    (when (< iend istart)
+      (errorf "end index ~s is smaller than start index ~s" iend istart))
+    (if (and (= istart 0) (= iend len))
       (%string-replace-body! str (make-string len c))
       (%string-replace-body! str
                              (string-append (substring str 0 start)
-                                            (make-string (- end start) c)
-                                            (substring str end len))))))
+                                            (make-string (- iend istart) c)
+                                            (string-copy str end))))))
 
 ;; Build index.
 ;; Technically, string-build-index mutates StringBody, but it's an idempotent

--- a/src/libstr.scm
+++ b/src/libstr.scm
@@ -186,16 +186,12 @@
 
 (define-in-module scheme (string-set! str k ch)
   (check-arg string? str)
-  (check-arg integer? k)
-  (check-arg exact? k)
   (check-arg char? ch)
-  (let1 len (string-length str)
-    (when (or (< k 0) (<= len k))
-      (error "string index out of range:" k))
+  (let1 cur (string-index->cursor str k)
     (%string-replace-body! str
-                           (string-append (substring str 0 k)
+                           (string-append (substring str 0 cur)
                                           (string ch)
-                                          (substring str (+ k 1) len)))))
+                                          (string-copy str (string-cursor-next str k))))))
 
 (set! (setter string-ref) string-set!)
 


### PR DESCRIPTION
More procedures can take string cursors. I'll just leave a TODO about KMP instead of converting it, it's been so long since I touched substring search algorithms.