### PR TITLE
compile-1: reinsert "hygiene alert" anchor

### DIFF
--- a/src/compile-1.scm
+++ b/src/compile-1.scm
@@ -521,6 +521,7 @@
     [(_ name expr)
      (unless (identifier? name) (error "syntax-error:" oform))
      (let1 cenv (cenv-add-name cenv (variable-name name))
+       ;; Hygiene alert
        ;; If NAME is an identifier, it is inserted by macro expander; we
        ;; can't simply place it in $define, since it would insert a toplevel
        ;; definition into the toplevel of macro-definition environment---


### PR DESCRIPTION
pass1/define-macro and define-pass1-syntax still refer to this "hygiene
alert" which has been removed since 2be701e75 (Rename macro-injected
toplevel binding for hygiene, 2014-11-05). Add it back for reference.

Or.. if there's no alert needed anymore, we could simply remove the other 'See "Hygiene alert"...' comments.