### PR TITLE
Improve MSYS2 download in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,8 @@ jobs:
       MSYSTEM: MINGW${{ matrix.bit }}
       MSYS2_PATH_TYPE: inherit
       MSYS2_PATH_LIST: D:\msys64\mingw${{ matrix.bit }}\bin;D:\msys64\usr\local\bin;D:\msys64\usr\bin;D:\msys64\bin
-      MSYS2_TARBALL_URL: http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20190524.tar.xz
+      MSYS2_TARBALL_URL1: http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20190524.tar.xz
+      MSYS2_TARBALL_URL2: https://sourceforge.net/projects/msys2/files/Base/x86_64/msys2-base-x86_64-20190524.tar.xz
       GAUCHE_VERSION_URL: https://practical-scheme.net/gauche/releases/latest.txt
       GAUCHE_INSTALLER_URL: https://prdownloads.sourceforge.net/gauche
       GAUCHE_PATH: ${{ matrix.devtool_path }}\Gauche\bin
@@ -110,10 +111,16 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install MSYS2
       run: |
-        curl -f -o msys2.tar.xz $env:MSYS2_TARBALL_URL
-        #tar xf msys2.tar.xz -C /d/
-        bash -c "7z x msys2.tar.xz -so | 7z x -aoa -si -ttar -oD:"
-        dir D:\
+        bash -lc @'
+          pwd
+          curl -f    -o msys2.tar.xz $MSYS2_TARBALL_URL1 ||
+          curl -f -L -o msys2.tar.xz $MSYS2_TARBALL_URL2
+          err1=$?
+          #tar xf msys2.tar.xz -C /d/
+          7z x msys2.tar.xz -so | 7z x -aoa -si -ttar -oD:
+          ls -l /d/
+          exit $err1
+        '@
     - name: Add MSYS2 path
       run: |
         echo "::set-env name=PATH::$env:MSYS2_PATH_LIST;$env:PATH"


### PR DESCRIPTION
今日、MSYS2 のダウンロードのサイトがダウンしていたため、
公式のミラーサイトを 1 個だけ追加してみました。
(pacman の方は、自動でミラーサイトを使うようでした)
