### PR TITLE
FIx unicode regex with casefold

### DIFF
--- a/test/utf-8.scm
+++ b/test/utf-8.scm
@@ -884,5 +884,9 @@
        (cond ((rxmatch (string->regexp "о[А-Я]а") "она")
               => rxmatch-substring)
              (else #f)))
+(test* "regexp/unicode-ci" "σζ\x01C5;"
+       (cond ((rxmatch (string->regexp "[[:LOWER:]]*" :case-fold #t) "σζ\x01C5;")
+              => rxmatch-substring)
+             (else #f)))
 
 (test-end)


### PR DESCRIPTION
This is a follow up of #602 . The same fix is applied to regex string pattern. A new charset "LC" (Cased Letters, one of Unicode General Categories) is introduced and also used by SRE.

Scm_CharSetRead() API is changed. I don't see another way of doing it without API breakage.