### PR TITLE
Fix typos in some code comments and error messages

### DIFF
--- a/lib/data/heap.scm
+++ b/lib/data/heap.scm
@@ -150,7 +150,7 @@
                      [(and (integer? num-entries) (>= num-entries 0))
                       (min num-entries xlen)]
                      [else
-                      (error "invalid num-entris value for build-binary-heap:"
+                      (error "invalid num-entries value for build-binary-heap:"
                              num-entries)])])
     (receive (<: >:)
         (ecase (comparator-flavor comparator)

--- a/lib/gauche/cgen/stub.scm
+++ b/lib/gauche/cgen/stub.scm
@@ -1568,7 +1568,7 @@
 ;; qualifiers := :base | :built-in | :private
 
 ;; 'qualifiers' modifies the generated code slightly.  :base and :built-in
-;; is exclusive.  :base generates a base class definition (inheritable
+;; are exclusive.  :base generates a base class definition (inheritable
 ;; from Scheme code), while :built-in generates a built-in class definition
 ;; (not inheritable from Scheme code).  If neither one appears, built-in
 ;; class is generated.  :private is an optional qualifier, and when it is

--- a/lib/gauche/sortutil.scm
+++ b/lib/gauche/sortutil.scm
@@ -69,7 +69,7 @@
                 (and (not (less? knext last))
                      (loop knext (read-char p))))))))]
    [(is-a? seq <sequence>) (%generic-sorted? seq less? key)]
-   [else (error "seqeuence required, but got:" seq)]))
+   [else (error "sequence required, but got:" seq)]))
 
 ;;; (merge a b less?)
 ;;; takes two lists a and b such that (sorted? a less?) and (sorted? b less?)

--- a/lib/text/console/generic.scm
+++ b/lib/text/console/generic.scm
@@ -93,7 +93,7 @@
         (error "Invalid color name:" color)))
   (define (check-option opt)
     (or (memq opt '(bright underscore reverse))
-        (error "Invalid atttribute option name:" opt)))
+        (error "Invalid attribute option name:" opt)))
   (match spec
     [(fgcolor bgcolor . opts)
      (check-color fgcolor)

--- a/src/compile-0.scm
+++ b/src/compile-0.scm
@@ -182,7 +182,7 @@
 ;; <constructor> : <symbol> | #f
 ;; <slot-spec>   : <slot-name> | (<slot-name> [<init-value>])
 ;;
-;; For each <slot-spec>, the following accessor/modifier are automatially
+;; For each <slot-spec>, the following accessor/modifier are automatically
 ;; generated.
 ;;
 ;;   NAME-SLOT      - accessor (macro)

--- a/src/compile.scm
+++ b/src/compile.scm
@@ -72,7 +72,7 @@
 ;;;     - Global constant variables are substituted to its value.
 ;;;     - Variable bindings are resolved.  Local variables are marked
 ;;;       according to its usage (# of reference count and set count).
-;;;     - Constant expressons are folded.
+;;;     - Constant expressions are folded.
 ;;;
 ;;;   Pass 2 (Variable and closure optimization):
 ;;;     - Traverses IForm and modify the tree to optimize it.
@@ -201,7 +201,7 @@
 ;;   Slots:
 ;;     name  - name of the variable (symbol)
 ;;     initval   - initialized value (Maybe IForm)
-;;     ref-count - in how many places this variable is referefnced?
+;;     ref-count - in how many places this variable is referenced?
 ;;     set-count - in how many places this variable is set!
 ;;
 
@@ -280,7 +280,7 @@
 ;;                local binding).   This slot may be #f.
 ;;
 ;;     current-proc - Holds the information of the current
-;;                compilig procedure.  It accumulates information needed
+;;                compiling procedure.  It accumulates information needed
 ;;                in later stages for the optimization.  This slot may
 ;;                be #f.
 ;;
@@ -292,7 +292,7 @@
 (define (make-cenv module :optional (frames '()) (exp-name #f))
   (%make-cenv module frames exp-name))
 
-;; Some cenv-related proceduers are in C for better performance.
+;; Some cenv-related procedures are in C for better performance.
 (inline-stub
  ;; env-lookup-int :: Name, LookupAs, Module, [Frame] -> Var
  ;;         where Var = Lvar | Identifier | Macro
@@ -588,7 +588,7 @@
    ))
 
 ;; $seq <body>
-;;    Sequensing.  <body> is a list of IForms.
+;;    Sequencing.  <body> is a list of IForms.
 ;;    The compile tries to avoid creating $seq node if <body> has only
 ;;    one expression, but optimization paths may introduce such a $seq node.
 ;;    There can also be an empty $seq node, ($seq '()).

--- a/src/gauche/exception.h
+++ b/src/gauche/exception.h
@@ -101,7 +101,7 @@ SCM_EXTERN int Scm_ConditionHasType(ScmObj c, ScmObj k);
    <message-prefix>, with no irritants.
 
    In Scheme level we won't show this structure.  If Scheme code accesses
-   the message slot, we return <preformatetd-message>.
+   the message slot, we return <preformatted-message>.
 
    C code that access 'message' slot directly needs to be modified.
  */


### PR DESCRIPTION
(found this commit while cleaning up my repo)