### PR TITLE
bcrypt: free crypt-ra's data on error case

### DIFF
--- a/ext/bcrypt/bcrypt.scm
+++ b/ext/bcrypt/bcrypt.scm
@@ -25,7 +25,9 @@
  (define-cproc crypt-ra (pass::<const-cstring> setting::<const-cstring>)
    (let* ([data::void* NULL] [size::int 0]
           [c::char* (crypt_ra pass setting (& data) (& size))])
-     (when (== c NULL) (Scm_SysError "crypt_ra failed"))
+     (when (== c NULL)
+       (free data)
+       (Scm_SysError "crypt_ra failed"))
      (let* ([r (SCM_MAKE_STR_COPYING c)])
        (free data)
        (return r))))


### PR DESCRIPTION
"data" could be reallocated by wrapper.c:_crypt_data_alloc(). This
happens before the actual encryption happens, so if it fails, we still
need to clean it up (we do call free() on successful case).

Found by address sanitizer, related to #638