### PR TITLE
ext/tls: respect external LDFLAGS

### DIFF
--- a/ext/tls/Makefile.in
+++ b/ext/tls/Makefile.in
@@ -84,7 +84,7 @@ $(AXTLS_OBJECTS): $(EXTRA_DIRS_TARGET)
 
 # We build the test executable (ssltest) at the build time
 $(SSLTEST): $(SSLTEST_OBJECTS) $(AXTLS_OBJECTS)
-	$(CCLD) $(LOCAL_LFLAGS) $(XLDFLAGS) -o $(SSLTEST) $(SSLTEST_OBJECTS) $(AXTLS_OBJECTS) $(LIBS)
+	$(CCLD) @LDFLAGS@ $(LOCAL_LFLAGS) $(XLDFLAGS) -o $(SSLTEST) $(SSLTEST_OBJECTS) $(AXTLS_OBJECTS) $(LIBS)
 
 # The 'system' macro hack is to suppress "ignoring result" warning
 $(SSLTEST_GENERATED) : axTLS/ssl/test/ssltest.c ssltest-mod.scm axtls_dirs


### PR DESCRIPTION
The user may pass LDFLAGS to configure script to change linker
behavior. In this case, they can pass LDFLAGS=-faddress=sanitize to
activate asan. Without this, linking ssltest fails. Related to #638.