### PR TITLE
Ensure deterministic `gosh -V` output order

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -215,9 +215,9 @@ void usage(int errorp)
 
 void version(void)
 {
-    printf("Gauche scheme shell, version %s [%s%s], %s\n",
-           GAUCHE_VERSION, SCM_CHAR_ENCODING_NAME, THREAD_OPT,
-           Scm_HostArchitecture());
+    Scm_Printf(SCM_CUROUT, "Gauche scheme shell, version %s [%s%s], %s\n",
+               GAUCHE_VERSION, SCM_CHAR_ENCODING_NAME, THREAD_OPT,
+               Scm_HostArchitecture());
     static ScmObj version_alist_proc = SCM_UNDEFINED;
     SCM_BIND_PROC(version_alist_proc, "version-alist", Scm_GaucheModule());
     ScmObj alist = Scm_ApplyRec0(version_alist_proc), cp;


### PR DESCRIPTION
The first line was printed using C stdio printf(), whereas the S-expressions were printed using Scm_Printf(). Since stdio and Scheme use different output buffers, and the Scheme output buffer was flushed first, the C flushing could be postponed until after the S-exprs, causing output in the wrong order.

Fix by writing the first line using Scm_Printf() as well.