### PR TITLE
Add testlog upload in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,7 @@ jobs:
         gcc -v
         ./DIST self-host-test
     - name: Copy testlog
+      if: success() || failure()
       run: |
         mkdir -p $TESTLOG_PATH/$TESTLOG_NAME
         cp ../Gauche-tmp-self-host-test/stage2/src/test.log $TESTLOG_PATH/$TESTLOG_NAME
@@ -69,6 +70,7 @@ jobs:
         gcc -v
         ./DIST self-host-test
     - name: Copy testlog
+      if: success() || failure()
       run: |
         mkdir -p $TESTLOG_PATH/$TESTLOG_NAME
         cp ../Gauche-tmp-self-host-test/stage2/src/test.log $TESTLOG_PATH/$TESTLOG_NAME
@@ -172,6 +174,7 @@ jobs:
           make check
         '@
     - name: Copy testlog
+      if: success() || failure()
       run: |
         mkdir $env:TESTLOG_PATH/$env:TESTLOG_NAME
         cp src/test.log $env:TESTLOG_PATH/$env:TESTLOG_NAME

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ jobs:
   build-linux:
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    env:
+      TESTLOG_NAME: testlog-linux
+      TESTLOG_PATH: testlog-linux
     steps:
     - uses: actions/checkout@v2
     - name: Install Gauche
@@ -27,10 +30,23 @@ jobs:
       run: |
         gcc -v
         ./DIST self-host-test
+    - name: Copy testlog
+      run: |
+        mkdir -p $TESTLOG_PATH/$TESTLOG_NAME
+        cp ../Gauche-tmp-self-host-test/stage2/src/test.log $TESTLOG_PATH/$TESTLOG_NAME
+    - name: Upload testlog
+      if: success() || failure()
+      uses: actions/upload-artifact@v1
+      with:
+        name: ${{ env.TESTLOG_NAME }}
+        path: ${{ env.TESTLOG_PATH }}
 
   build-osx:
     runs-on: macos-latest
     timeout-minutes: 60
+    env:
+      TESTLOG_NAME: testlog-osx
+      TESTLOG_PATH: testlog-osx
     steps:
     - uses: actions/checkout@v2
     - name: Install Gauche
@@ -52,6 +68,16 @@ jobs:
       run: |
         gcc -v
         ./DIST self-host-test
+    - name: Copy testlog
+      run: |
+        mkdir -p $TESTLOG_PATH/$TESTLOG_NAME
+        cp ../Gauche-tmp-self-host-test/stage2/src/test.log $TESTLOG_PATH/$TESTLOG_NAME
+    - name: Upload testlog
+      if: success() || failure()
+      uses: actions/upload-artifact@v1
+      with:
+        name: ${{ env.TESTLOG_NAME }}
+        path: ${{ env.TESTLOG_PATH }}
 
   build-windows:
     runs-on: windows-latest
@@ -75,6 +101,8 @@ jobs:
       GAUCHE_VERSION_URL: https://practical-scheme.net/gauche/releases/latest.txt
       GAUCHE_INSTALLER_URL: https://prdownloads.sourceforge.net/gauche
       GAUCHE_PATH: ${{ matrix.devtool_path }}\Gauche\bin
+      TESTLOG_NAME: testlog-windows-${{ matrix.arch }}
+      TESTLOG_PATH: testlog-windows
     steps:
     - run: git config --global core.autocrlf false
     - uses: actions/checkout@v2
@@ -143,16 +171,20 @@ jobs:
           cd $GITHUB_WORKSPACE
           make check
         '@
+    - name: Copy testlog
+      run: |
+        mkdir $env:TESTLOG_PATH/$env:TESTLOG_NAME
+        cp src/test.log $env:TESTLOG_PATH/$env:TESTLOG_NAME
+    - name: Upload testlog
+      if: success() || failure()
+      uses: actions/upload-artifact@v1
+      with:
+        name: ${{ env.TESTLOG_NAME }}
+        path: ${{ env.TESTLOG_PATH }}
     #- name: Upload result
     #  if: success() || failure()
     #  uses: actions/upload-artifact@v1
     #  with:
     #    name: Gauche-${{ matrix.arch }}
     #    path: ../Gauche-mingw-dist/Gauche-${{ matrix.arch }}
-    #- name: Upload result2 (for rfc.tls debug)
-    #  if: (success() || failure()) && matrix.arch == 'x86_64'
-    #  uses: actions/upload-artifact@v1
-    #  with:
-    #    name: tls
-    #    path: ext/tls
 


### PR DESCRIPTION
調査用に src/test.log を保存するようにしてみました。
これで、停止箇所の情報が得られるかと。。。

＜テスト結果＞
https://github.com/Hamayama/Gauche/actions/runs/44897014

＜関連情報＞
https://practical-scheme.net/wiliki/wiliki.cgi?Gauche%3ABugs#H-1qgtcx1
https://gist.github.com/Hamayama/3cc0e9c0c5283e7fc422360c6e5bd372

関連プルリクエスト #601 #603 #605 #606
