### PR TITLE
Further simplify version()

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -225,8 +225,7 @@ void version(void)
     SCM_FOR_EACH(cp, alist) {
         Scm_Printf(SCM_CUROUT, "%S\n", SCM_CAR(cp));
     }
-    Scm_FlushAllPorts(TRUE);
-    exit(0);
+    Scm_Exit(0);
 }
 
 void invoke_other_version(const char *version, int argc, char **argv)


### PR DESCRIPTION
Yet another way to simplify of `version()` by using `Scm_Exit()` instead of manually flushing ports.