### PR TITLE
Fix %string-index-dump return uninitialized object

### DIFF
--- a/src/libstr.scm
+++ b/src/libstr.scm
@@ -240,7 +240,7 @@
   (return (Scm_StringBodyFastIndexableP (SCM_STRING_BODY s))))
 
 (select-module gauche.internal)
-(define-cproc %string-index-dump (s::<string> :optional (p::<port> (current-output-port)))
+(define-cproc %string-index-dump (s::<string> :optional (p::<port> (current-output-port))) ::<void>
   (Scm_StringBodyIndexDump (SCM_STRING_BODY s) p))
 
 ;;


### PR DESCRIPTION
clang detected [1] correctly that %string-index-dump can return an
uninitialized ScmObj which is not a good news for anybody who happens to
handle it. Mark the function ::\<void> to return SCM_UNDEFINED.

[1]

```
libstr.scm:247:25: warning: variable 'SCM_RESULT' is uninitialized when used here [-Wuninitialized]
SCM_RETURN(SCM_OBJ_SAFE(SCM_RESULT));
                        ^~~~~~~~~~
./gauche.h:536:33: note: expanded from macro 'SCM_OBJ_SAFE'
                                ^~~
./gauche.h:1889:44: note: expanded from macro 'SCM_RETURN'
                                           ^~~~~
libstr.scm:274:18: note: initialize the variable 'SCM_RESULT' to silence this warning
ScmObj SCM_RESULT;
                 ^
                  = NULL
```