### PR TITLE
regexp: support SRE grapheme syntax bog and eog

### DIFF
--- a/doc/HOWTO-callback-scheme.adoc
+++ b/doc/HOWTO-callback-scheme.adoc
@@ -10,7 +10,7 @@ a module `my-module`):
     ...
     static ScmObj x_proc = SCM_UNDEFINED;
     SCM_BIND_PROC(x_proc, "my-procedure", 
-                  Scm_FindModule(SCM_INTERN("my-module"), 0));
+                  Scm_FindModule(SCM_SYMBOL(SCM_INTERN("my-module")), 0));
     ...
 
     ScmObj result = Scm_ApplyRec(x_proc, args);

--- a/lib/gauche/regexp.scm
+++ b/lib/gauche/regexp.scm
@@ -227,6 +227,8 @@
           [(eq? n 'bow)  (disp "\\b(?=\\w)")] ; unsupported pcre syntax
           [(eq? n 'eow)  (disp "\\b(?<=\\w)")] ; unsupported pcre syntax
           [(eq? n 'nwb)  (disp "\\B")]
+          [(eq? n 'bog)  (disp "<bog>")] ; unsupported syntax
+          [(eq? n 'eog)  (disp "<eog>")] ; unsupported syntax
           [(not (pair? n)) (err "invalid AST node" n)]
           [else (case (car n)
                   [(comp) (rlet1 s (write-to-string (cdr n))

--- a/src/builtin-syms.scm
+++ b/src/builtin-syms.scm
@@ -167,6 +167,8 @@
     (bow                       SCM_SYM_BOW)
     (eow                       SCM_SYM_EOW)
     (nwb                       SCM_SYM_NWB)
+    (bog                       SCM_SYM_BOG)
+    (eog                       SCM_SYM_EOG)
     (comp                      SCM_SYM_COMP)
     (*                         SCM_SYM_STAR)
     (*?                        SCM_SYM_STARQ)


### PR DESCRIPTION
As discussed in #501 this is a hybrid approach where most of the code is
still in Scheme and it's called up from C regex engine.

When Scm_RegExec() detects a beginning or end of grapheme node [1], it
checks if a grapheme predicate has been made and saved in match_ctx. If
not it calls make-grapheme-predicate to create one.

make-grapheme-predicate is kinda like make-grapheme-cluster-reader. It
gets new grapheme boundary positions from the generator and checks if
the given position is at the boundary or not. All boundary positions are
saved in a closure to avoid going running the generator again and again
on each query.

The position is passed in as a cursor instead of an index because
regexp.c operates on C pointers. Converting C pointers to cursors are
much cheaper than indexes on multibyte strings.

This approach increases match_ctx size (i.e. stack usage) which means we
may hit stack limit sooner. But that's probably not a practical problem.
The predicate also has to be recreated when back tracking. But that's
probably better for safety.

[1] The SRFI does not describe these well. But according to chibi, the
only difference between bog and eog is only bog can match the beginning
of a string, and only eog can match the end. All other grapheme
boundaries in between match both.