### PR TITLE
Fix new ExtendedPair check on 64-bit Windows

### DIFF
--- a/src/gauche.h
+++ b/src/gauche.h
@@ -1125,7 +1125,7 @@ SCM_EXTERN int Scm_CheckingPairP(ScmObj);
 #define SCM_SET_CAR_UNCHECKED(obj, value) (SCM_CAR(obj) = (value))
 #define SCM_SET_CDR_UNCHECKED(obj, value) (SCM_CDR(obj) = (value))
 
-#if SIZEOF_LONG == 4
+#if SIZEOF_LONG == 4 && !defined(_WIN64)
 #define SCM_ODD_WORD_POINTER_P(p) (SCM_WORD(p) & 0x4)
 #else /*SIZEOF_LONG == 8*/
 #define SCM_ODD_WORD_POINTER_P(p) (SCM_WORD(p) & 0x8)


### PR DESCRIPTION
コミット 019a3e6 の修正になります。

64-bit の Windows では、ポインタのサイズは 8 バイトですが、
long のサイズは 4 バイトのため、判定に失敗していました。
(ログ：https://github.com/shirok/Gauche/runs/510045705 )


＜テスト結果＞
https://github.com/Hamayama/Gauche/actions/runs/57260012
