### PR TITLE
make gosh -ftest work outside source tree

### DIFF
--- a/doc/program.texi
+++ b/doc/program.texi
@@ -283,7 +283,7 @@ heap. @xref{String cursors}.
 @item test
 Adds "@code{../src}" and "@code{../lib}" to the load path before loading
 initialization file.  This is useful when you want to test the
-compiled @code{gosh} interpreter inside source tree, without installing it.
+compiled @code{gosh} interpreter without installing it.
 @end table
 @c JP
 このオプションはコンパイラとランタイムの動作に影響を与えます。
@@ -319,7 +319,7 @@ lambda lifting最適化パスを抑止します。
 @item test
 "@code{../src}" と "@code{../lib}" を、初期化ファイルを読む前に
 ロードパスに加えます。これは、作成された@code{gosh}をインストールせずに
-ソースツリーの中で実行してみるのに便利です。
+実行してみるのに便利です。
 @end table
 @c COMMON
 @end deftp

--- a/src/main.c
+++ b/src/main.c
@@ -451,6 +451,21 @@ static void test_paths_setup(char **av)
         Scm_AddLoadPath("../../src", FALSE);
         Scm_AddLoadPath("../../libsrc", FALSE);
         Scm_AddLoadPath("../../lib", FALSE);
+    } else {
+        // should be synchronized with the ifdefs in paths to avoid
+        // triggering Scm_Error.
+#if defined(GAUCHE_WINDOWS) || defined(GAUCHE_MACOSX_FRAMEWORK) || defined(__linux__)
+        ScmObj install_dir = Scm__RuntimeDirectory();
+        ScmObj src = Scm_StringAppendC(SCM_STRING(install_dir), "/src", -1, -1);
+        test_ld_path_setup(av, Scm_GetStringConst(SCM_STRING(src)));
+        Scm_AddLoadPath(Scm_GetStringConst(SCM_STRING(src)), FALSE);
+        ScmObj libsrc = Scm_StringAppendC(SCM_STRING(install_dir), "/libsrc", -1, -1);
+        Scm_AddLoadPath(Scm_GetStringConst(SCM_STRING(libsrc)), FALSE);
+        ScmObj lib = Scm_StringAppendC(SCM_STRING(install_dir), "/lib", -1, -1);
+        Scm_AddLoadPath(Scm_GetStringConst(SCM_STRING(lib)), FALSE);
+#else
+        fprintf(stderr, "Unable to find source tree, -ftest has no effect\n");
+#endif
     }
     /* Also set a feature identifier gauche.in-place, so that other modules
        may initialize differently if needed. */


### PR DESCRIPTION
I was surprised that -ftest has no effect when running outside source
tree. I misused it because the document clearly says "inside". But it's
arguably more convenient to run uninstalled gosh from anywhere.

This uses /proc/self/exe for this which is not portable (but more
reliable than argv[0]). On other systems, at least we do say -ftest does
nothing to make it clear.