### PR TITLE
Change srfi-144 fl+* test

### DIFF
--- a/ext/srfi/test.scm
+++ b/ext/srfi/test.scm
@@ -1413,7 +1413,7 @@
   (define-module srfi.144 (extend srfi-144))
   (define-module tests.scheme.test
     (use gauche.test)
-    (export test test/unspec-or-exn test/approx test/approx-1ulp)
+    (export test test/one-of test/unspec-or-exn test/approx test/approx-1ulp)
     (define (f=? a b)
       (cond [(flonum? a)
              (and (flonum? b)
@@ -1428,6 +1428,11 @@
       (syntax-rules ()
         [(_ expr expected)
          (test* #"~'expr" expected expr f=?)]))
+    (define-syntax test/one-of
+      (syntax-rules ()
+        [(_ expr expected-list)
+         (test* #"~'expr" expected-list expr
+                (^[elis r] (any (cut f=? <> r) elis)))]))
     (define-syntax test/unspec-or-exn
       (syntax-rules ()
         [(_ expr _)

--- a/test/include/srfi-144-tests.scm
+++ b/test/include/srfi-144-tests.scm
@@ -638,7 +638,7 @@
      (test (fl* nan one) nan)
      (test (fl* one nan) nan)
      ;; [SK] (fl* (flonum 1/3) (flonum 1/3) (flonum 1/3)) yields 1ulp error
-     ;; comapred to (flonum (expt 1/3 3)).
+     ;; compared to (flonum (expt 1/3 3)).
      (test/approx-1ulp (map fl* somereals somereals somereals)
                        (map (lambda (x) (flonum (expt x 3)))
                             somereals))
@@ -675,7 +675,7 @@
        ;; FIXME: the following test assumes IEEE double precision,
        ;; in which (expt 10 23) lies exactly halfway between the
        ;; two nearest flonums.
-       ;; [SK] MinGW's fma doesn't handle it corectly.
+       ;; [SK] MinGW's fma doesn't handle it correctly.
        (cond-expand
         [gauche.os.windows]
         [else
@@ -691,12 +691,10 @@
      (test-assert (flnan? (fl+* posinf zero nan)))
      (test-assert (flnan? (fl+* neginf zero nan)))
 
-     ;; On MinGW-w64 (gcc 9.2.0), result is +nan.0 instead of neginf/posinf.
-     (cond-expand
-      [gauche.os.windows]
-      [else
-       (test (fl+* fl-greatest fl-greatest neginf) neginf)
-       (test (fl+* fl-greatest (fl- fl-greatest) posinf) posinf)])
+     ;; POSIX spec says fma function returns either a NaN or
+     ;; an implementation-defined value in these cases.
+     (test/one-of (fl+* fl-greatest fl-greatest neginf) `(,nan ,neginf))
+     (test/one-of (fl+* fl-greatest (fl- fl-greatest) posinf) `(,nan ,posinf))
 
      (test-assert (flnan? (fl+* nan one one)))
      (test-assert (flnan? (fl+* one nan one)))


### PR DESCRIPTION
srfi-144 の fl+* 手続き (内部で C の fma 関数を使用) のテストを、2 件変更しました。
( (x * y) + z の (x * y) が Inf で z がそれと逆符号の Inf の場合、
 計算結果が NaN のときも 正解と判定するようにしました)


＜テスト結果＞
https://github.com/Hamayama/Gauche/actions/runs/56076957


＜参考URL＞
- テストが NG になった件
  https://github.com/shirok/Gauche/pull/625

- MinGW-w64 の C ランタイム
  https://sourceforge.net/p/mingw-w64/mingw-w64/ci/master/tree/mingw-w64-crt/math/fma.c
  https://sourceforge.net/p/mingw-w64/mingw-w64/ci/fd78dd54e38c5b977cb2b6bab3bc20b63239911d/

- POSIX fma
  https://pubs.opengroup.org/onlinepubs/9699919799/functions/fma.html
  ( NaN または 処理系定義の値を返す )

- C99 fma
  https://en.cppreference.com/w/c/numeric/math/fma (英語)
  https://ja.cppreference.com/w/c/numeric/math/fma (日本語)
  (これだと NaN のみを返すように読めるが、実際の処理系は Inf を返すものが多い。。。)
