### PR TITLE
Add GitHub Actions (build workflow)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,189 @@
+name: Build
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install Gauche
+      run: |
+        pwd
+        curl -f -o get-gauche.sh https://raw.githubusercontent.com/shirok/get-gauche/master/get-gauche.sh
+        chmod +x get-gauche.sh
+        ./get-gauche.sh --auto --home
+    - name: Add Gauche path
+      run: |
+        PATH="$HOME/bin:$PATH"
+        echo "::set-env name=PATH::$PATH"
+    - name: Run Gauche once
+      run: |
+        echo $PATH
+        gosh -V
+    - name: Install tools
+      run: |
+        sudo apt-get install libgdbm-dev
+    - name: Build
+      run: |
+        pwd
+        ./DIST gen
+        ./configure
+        make -j4
+    - name: Test
+      run: |
+        pwd
+        make check
+
+  build-osx:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install Gauche
+      run: |
+        pwd
+        curl -f -o get-gauche.sh https://raw.githubusercontent.com/shirok/get-gauche/master/get-gauche.sh
+        chmod +x get-gauche.sh
+        ./get-gauche.sh --auto --home
+    - name: Add Gauche path
+      run: |
+        PATH="$HOME/bin:$PATH"
+        echo "::set-env name=PATH::$PATH"
+    - name: Run Gauche once
+      run: |
+        echo $PATH
+        gosh -V
+    - name: Install tools
+      run: |
+        brew install automake
+    - name: Build
+      run: |
+        pwd
+        ./DIST gen
+        ./configure
+        make -j4
+    - name: Test
+      run: |
+        pwd
+        make check
+
+  build-windows:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x86_64, i686]
+        include:
+        - arch: x86_64
+          bit: 64
+          progpath: C:\Program Files
+        - arch: i686
+          bit: 32
+          progpath: C:\Program Files (x86)
+    env:
+      MSYSTEM: MINGW${{ matrix.bit }}
+      MSYS2_PATH_TYPE: inherit
+      MSYS2_PATH_LIST: D:\msys64\mingw${{ matrix.bit }}\bin;D:\msys64\usr\local\bin;D:\msys64\usr\bin;D:\msys64\bin
+      MINGW_TYPE: mingw${{ matrix.bit }}
+      MINGW_ARCH: ${{ matrix.arch }}
+      MINGW_PATH: /mingw${{ matrix.bit }}/bin
+      GAUCHE_INFO_URL: https://practical-scheme.net/gauche/releases
+      GAUCHE_INSTALLER_URL: https://prdownloads.sourceforge.net/gauche
+      GAUCHE_INSTALLER_BIT: ${{ matrix.bit }}bit
+      GAUCHE_PATH: ${{ matrix.progpath }}\Gauche\bin
+      RESULT_NAME: Gauche-${{ matrix.arch }}
+      RESULT_PATH: ..\Gauche-mingw-dist\Gauche-${{ matrix.arch }}
+    steps:
+    - run: git config --global core.autocrlf false
+    - uses: actions/checkout@v2
+    - name: Install MSYS2
+      run: |
+        #del alias:curl
+        curl -f -o msys2.tar.xz http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20190524.tar.xz
+        #tar xf msys2.tar.xz
+        bash -c "7z x msys2.tar.xz -so | 7z x -aoa -si -ttar"
+        dir
+        mv msys64 D:\
+        dir D:\
+    - name: Add MSYS2 path
+      run: |
+        $env:PATH = "$env:MSYS2_PATH_LIST;$env:PATH"
+        echo "::set-env name=PATH::$env:PATH"
+    - name: Run MSYS2 once
+      run: |
+        $script = @'
+          pwd
+          uname -m
+          uname -a
+          echo $PATH
+        '@
+        & bash -lc $script
+    - name: Install MinGW-w64
+      run: |
+        $script = @'
+          pacman -S --noconfirm base-devel
+          pacman -S --noconfirm $MINGW_TYPE/mingw-w64-${MINGW_ARCH}-toolchain
+        '@
+        & bash -lc $script
+    - name: Install Gauche
+      run: |
+        #del alias:curl
+        $env:GAUCHE_INSTALLER_VERSION = curl -f $env:GAUCHE_INFO_URL/latest.txt
+        echo $env:GAUCHE_INSTALLER_VERSION
+        $env:GAUCHE_INSTALLER = "Gauche-mingw-${env:GAUCHE_INSTALLER_VERSION}-${env:GAUCHE_INSTALLER_BIT}.msi"
+        echo $env:GAUCHE_INSTALLER
+        curl -f -L -o $env:GAUCHE_INSTALLER $env:GAUCHE_INSTALLER_URL/$env:GAUCHE_INSTALLER
+        dir
+        msiexec /i $env:GAUCHE_INSTALLER /quiet /qn /norestart
+    - name: Add Gauche path
+      run: |
+        $env:PATH = "$env:GAUCHE_PATH;$env:PATH"
+        echo "::set-env name=PATH::$env:PATH"
+    - name: Run Gauche once
+      run: |
+        gosh -V
+    - name: Install tools
+      run: |
+        $script = @'
+          #pacman -S --noconfirm msys/winpty
+          #winpty --version
+          where openssl
+          openssl version
+          mv $MINGW_PATH/openssl.exe $MINGW_PATH/openssl_NG.exe
+          where openssl
+          #openssl version
+        '@
+        & bash -lc $script
+    - name: Build
+      run: |
+        $script = @'
+          pwd
+          cd $GITHUB_WORKSPACE
+          gcc -v
+          ./DIST gen
+          src/mingw-dist.sh
+        '@
+        & bash -lc $script
+    - name: Test
+      run: |
+        $script = @'
+          pwd
+          cd $GITHUB_WORKSPACE
+          make check
+        '@
+        & bash -lc $script
+    - name: Upload result
+      if: success() || failure()
+      uses: actions/upload-artifact@v1
+      with:
+        name: ${{ env.RESULT_NAME }}
+        path: ${{ env.RESULT_PATH }}
+    - name: Upload result2
+      if: (success() || failure()) && matrix.arch == 'x86_64'
+      uses: actions/upload-artifact@v1
+      with:
+        name: tls
+        path: ext/tls
+


