### PR TITLE
Change install drive in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,10 +64,10 @@ jobs:
         include:
         - arch: x86_64
           bit: 64
-          progpath: C:\Program Files
+          devtool_path: D:\devtool
         - arch: i686
           bit: 32
-          progpath: C:\Program Files (x86)
+          devtool_path: D:\devtool
     env:
       MSYSTEM: MINGW${{ matrix.bit }}
       MSYS2_PATH_TYPE: inherit
@@ -75,7 +75,7 @@ jobs:
       MSYS2_TARBALL_URL: http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20190524.tar.xz
       GAUCHE_VERSION_URL: https://practical-scheme.net/gauche/releases/latest.txt
       GAUCHE_INSTALLER_URL: https://prdownloads.sourceforge.net/gauche
-      GAUCHE_PATH: ${{ matrix.progpath }}\Gauche\bin
+      GAUCHE_PATH: ${{ matrix.devtool_path }}\Gauche\bin
     steps:
     - run: git config --global core.autocrlf false
     - uses: actions/checkout@v2
@@ -83,10 +83,8 @@ jobs:
       run: |
         #del alias:curl
         curl -f -o msys2.tar.xz $env:MSYS2_TARBALL_URL
-        #tar xf msys2.tar.xz
-        bash -c "7z x msys2.tar.xz -so | 7z x -aoa -si -ttar"
-        dir
-        mv msys64 D:\
+        #tar xf msys2.tar.xz -C /d/
+        bash -c "7z x msys2.tar.xz -so | 7z x -aoa -si -ttar -oD:"
         dir D:\
     - name: Add MSYS2 path
       run: |
@@ -117,7 +115,7 @@ jobs:
         echo $env:GAUCHE_INSTALLER
         curl -f -L -o $env:GAUCHE_INSTALLER $env:GAUCHE_INSTALLER_URL/$env:GAUCHE_INSTALLER
         dir
-        msiexec /i $env:GAUCHE_INSTALLER /quiet /qn /norestart
+        msiexec /a $env:GAUCHE_INSTALLER /quiet /qn /norestart TARGETDIR=${{ matrix.devtool_path }}
     - name: Add Gauche path
       run: |
         $env:PATH = "$env:GAUCHE_PATH;$env:PATH"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,20 +92,18 @@ jobs:
         echo "::set-env name=PATH::$env:PATH"
     - name: Run MSYS2 once
       run: |
-        $script = @'
+        bash -lc @'
           pwd
           uname -m
           uname -a
           echo $PATH
         '@
-        bash -lc $script
     - name: Install MinGW-w64
       run: |
-        $script = @'
+        bash -lc @'
           pacman -S --noconfirm base-devel
           pacman -S --noconfirm mingw${{ matrix.bit }}/mingw-w64-${{ matrix.arch }}-toolchain
         '@
-        bash -lc $script
     - name: Install Gauche
       run: |
         #del alias:curl
@@ -125,7 +123,7 @@ jobs:
         gosh -V
     - name: Install tools
       run: |
-        $script = @'
+        bash -lc @'
           #pacman -S --noconfirm msys/winpty
           #winpty --version
           where openssl
@@ -134,25 +132,22 @@ jobs:
           where openssl
           /usr/bin/openssl version
         '@
-        bash -lc $script
     - name: Build
       run: |
-        $script = @'
+        bash -lc @'
           pwd
           cd $GITHUB_WORKSPACE
           gcc -v
           ./DIST gen
           src/mingw-dist.sh
         '@
-        bash -lc $script
     - name: Test
       run: |
-        $script = @'
+        bash -lc @'
           pwd
           cd $GITHUB_WORKSPACE
           make check
         '@
-        bash -lc $script
     #- name: Upload result
     #  if: success() || failure()
     #  uses: actions/upload-artifact@v1


### PR DESCRIPTION
どうも、GitHub Actions で、Windows の実行時に C ドライブに書き込むと、
ファイルが見つからないことがあるようです。
(例. https://github.com/shirok/Gauche/runs/462013061?check_suite_focus=true )

このため、Gauche のインストール先を、D ドライブに変更してみました。

これでも発生するようなら、また考えます。。。

＜テスト結果＞
https://github.com/Hamayama/Gauche/actions/runs/43729956

関連プルリクエスト #601 #603
