### PR TITLE
The last missing piece of SRFI 115

### DIFF
--- a/doc/corelib.texi
+++ b/doc/corelib.texi
@@ -11431,13 +11431,10 @@ not by the engine).
 @defun regexp-parse-sre sre
 @c EN
 Parses @var{sre} as a Scheme Regular Expression as described in
-SRFI-115 and returns its AST. Only a subset of SRE is supported at the
-moment. The following syntax is not supported:
-@code{bog}, @code{eog} and @code{grapheme}.
+SRFI-115 and returns its AST.
 @c JP
 @var{sre}をsrfi-115で定義されるScheme正規表現としてパーズし、
-結果をASTで返します。今のところ、SREのサブセットがサポートされています。
-サポートされていないのは@code{bog}、@code{eog}、@code{grapheme}です。
+結果をASTで返します。
 @c COMMON
 @pxref{R7RS regular expressions}.
 @end defun
@@ -11559,6 +11556,7 @@ to convert it to this AST back and forth.   Contributions are welcome.
        | bos | eos    ; beginning/end of string assertion
        | bol | eol    ; beginning/end of line assertion
        | bow | eow | wb | nwb ; word-boundary/negative word boundary assertion
+       | bog | eog    ; beginning/end of grapheme assertion
 
 <clause> : (seq <ast> ...)       ; sequence
        | (seq-uncase <ast> ...)  ; sequence (case insensitive match)

--- a/doc/modr7rs.texi
+++ b/doc/modr7rs.texi
@@ -7063,9 +7063,6 @@ Originally defined as srfi-115.
 
 @end deftp
 
-Note that support for this module is not complete. Grapheme syntax is
-still missing.
-
 @subheading Scheme regular expression syntax
 
 @subsubheading Syntax summary

--- a/lib/gauche/regexp/sre.scm
+++ b/lib/gauche/regexp/sre.scm
@@ -250,6 +250,8 @@
     (define (sre-sym sre)
       (case sre
         [(bos eos bol eol bow eow nwb bog eog) sre]
+        [(grapheme) (%sre->ast
+                     '(: bog (non-greedy-repeated 1 #f any) eog))]
         [(word) (%sre->ast '(word+ any))]
         [else (err "not supported" sre)]))
 
@@ -267,7 +269,6 @@
                [(null? (cdddr rest)) (list (%sre->ast (caddr rest)))]
                [else (err "unsupported syntax" sre)])))
 
-    ;; FIXME: missing grapheme
     (define (sre-list sym rest)
       (case sym
         [(* zero-or-more) `(rep 0 #f ,@(loop rest))]

--- a/lib/gauche/regexp/sre.scm
+++ b/lib/gauche/regexp/sre.scm
@@ -55,6 +55,10 @@
 ;;
 ;; Corner cases, positions zero and length, should be handled by the
 ;; caller.
+;;
+;; Note, if we assume "cur" only moves forward, we could keep at most
+;; two cursors in saved-curs. That means backtracking MUST recreate a
+;; new predicate because it breaks the "moving forward" assumption.
 (define (make-grapheme-predicate str)
   (let ([get-more (call-with-input-string str
                     (lambda (port)

--- a/test/include/regexp-sre-utf8.scm
+++ b/test/include/regexp-sre-utf8.scm
@@ -21,3 +21,6 @@
 (test-sre '("кириллица") '(w/nocase "КИРИЛЛИЦА") "кириллица")
 
 (test-sre '("") '(w/ascii (* numeric)) "１２３４５")
+
+(test-sre '("한") '(: bog grapheme eog) "한")
+(test-sre #f '(: "ᄒ" bog grapheme eog "ᆫ") "한")

--- a/test/srfi.scm
+++ b/test/srfi.scm
@@ -2088,6 +2088,27 @@
 (test* "regexp-extract"
        '("123" "456" "789")
        (regexp-extract '(* numeric) "abc123def456ghi789"))
+(cond-expand
+ (full-unicode
+  (test* "regexp-extract"
+         '("a" "b" "c") (regexp-extract 'grapheme "abc"))
+  (test* "regexp-extract"
+         '("a" " " "b" " " "c") (regexp-extract 'grapheme "a b c"))
+  (test* "regexp-extract"
+         '("a" "\n" "b" "\r\n" "c") (regexp-extract 'grapheme "a\nb\r\nc"))
+  (test* "regexp-extract"
+         '("a\x0300;" "b\x0301;\x0302;" "c\x0303;\x0304;\x0305;")
+         (regexp-extract 'grapheme "a\x0300;b\x0301;\x0302;c\x0303;\x0304;\x0305;"))
+  (test* "regexp-extract"
+         '("한" "글") (regexp-extract 'grapheme "한글"))
+  (test* "regexp-extract"
+         '("한" "글")
+         (regexp-extract
+          'grapheme
+          ((with-module gauche.unicode utf8->string)
+           '#u8(#xe1 #x84 #x92 #xe1 #x85 #xa1 #xe1 #x86 #xab
+                     #xe1 #x84 #x80 #xe1 #x85 #xb3 #xe1 #x86 #xaf)))))
+ (else))
 
 (test* "regexp-split"
        '("abc" "def" "ghi" "")


### PR DESCRIPTION
This adds 'grapheme syntax, the last piece before we can declare full SRE coverage. Documents and tests are updated to cover changes in this commit as well as #618 