### PR TITLE
Fix `gosh -V` output to a pipe

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -225,6 +225,7 @@ void version(void)
     SCM_FOR_EACH(cp, alist) {
         Scm_Printf(SCM_CUROUT, "%S\n", SCM_CAR(cp));
     }
+    Scm_FlushAllPorts(TRUE);
     exit(0);
 }
 


### PR DESCRIPTION
`gosh -V` would write all version output, but `gosh -V | less` would not write the S-expressions. Fix by flushing output ports.