### PR TITLE
Improve cond-expand error message without else clause

### DIFF
--- a/src/libmacro.scm
+++ b/src/libmacro.scm
@@ -110,7 +110,7 @@
 
      (define (rec cls)
        (cond
-        [(null? cls) (error "Unfulfilled cond-expand:" cls)]
+        [(null? cls) (error "Unfulfilled cond-expand (likely missing feature to run this code)")]
         [(not (pair? (car cls)))
          (error "Bad clause in cond-expand:" (car cls))]
         [(c (r (caar cls)) else.)


### PR DESCRIPTION
The current error message is technically not wrong, but not as
helpful. Add "missing feature" to suggest that some cond-expand just
needs updating a bit. #593