### PR TITLE
line-edit: macros, kill-line and insert-parenthese

### DIFF
--- a/lib/text/line-edit.scm
+++ b/lib/text/line-edit.scm
@@ -658,6 +658,9 @@
   (let1 ch (getch (~ ctx'console)) ; TODO: octal digits input
     (gap-buffer-edit! buf `(i #f ,(x->string ch)))))
 
+(define (insert-parentheses ctx buf key)
+  (macro! ctx #\( #\) (ctrl #\b)))
+
 (define (commit-input ctx buf key)
   'commit)
 
@@ -930,7 +933,7 @@
               `(,(alt #\%) . ,undefined-command)
               `(,(alt #\&) . ,undefined-command)
               `(,(alt #\') . ,undefined-command)
-              `(,(alt #\() . ,undefined-command)
+              `(,(alt #\() . ,insert-parentheses)
               `(,(alt #\)) . ,undefined-command)
               `(,(alt #\*) . ,undefined-command)
               `(,(alt #\+) . ,undefined-command)

--- a/lib/text/line-edit.scm
+++ b/lib/text/line-edit.scm
@@ -780,14 +780,10 @@
     [_ 'unchanged]))
 
 (define (kill-word ctx buf key)
-  (set-mark! ctx buf)
-  (forward-word ctx buf key)
-  (kill-region ctx buf key))
+  (macro! ctx (ctrl #\@) (alt #\f) (ctrl #\w)))
 
 (define (backward-kill-word ctx buf key)
-  (set-mark! ctx buf)
-  (backward-word ctx buf key)
-  (kill-region ctx buf key))
+  (macro! ctx (ctrl #\@) (alt #\b) (ctrl #\w)))
 
 (define (refresh-display ctx buf key)
   (reset-terminal (~ ctx'console))

--- a/lib/text/line-edit.scm
+++ b/lib/text/line-edit.scm
@@ -182,11 +182,11 @@
        ;;   undone - the command undid the change.  we record the fact,
        ;;            for the consecutive undo behaves differently than
        ;;            other commands.
-       ;;   <edit-command> - the commad changed the buffer contents,
-       ;;        and the return value is an edit command to undo the
-       ;;        change.
+       ;;   <edit-command> - the command changed the buffer contents,
+       ;;            and the return value is an edit command to undo the
+       ;;            change.
        ;;   (yanked <edit-command>) - this is only returned by yank and yank-pop
-       ;;        command.
+       ;;            command.
        ;;
        ;; If the key is a character and it is not registered in the table,
        ;; we treat as if it is associated to the self-insert-command.

--- a/lib/text/line-edit.scm
+++ b/lib/text/line-edit.scm
@@ -751,13 +751,13 @@
   'moved)
 
 (define (kill-line ctx buf key)
-  (if (not (gap-buffer-gap-at? buf 'end))
-    (let* ([len (- (gap-buffer-content-length buf) (gap-buffer-pos buf))]
-           [e (gap-buffer-edit! buf `(d #f ,len))])
-      ;; e contains (i <pos> <killed-string>)
-      (save-kill-ring ctx (caddr e))
-      e)
-    'unchanged))
+  (cond
+   [(gap-buffer-gap-at? buf 'end)
+    'unchanged]
+   [(eqv? (gap-buffer-ref buf (gap-buffer-pos buf)) #\newline)
+    (macro! ctx (ctrl #\d))]
+   [else
+    (macro! ctx (ctrl #\@) (ctrl #\e) (ctrl #\w))]))
 
 (define (kill-region ctx buf key)
   (match (selected-range ctx buf)


### PR DESCRIPTION
After my rambling in the other pull request, I realized the idea was not that bad to implement. So here's a first try to add `macro!` procedure. Both C-k and M-( are updated/added as macros. They look pretty good.