### PR TITLE
Improve MSYS2 download in build workflow v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,15 @@
 name: Build
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  #schedule:
+  #  - cron: '0 */2 * * *'
 
 jobs:
   build-linux:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     env:
       TESTLOG_NAME: testlog-linux
       TESTLOG_PATH: testlog-linux
@@ -44,7 +48,7 @@ jobs:
 
   build-osx:
     runs-on: macos-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     env:
       TESTLOG_NAME: testlog-osx
       TESTLOG_PATH: testlog-osx
@@ -83,7 +87,7 @@ jobs:
 
   build-windows:
     runs-on: windows-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
@@ -99,8 +103,9 @@ jobs:
       MSYSTEM: MINGW${{ matrix.bit }}
       MSYS2_PATH_TYPE: inherit
       MSYS2_PATH_LIST: D:\msys64\mingw${{ matrix.bit }}\bin;D:\msys64\usr\local\bin;D:\msys64\usr\bin;D:\msys64\bin
-      MSYS2_TARBALL_URL1: http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20190524.tar.xz
-      MSYS2_TARBALL_URL2: https://sourceforge.net/projects/msys2/files/Base/x86_64/msys2-base-x86_64-20190524.tar.xz
+      MSYS2_TARBALL_URL1: https://github.com/msys2/msys2-installer/releases/download/nightly-x86_64/msys2-base-x86_64-latest.tar.xz
+      MSYS2_TARBALL_URL2: http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20190524.tar.xz
+      MSYS2_TARBALL_URL3: https://sourceforge.net/projects/msys2/files/Base/x86_64/msys2-base-x86_64-20190524.tar.xz
       GAUCHE_VERSION_URL: https://practical-scheme.net/gauche/releases/latest.txt
       GAUCHE_INSTALLER_URL: https://prdownloads.sourceforge.net/gauche
       GAUCHE_PATH: ${{ matrix.devtool_path }}\Gauche\bin
@@ -113,8 +118,9 @@ jobs:
       run: |
         bash -lc @'
           pwd
-          curl -f    -o msys2.tar.xz $MSYS2_TARBALL_URL1 ||
-          curl -f -L -o msys2.tar.xz $MSYS2_TARBALL_URL2
+          curl -f -L -o msys2.tar.xz $MSYS2_TARBALL_URL1 ||
+          curl -f    -o msys2.tar.xz $MSYS2_TARBALL_URL2 ||
+          curl -f -L -o msys2.tar.xz $MSYS2_TARBALL_URL3
           err1=$?
           #tar xf msys2.tar.xz -C /d/
           7z x msys2.tar.xz -so | 7z x -aoa -si -ttar -oD:
@@ -130,10 +136,17 @@ jobs:
           pwd
           echo $PATH
         '@
+    - name: Update MSYS2
+      run: |
+        bash -lc @'
+          pacman --version
+          pacman -Syyuu --noconfirm
+        '@
     - name: Install MinGW-w64
       run: |
         bash -lc @'
-          pacman -S --noconfirm base-devel
+          pacman --version
+          pacman -S --noconfirm base-devel &&
           pacman -S --noconfirm mingw${{ matrix.bit }}/mingw-w64-${{ matrix.arch }}-toolchain
         '@
     - name: Install Gauche

--- a/test/include/srfi-144-tests.scm
+++ b/test/include/srfi-144-tests.scm
@@ -690,8 +690,14 @@
      (test-assert (flnan? (fl+* zero neginf nan)))
      (test-assert (flnan? (fl+* posinf zero nan)))
      (test-assert (flnan? (fl+* neginf zero nan)))
-     (test (fl+* fl-greatest fl-greatest neginf) neginf)
-     (test (fl+* fl-greatest (fl- fl-greatest) posinf) posinf)
+
+     ;; On MinGW-w64 (gcc 9.2.0), result is +nan.0 instead of neginf/posinf.
+     (cond-expand
+      [gauche.os.windows]
+      [else
+       (test (fl+* fl-greatest fl-greatest neginf) neginf)
+       (test (fl+* fl-greatest (fl- fl-greatest) posinf) posinf)])
+
      (test-assert (flnan? (fl+* nan one one)))
      (test-assert (flnan? (fl+* one nan one)))
      (test-assert (flnan? (fl+* one one nan)))


### PR DESCRIPTION
MSYS2のダウンロードを調整しました。

- stable (2019-5-24) ではなく latest を優先してダウンロードするようにしました。
  pacman の修正やミラーサイトの追加等がされているようです。
  また、ダウンロード後は、pacman -Syyuu で最新版にアップデートするようにしました。
  ( 安定版でいきたかったのですが、pacman が core dump したりしているので。。。
  https://github.com/shirok/Gauche/runs/488783601?check_suite_focus=true )

- また、タイムアウト時間を 90 分に増やしました。
  ダウンロードのリトライ等で、時間がかかるケースがあるため。
  ( linux と osx は増やす必要はありませんが、また干渉があるといやなので、合わせました)

- また、上記変更により、MinGW-w64 の gcc のバージョンが 8.3.0 から 9.2.0 に上がりました。
  このせいか、srfi-144 のテストが 2 件エラーになるようになったため、
  スキップするようにしました。
  ```
  test (fl+* fl-greatest fl-greatest neginf): expects -inf.0 => got +nan.0
  test (fl+* fl-greatest (fl- fl-greatest) posinf): expects +inf.0 => got +nan.0
  ```

＜テスト結果＞
https://github.com/Hamayama/Gauche/actions/runs/51153221

＜関連情報＞
https://practical-scheme.net/wiliki/wiliki.cgi?Gauche%3ABugs#H-1qgtcx1
https://gist.github.com/Hamayama/3cc0e9c0c5283e7fc422360c6e5bd372

関連プルリクエスト #622
