### PR TITLE
Make (trace-macro #f) the same as (untrace-macro)

### DIFF
--- a/src/libmacbase.scm
+++ b/src/libmacbase.scm
@@ -194,6 +194,7 @@
   (match args
     [() #f]                             ;just show current traces
     [(#t) (set! *trace-macro* #t)]      ;trace all macros
+    [(#f) (set! *trace-macro* #f)]      ;untrace all macros
     [(objs ...)
      (unless (every (^x (or (symbol? x) (regexp? x))) objs)
        (error "Argument(s) of trace-macro should be a \


### PR DESCRIPTION
The error message from trace-macro mentions "Arguments.. should be a
boolean..." which suggests that #f can be accepted as well. The document
is also the same

    When called with single boolean value, it sets the current setting
    to that value.  Returns the updated setting.

So let's make `(trace-macro #f)` work, just to be a bit more convenient.