### PR TITLE
Experimental command-lines module

### DIFF
--- a/lib/Makefile.in
+++ b/lib/Makefile.in
@@ -96,6 +96,7 @@ SCMFILES = \
        gauche/package/util.scm gauche/package/compile.scm \
        gauche/experimental/ref.scm gauche/experimental/lamb.scm \
        gauche/experimental/app.scm \
+       gauche/experimental/command-lines.scm \
        r7rs-setup.scm \
        binary/ftype.scm binary/pack.scm \
        control/job.scm control/mapper.scm control/thread-pool.scm \

--- a/lib/gauche/experimental/command-lines.scm
+++ b/lib/gauche/experimental/command-lines.scm
@@ -1,0 +1,37 @@
+(define-module gauche.experimental.command-lines
+  (use file.util)
+  (export os-executable-file os-command-line script-file script-directory
+          command-name command-args command-line command-line-offset
+          filename->command-name))
+
+(select-module gauche.experimental.command-lines)
+
+;;; Fundamental
+
+(define (os-executable-file) #f)
+(define (os-command-line) *os-command-line*)
+(define (command-line-offset) *command-line-offset*)
+
+;;; Derived
+
+(define (script-directory)
+  (let ((sf (script-file)))
+    (and sf (string-append (sys-dirname sf) "/"))))
+
+(define (command-line)
+  (and (command-line-offset)
+       (list-tail (os-command-line) (command-line-offset))))
+
+(define (command-name)
+  (and (command-line-offset)
+       (filename->command-name
+        (list-ref (os-command-line) (command-line-offset)))))
+
+(define (command-args)
+  (if (not (command-line-offset)) '()
+      (list-tail (os-command-line) (+ (command-line-offset) 1))))
+
+(define (command-line) (cons (or (command-name) "") (command-args)))
+
+(define (filename->command-name arg)
+  (path-sans-extension (sys-basename arg)))

--- a/src/gauche.h
+++ b/src/gauche.h
@@ -1998,7 +1998,8 @@ SCM_EXTERN void Scm_Cleanup(void);
 SCM_EXTERN void Scm_Exit(int code) SCM_NORETURN;
 SCM_EXTERN void Scm_Abort(const char *msg) SCM_NORETURN;
 SCM_EXTERN void Scm_Panic(const char *msg, ...) SCM_NORETURN;
-SCM_EXTERN ScmObj Scm_InitCommandLine(int argc, const char *argv[]);
+SCM_EXTERN ScmObj Scm_InitCommandLine(const char *argv[], int argc,
+                                      int offset);
 
 SCM_EXTERN void Scm_SimpleMain(int argc, const char *argv[],
                                const char *script, u_long flags);

--- a/src/libeval.scm
+++ b/src/libeval.scm
@@ -642,6 +642,9 @@
 (inline-stub
  (initcode
   (Scm_BindPrimitiveParameter (Scm_GaucheModule) "command-line" SCM_NIL 0)))
+(inline-stub
+ (initcode
+  (Scm_BindPrimitiveParameter (Scm_GaucheModule) "script-file" SCM_FALSE 0)))
 
 ;;
 ;; External view of VM.


### PR DESCRIPTION
I'm preparing a SRFI to specify the behavior of the R7RS `command-line` procedure in more detail, and add some related procedures. Here's a sample implementation for Gauche. Do you think this kind of thing is a good idea?

Sample output from a script:

```scheme
(os-executable-file) => #f
(os-command-line) => ("gosh" "-r" "7" "./command-lines-test" "foo" "bar" "baz")
(script-file) => "/Users/lassi/tmp/scheme/gauche/command-lines-test"
(script-directory) => "/Users/lassi/tmp/scheme/gauche/"
(command-name) => "command-lines-test"
(command-args) => ("foo" "bar" "baz")
(command-line) => ("command-lines-test" "foo" "bar" "baz")
(command-line-offset) => 3
```

Sample output from the REPL:

```scheme
$ gosh
> (import (gauche experimental command-lines))
> (command-line)
("")
> (command-name)
#f
> (command-args)
()
> (script-file)
#f
> (script-directory)
#f
> (command-line-offset)
#f
> (os-command-line)
("gosh")
> (os-executable-file)
#f
```

`os-executable-file` is inherently non-portable. I plan to make it optional in the SRFI; a proper implementation covering most operating systems takes about 100 lines of C.