### PR DESCRIPTION
- GitHub Actions に、自動ビルドのワークフローを設定してみました。

- GitHub Actions は、GitHub のデフォルトの機能で、
  ./github/workflows の下に YAML ファイルを置くと自動で実行されます。
  ( https://help.github.com/en/actions/getting-started-with-github-actions/about-github-actions )
  ( Settings - Actions メニューで OFF にもできます
    https://github.community/t5/GitHub-Actions/How-can-I-disable-a-github-action/td-p/39648 )

- 今回は、そこに build.yml というファイルを作成しました。

- ビルド対象は、linux, osx, windows(x86_64,i686) にしました。
  (linux と osx 用の記述については、Gauche の .travis.yml を参考にしました)

- push または pull_request のタイミングで起動します。

- 実行結果は、Gauche の GitHub のページの Actions というタブを開くと確認できます。
  (実行結果の例: https://github.com/Hamayama/Gauche/actions/runs/42170613 )


＜その他、参考情報等＞

1. YAML ファイルの記述を間違えると、すぐに job が完了したり、
   1行目にエラーがあるというようなメッセージが出たりする。
   (実際には、YAML ファイルのどこかに間違いがある。。。)

2. いろいろ試していたら、job が動きっぱなしになり Cancel もできなくなったことがあった。
   GitHub をログアウトして、しばらくしてログインし直したら、Cancel できた。

3. 現状、実行結果を消す機能が、どこにも存在しない。。。
    ( https://github.community/t5/GitHub-Actions/Delete-old-workflow-results/td-p/30589 )

4. 複数の run: の間で環境変数の変更を共有するには、独特の書き方が必要。
   ( https://github.community/t5/GitHub-Actions/Support-saving-environment-variables-between-steps/td-p/31373
   https://help.github.com/en/actions/reference/development-tools-for-github-actions#set-an-environment-variable-set-env )

5. Linux と OSX では、run: のシェルはデフォルトで bash になる。
   ( https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#using-a-specific-shell )
   
   Windows では、run: のシェルはデフォルトで PowerShell になる。
   これは、かなり記述が難しい。例えば、以下。
   (a) dir は Get-ChildItem の alias なので、オプションが異なる
   (b) curl も環境によっては Invoke-WebRequest の alias になる。しかし、GitHub Actions 内では alias にはならないもよう
   (c) 環境変数の参照は、`$VAR` ではなく `$env:VAR` と書く
   (d) パイプやリダイレクトがうまく動かない ( bash -c で回避したりしている。何かルールがありそうだが。。。)
   
   Windows で、shell: cmd を書くと、シェルが cmd.exe になる。しかし、これもいろいろと難しい。
   Windows で、shell: bash を書くと、シェルが Git for Windows の bash になる (MSYS2 の bash にはならないので要注意) 。

6. MSYS2/MinGW-w64 環境については、自分で記述してインストールしないといけない。
   C ドライブのルートにはインストールできなかったため、D ドライブにインストールするようにした。

7. Windows では、チェックアウト ( `- uses: actions/checkout@v2` ) の前に
   `- run: git config --global core.autocrlf false` を記述しないと、
   改行コードの自動変換によりエラーが発生した。
