### PR TITLE
Fix sre (w/nocase (... lower))

### DIFF
--- a/lib/gauche/regexp/sre.scm
+++ b/lib/gauche/regexp/sre.scm
@@ -42,6 +42,9 @@
 (define ascii (make-parameter #f))
 (define nocapture (make-parameter #f))
 (define casefold (make-parameter #f))
+(define char-set:cased (char-set-union char-set:lower-case
+                                       char-set:upper-case
+                                       char-set:title-case))
 
 (define-condition-type <regexp-invalid-sre> <error> #f
   (offending-item))
@@ -88,9 +91,18 @@
       [(any) 'any]
       [(nonl) (cset-sre '(~ #\newline #\return))]
       [(ascii) char-set:ascii]
-      [(lower lower-case) char-set:lower-case]
-      [(upper upper-case) char-set:upper-case]
-      [(title title-case) char-set:title-case]
+      [(lower lower-case)
+       (cond
+        [(casefold) char-set:cased]
+        [else char-set:lower-case])]
+      [(upper upper-case)
+       (cond
+        [(casefold) char-set:cased]
+        [else char-set:upper-case]) ]
+      [(title title-case)
+       (cond
+        [(casefold) char-set:cased]
+        [else char-set:title-case])]
       [(alpha alphabetic) char-set:letter]
       [(num numeric) char-set:digit]
       [(alnum alphanum alphanumeric) char-set:letter+digit]

--- a/lib/gauche/regexp/sre.scm
+++ b/lib/gauche/regexp/sre.scm
@@ -93,24 +93,33 @@
       [(ascii) char-set:ascii]
       [(lower lower-case)
        (cond
+        [(ascii) char-set:ascii-lower-case]
         [(casefold) char-set:cased]
         [else char-set:lower-case])]
       [(upper upper-case)
        (cond
+        [(ascii) char-set:ascii-upper-case]
         [(casefold) char-set:cased]
         [else char-set:upper-case]) ]
       [(title title-case)
        (cond
         [(casefold) char-set:cased]
         [else char-set:title-case])]
-      [(alpha alphabetic) char-set:letter]
-      [(num numeric) char-set:digit]
-      [(alnum alphanum alphanumeric) char-set:letter+digit]
-      [(punct punctuation) char-set:punctuation]
-      [(symbol) char-set:symbol]
-      [(graph graphic) char-set:graphic]
+      [(alpha alphabetic)
+       (if (ascii) char-set:ascii-lower-case char-set:letter)]
+      [(num numeric)
+       (if (ascii) char-set:ascii-digit char-set:digit)]
+      [(alnum alphanum alphanumeric)
+       (if (ascii) char-set:ascii-letter+digit char-set:letter+digit)]
+      [(punct punctuation)
+       (if (ascii) char-set:ascii-punctuation char-set:punctuation)]
+      [(symbol)
+       (if (ascii) char-set:ascii-symbol char-set:symbol)]
+      [(graph graphic)
+       (if (ascii) char-set:ascii-graphic char-set:graphic)]
       [(space white whitespace) char-set:whitespace]
-      [(print printing) char-set:printing]
+      [(print printing)
+       (if (ascii) char-set:ascii-printing char-set:printing)]
       [(cntrl control) (ucs-range->char-set 0 32)]
       [(xdigit hex-digit) char-set:hex-digit]
       [else #f]))

--- a/lib/gauche/regexp/sre.scm
+++ b/lib/gauche/regexp/sre.scm
@@ -182,21 +182,18 @@
 
     ;; FIXME: missing bog, eog, grapheme
     (define (sre-list sym rest)
-      (define (map-one sre)
-        (%sre->ast sre))
-
       (define (loop :optional (rest rest))
-        (map (cut map-one <>) rest))
+        (map %sre->ast rest))
 
       (define (seq-loop :optional (rest rest))
         `(seq ,@(map %sre->ast rest)))
 
       (define (cpat test)
-        `(cpat ,(test (map-one (car rest)))
-               (,(map-one (cadr rest)))
+        `(cpat ,(test (%sre->ast (car rest)))
+               (,(%sre->ast (cadr rest)))
                ,(cond
                  [(null? (cddr rest)) '()]
-                 [(null? (cdddr rest)) (list (map-one (caddr rest)))]
+                 [(null? (cdddr rest)) (list (%sre->ast (caddr rest)))]
                  [else (err "unsupported syntax" sre)])))
 
       (case sym
@@ -256,10 +253,10 @@
         [(if-backref) `(cpat ,(if (number? (car rest))
                                 (car rest)
                                 (err "if-backref can only take a number" sre))
-                             (,(map-one (cadr rest)))
+                             (,(%sre->ast (cadr rest)))
                              ,(cond
                                [(null? (cddr rest)) '()]
-                               [(null? (cdddr rest)) (list (map-one (caddr rest)))]
+                               [(null? (cdddr rest)) (list (%sre->ast (caddr rest)))]
                                [else (err "unsupported syntax" sre)]))]
         [(if-look-ahead) (cpat (^x `(assert ,x)))]
         [(if-neg-look-ahead) (cpat (^x `(nassert ,x)))]

--- a/lib/gauche/regexp/sre.scm
+++ b/lib/gauche/regexp/sre.scm
@@ -186,16 +186,16 @@
     (define (seq-loop rest)
       `(seq ,@(map %sre->ast rest)))
 
+    (define (cpat test rest)
+      `(cpat ,(test (%sre->ast (car rest)))
+             (,(%sre->ast (cadr rest)))
+             ,(cond
+               [(null? (cddr rest)) '()]
+               [(null? (cdddr rest)) (list (%sre->ast (caddr rest)))]
+               [else (err "unsupported syntax" sre)])))
+
     ;; FIXME: missing bog, eog, grapheme
     (define (sre-list sym rest)
-      (define (cpat test)
-        `(cpat ,(test (%sre->ast (car rest)))
-               (,(%sre->ast (cadr rest)))
-               ,(cond
-                 [(null? (cddr rest)) '()]
-                 [(null? (cdddr rest)) (list (%sre->ast (caddr rest)))]
-                 [else (err "unsupported syntax" sre)])))
-
       (case sym
         [(* zero-or-more) `(rep 0 #f ,@(loop rest))]
         [(+ one-or-more) `(rep 1 #f ,@(loop rest))]
@@ -258,10 +258,10 @@
                                [(null? (cddr rest)) '()]
                                [(null? (cdddr rest)) (list (%sre->ast (caddr rest)))]
                                [else (err "unsupported syntax" sre)]))]
-        [(if-look-ahead) (cpat (^x `(assert ,x)))]
-        [(if-neg-look-ahead) (cpat (^x `(nassert ,x)))]
-        [(if-look-behind) (cpat (^x `(assert (lookbehind ,x))))]
-        [(if-neg-look-behind) (cpat (^x `(nassert (lookbehind ,x))))]
+        [(if-look-ahead) (cpat (^x `(assert ,x)) rest)]
+        [(if-neg-look-ahead) (cpat (^x `(nassert ,x)) rest)]
+        [(if-look-behind) (cpat (^x `(assert (lookbehind ,x))) rest)]
+        [(if-neg-look-behind) (cpat (^x `(nassert (lookbehind ,x))) rest)]
         [else (err "invalid SRE" sym)]))
 
     (define (fold-case cset)

--- a/test/include/regexp-sre-utf8.scm
+++ b/test/include/regexp-sre-utf8.scm
@@ -14,11 +14,10 @@
 (test-sre '("σζ") '(* lower) "σζ")
 (test-sre '("Σ") '(* upper) "Σ")
 (test-sre '("\x01C5;") '(* title) "\x01C5;")
+(test-sre '("σζ\x01C5;") '(w/nocase (* lower)) "σζ\x01C5;")
 
 (test-sre '("кириллица") '(* alpha) "кириллица")
 (test-sre '("") '(w/ascii (* alpha)) "кириллица")
 (test-sre '("кириллица") '(w/nocase "КИРИЛЛИЦА") "кириллица")
 
 (test-sre '("") '(w/ascii (* numeric)) "１２３４５")
-
-


### PR DESCRIPTION
The main bug fix is in the second-to-last patch. Others are just code cleanup.

The main problem with SRE `(w/nocase (* lower))` is that the "lower case"  charset does not cover everything we need to match case-insensitively. In order to work correctly in this case, we basically need to turn `lower` to `char-set:letter`, not `char-set:lower-case`, then let the case folding sort out which is which.

Now Gauche passes everything [1] in the Chibi test suite [2].

[1] except grapheme ones of course
[2] I made a portable srfi-115 implementation, including full chibi tests https://github.com/scheme-requests-for-implementation/srfi-115/pull/3