### PR TITLE
Enable and wrap profiler code with MOSTLY_FALSE

### DIFF
--- a/src/gauche/prof.h
+++ b/src/gauche/prof.h
@@ -131,7 +131,7 @@ SCM_EXTERN void Scm_ProfilerCountBufferFlush(ScmVM *vm);
 #ifdef GAUCHE_PROFILE
 #define SCM_PROF_COUNT_CALL(vm, obj)                                    \
     do {                                                                \
-        if (vm->profilerRunning) {                                      \
+        if (MOSTLY_FALSE(vm->profilerRunning)) {                        \
             if (vm->prof->currentCount == SCM_PROF_COUNTER_IN_BUFFER) { \
                 Scm_ProfilerCountBufferFlush(vm);                       \
             }                                                           \

--- a/src/vm.c
+++ b/src/vm.c
@@ -451,8 +451,9 @@ static void vm_unregister(ScmVM *vm)
 #endif
 
 /* Hint for gcc -- at this moment, using __builtin_expect doesn't
-   do any good.  I'll try this later on. */
-#if 0
+   do any good (except for SCM_PROF_COUNT_CALL). I'll try this
+   later on. */
+#if 1
 #define MOSTLY_FALSE(expr)  __builtin_expect(expr, 0)
 #else
 #define MOSTLY_FALSE(expr)  expr


### PR DESCRIPTION
Profiler code is almost always off and better be outside of the core
interpreter loop, higher chance of keeping the entire interpreter in the
instruction cache (and hopefully be nicer to branch predictor too).

MOSTLY_FALSE can be used for this. On gcc-8.2.0 (and Intel CPU), I can
see the original comment is true, run_loop() seems not affected by
current MOSTLY_FALSE "calls".

It does move profiler code (about 8 instructions) out though. It jumps
if profilerRunning is on, to some code at the very bottom of
run_loop. Before MOSTLY_FALSE code, it jumps if profilerRunning is off.

No actual performance measurements are done. I fear this is the kind of
micro optimization that is lost in the noise. Small improvements add up
though, hopefully.