### PR TITLE
Final SRFI 176

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -225,6 +225,10 @@ void version(void)
     printf("(encodings %s)\n", SCM_CHAR_ENCODING_NAME);
     printf("(website \"https://practical-scheme.net/gauche\")\n");
     printf("(build.platform \"%s\")\n", Scm_HostArchitecture());
+    printf("(scheme.path");
+    for (ScmObj p = Scm_GetLoadPath(); SCM_PAIRP(p); p = SCM_CDR(p))
+        printf(" \"%s\"", Scm_GetStringConst(SCM_STRING(SCM_CAR(p))));
+    printf(")\n");
     exit(0);
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -222,6 +222,7 @@ void version(void)
     printf("(command \"gosh\")\n");
     printf("(scheme.id gauche)\n");
     printf("(languages scheme r5rs r7rs)\n");
+    printf("(encodings %s)\n", SCM_CHAR_ENCODING_NAME);
     printf("(website \"https://practical-scheme.net/gauche\")\n");
     printf("(build.platform \"%s\")\n", Scm_HostArchitecture());
     exit(0);

--- a/src/main.c
+++ b/src/main.c
@@ -220,10 +220,10 @@ void version(void)
            Scm_HostArchitecture());
     printf("(version \"%s\")\n", GAUCHE_VERSION);
     printf("(command \"gosh\")\n");
-    printf("(scheme-id gauche)\n");
-    printf("(language scheme r5rs r7rs)\n");
+    printf("(scheme.id gauche)\n");
+    printf("(languages scheme r5rs r7rs)\n");
     printf("(website \"https://practical-scheme.net/gauche\")\n");
-    printf("(platform \"%s\")\n", Scm_HostArchitecture());
+    printf("(build.platform \"%s\")\n", Scm_HostArchitecture());
     exit(0);
 }
 


### PR DESCRIPTION
- Renames the properties that were renamed in the finalized SRFI.
- Adds the `encodings` property (currently lists only `SCM_CHAR_ENCODING_NAME`, could also list other available encodings).
- Adds the `scheme.path` property. Doesn't currently sanity-check that load path entries are valid LOSE strings.