### PR TITLE
line-edit: consider an empty line "complete"

### DIFF
--- a/lib/gauche/interactive/editable-reader.scm
+++ b/lib/gauche/interactive/editable-reader.scm
@@ -85,7 +85,7 @@
 ;; We have to handle both toplevel command (begins with comma, ends with
 ;; newline) and the complete sexp.
 (define (%input-complete? s)
-  (and (not (equal? s ""))
-       (if-let1 m (#/^\s*,(.*)/ s)
-         (not (#/^\s*$/ (m 1)))
-         (complete-sexp? s))))
+  (or (equal? s "")
+      (if-let1 m (#/^\s*,(.*)/ s)
+        (not (#/^\s*$/ (m 1)))
+        (complete-sexp? s))))


### PR DESCRIPTION
%input-complete? is used to determine if an expression is not complete
when \n is typed. If not, the REPL should continue reading instead of
evaluating the expression.

The current condition considers an empty string "not complete"
though. This means if you press Enter right away, e.g. to insert a few
empty lines from the last result, you'll have to press twice for the
REPL to consider "complete" and give you a new prompt.

Change the condition here to consider an empty string "complete" to
avoid that.