### PR TITLE
www.css: support CSS3 An+B microsyntax

### DIFF
--- a/lib/www/css.scm
+++ b/lib/www/css.scm
@@ -34,6 +34,7 @@
 (define-module www.css
   (use gauche.generator)
   (use gauche.lazy)
+  (use gauche.unicode)
   (use parser.peg)
   (use util.match)
   (use text.tree)
@@ -472,7 +473,7 @@
 
 (define %component-value+  ; whitespace preserving
   ($lazy ($/ ($seq ($tok 'WHITESPACE) ($return '(WHITESPACE)))
-             %brace-block %paren-block %bracket-block %function-call
+             %brace-block %paren-block %bracket-block %function-call+
              %preserved-token)))
 
 (define (block-parser opener closer tag :optional (preserve-ws? #f))
@@ -493,6 +494,12 @@
   ($lift (^[fn args _] `(funcall ,fn ,@args))
          ($tok 'FUNCTION)
          ($many ($seq ($not ($tok 'CLOSE-PAREN)) %component-value))
+         ($tok 'CLOSE-PAREN)))
+
+(define %function-call+
+  ($lift (^[fn args _] `(funcall ,fn ,@args))
+         ($tok 'FUNCTION)
+         ($many ($seq ($not ($tok 'CLOSE-PAREN)) %component-value+))
          ($tok 'CLOSE-PAREN)))
 
 (define %at-rule
@@ -598,13 +605,89 @@
    ($/ %type-selector %attr-selector %class-selector %id-selector
        %pseudo-selector)))
 
+(define %sign
+  ($or ($seq ($delim #\+) ($return +))
+       ($seq ($delim #\-) ($return -))))
+
+(define %optional-sign
+  ($optional %sign +))
+
+(define-syntax %match1
+  (syntax-rules ()
+    [(_ pat body0 body ...)
+     (lambda (s)
+       (if (pair? s)
+         (match (car s)
+           [pat ((begin body0 body ...) (cdr s))]
+           [_ (return-failure/expect (write-to-string 'pat) s)])
+         (return-failure/expect (write-to-string 'pat) s)))]
+    [(_ pat)
+     (lambda (s)
+       (if (pair? s)
+         (match (car s)
+           [pat (return-result (car s) (cdr s))]
+           [_ (return-failure/expect (write-to-string 'pat) s)])
+         (return-failure/expect (write-to-string 'pat) s)))]))
+
+(define (symbol-foldcase sym)
+  (string->symbol
+   (string-foldcase
+    (symbol->string sym))))
+
+(define (%one-of-ident-ci idents)
+  (%match1 ('IDENT . (and ident
+                          (= symbol-foldcase
+                             (? (cut memq <> idents)))))
+           ($return ident)))
+
+(define (%%an+b a b)
+  ($return
+   (if (= a 0)
+       b
+       `(:an+b ,a ,b))))
+
+(define (%n-b a n-b)
+  (rxmatch-if (#/^n(-\d+)$/ (symbol->string n-b))
+      (_ b)
+     (%%an+b a (string->number b))
+    ($fail "n-b")))
+
+(define %an+b
+  ($between %WS*
+            ($/ ($let ([sign %optional-sign])
+                  ($or ($let ([a ($or (%match1 ('DIMENSION a (or 'n 'N))
+                                               ($return a))
+                                      ($seq (%one-of-ident-ci '(n))
+                                            ($return 1))
+                                      ($seq (%one-of-ident-ci '(-n))
+                                            ($return -1)))]
+                              [b ($optional
+                                  ($lift (cut <> <>)
+                                         ($between %WS* %sign %WS*)
+                                         ($tok 'NUMBER))
+                                  0)])
+                         (%%an+b (sign a) b))
+                       (%match1 ('DIMENSION a n-b)
+                                (%n-b (sign a) n-b))
+                       (%match1 ('IDENT . n-b)
+                                (%n-b (sign 1) n-b))))
+                ($lift (cut <> <>)
+                       %optional-sign
+                       ($tok 'NUMBER))
+                (%one-of-ident-ci '(even odd)))
+            %WS*))
+
 ;; NB: negation-selector is also treated in pseudo-fn
 (define (%pseudo-fn s)
   (match s
     [(('funcall name . arg-tokens) . rest)
-     (receive (r v s) (if (eq? name 'not)
-                        (%negation-selector-arg arg-tokens)
-                        (%pseudo-fn-arg arg-tokens))
+     (receive (r v s) (case (symbol-foldcase name)
+                        [(not)
+                         (%negation-selector-arg arg-tokens)]
+                        [(nth-child nth-last-child nth-of-type nth-last-of-type)
+                         (%an+b arg-tokens)]
+                        [else
+                         (%pseudo-fn-arg arg-tokens)])
        (if (and (parse-success? r)
                 (null? s))
          (return-result (list name v) rest)
@@ -851,7 +934,7 @@
 (define %selector-only
   ($seq %WS*
         ($many ($seq ($not ($tok 'OPEN-BRACE))
-                     ($/ %paren-block %bracket-block %function-call
+                     ($/ %paren-block %bracket-block %function-call+
                          %preserved-token ($tok 'WHITESPACE))))))
 
 ;; TODO: make this customizable

--- a/lib/www/css.scm
+++ b/lib/www/css.scm
@@ -201,6 +201,9 @@
   (define (render-arg arg)
     (match arg
       [#(v ...)  (intersperse " " (map render-attrval v))]
+      [(:an+b a b) `(,(if (= a 1) "" a)
+                     n
+                     ,(if (= b 0) "" (format "~@d" b)))]
       [(/ v ...) (intersperse "/" (map render-attrval v))]
       [v (render-attrval v)]))
 

--- a/lib/www/css.scm
+++ b/lib/www/css.scm
@@ -673,7 +673,9 @@
                        (%match1 ('DIMENSION a n-b)
                                 (%n-b (sign a) n-b))
                        (%match1 ('IDENT . n-b)
-                                (%n-b (sign 1) n-b))))
+                                (if-let1 n-b* (symbol-sans-prefix n-b '-)
+                                  (%n-b -1 n-b*)
+                                  (%n-b 1 n-b)))))
                 ($lift (cut <> <>)
                        %optional-sign
                        ($tok 'NUMBER))

--- a/lib/www/css.scm
+++ b/lib/www/css.scm
@@ -303,7 +303,7 @@
 (define %escape ($/ %unicode ($seq ($. #\\) ($none-of #[\n\r\f0-9a-f]))))
 ;; nmstart [_a-z]|{nonascii}|{escape} => char
 (define %nmstart ($/ ($. #[_a-zA-Z]) %nonascii %escape))
-  
+
 ;; nonascii [^\0-\237] => char
 (define %nonascii ($none-of #[\x00-\x9f]))
 ;; unicode \\[0-9a-f]{1,6}(\r\n|[ \n\r\t\f])?  => char
@@ -520,7 +520,7 @@
     (if (string-ci=? (symbol->string v) "important")
       ($return '!important)
       ($fail "!important expected"))))
-        
+
 (define %declaration
   ($lift (^[name _ _ block important _] (list name block important))
          ($tok 'IDENT) %WS* ($tok 'COLON)
@@ -540,7 +540,7 @@
 
 (define %rule-list
   ($many ($/ ($tok 'WHITESPACE) %qualified-rule %at-rule)))
-               
+
 ;;
 ;; Higher-level parser
 ;;

--- a/lib/www/css.scm
+++ b/lib/www/css.scm
@@ -616,7 +616,7 @@
            (match sel
              [('not not-arg) `(:not ,not-arg)]
              [(? symbol?) `(,(if elem? ':: ':) ,sel)]
-             [_ `(,(if elem? ':: ':) ,@sel)]))
+             [_ `(,(if elem? ':: ':) ,sel)]))
          ($tok 'COLON) ($optional ($tok 'COLON))
          ($/ ($tok 'IDENT) %pseudo-fn)))
 

--- a/lib/www/css.scm
+++ b/lib/www/css.scm
@@ -663,8 +663,10 @@
 ;; it as a selector and returns <pattern> structure of S-expr CSS.
 ;; If it can't be parsed, returns #f.
 (define (parse-selectors tokens)
-  (receive (val next) (peg-run-parser %selector-group tokens)
-    (and (null? next) val)))
+  (receive (r v s) (%selector-group tokens)
+    (and (parse-success? r)
+         (null? s)
+         v)))
 
 ;; default declaration value parser
 ;; This part roughly follows CSS2.1 spec appendix G.

--- a/lib/www/css.scm
+++ b/lib/www/css.scm
@@ -204,7 +204,7 @@
       [(:an+b a b) `(,(if (= a 1) "" a)
                      n
                      ,(if (= b 0) "" (format "~@d" b)))]
-      [(/ v ...) (intersperse "/" (map render-attrval v))]
+      [('/ v ...) (intersperse "/" (map render-attrval v))]
       [v (render-attrval v)]))
 
   (define (render-decl decl)

--- a/test/www.scm
+++ b/test/www.scm
@@ -390,8 +390,40 @@ Content-Disposition: form-data; name=bbb
        #f
        (parse-css-selector-string ":::"))
 
-(test* "parse-css-selector-string (pseudo-class with arg)"
+(test* "parse-css-selector-string (nth-child)"
        '(* (: (nth-child 1)))
        (parse-css-selector-string ":nth-child(1)"))
+
+(test* "parse-css-selector-string (nth-child an+b)"
+       '(* (: (nth-child (:an+b 2 1))))
+       (parse-css-selector-string ":nth-child(2n+1)"))
+
+(test* "parse-css-selector-string (nth-child an+b)"
+       '(* (: (nth-child (:an+b 1 0))))
+       (parse-css-selector-string ":nth-child(n)"))
+
+(test* "parse-css-selector-string (nth-child an+b)"
+       '(* (: (nth-child (:an+b -1 0))))
+       (parse-css-selector-string ":nth-child(-n)"))
+
+(test* "parse-css-selector-string (nth-child an+b)"
+       '(* (: (nth-child (:an+b -3 4))))
+       (parse-css-selector-string ":nth-child(-3n+4)"))
+
+(test* "parse-css-selector-string (nth-child an+b)"
+       '(* (: (nth-child (:an+b -3 -4))))
+       (parse-css-selector-string ":nth-child(-3n-4)"))
+
+(test* "parse-css-selector-string (nth-child an+b)"
+       #f
+       (parse-css-selector-string ":nth-child(- n)"))
+
+(test* "parse-css-selector-string (nth-child an+b)"
+       '(* (:not (: (nth-child (:an+b -1 0)))))
+       (parse-css-selector-string ":not(:nth-child(-n))"))
+
+(test* "parse-css-selector-string (nth-child an+b)"
+       #f
+       (parse-css-selector-string ":not(:nth-child(- n))"))
 
 (test-end)

--- a/test/www.scm
+++ b/test/www.scm
@@ -390,4 +390,8 @@ Content-Disposition: form-data; name=bbb
        #f
        (parse-css-selector-string ":::"))
 
+(test* "parse-css-selector-string (pseudo-class with arg)"
+       '(* (: (nth-child 1)))
+       (parse-css-selector-string ":nth-child(1)"))
+
 (test-end)

--- a/test/www.scm
+++ b/test/www.scm
@@ -347,7 +347,7 @@ Content-Disposition: form-data; name=bbb
       (print "echo \"CONTENT_LENGTH = $CONTENT_LENGTH\"")
       (print "echo \"QUERY_STRING = $QUERY_STRING\"")
       (print "cat")))
-       
+
   (test* "run-cgi-script->string-list (using parameters)"
          '("REQUEST_METHOD = POST"
            "CONTENT_TYPE = application/x-www-form-urlencoded"
@@ -387,5 +387,3 @@ Content-Disposition: form-data; name=bbb
 (run-css-test)
 
 (test-end)
-
-

--- a/test/www.scm
+++ b/test/www.scm
@@ -407,6 +407,10 @@ Content-Disposition: form-data; name=bbb
        (parse-css-selector-string ":nth-child(-n)"))
 
 (test* "parse-css-selector-string (nth-child an+b)"
+       '(* (: (nth-child (:an+b -1 -6))))
+       (parse-css-selector-string ":nth-child(-n-6)"))
+
+(test* "parse-css-selector-string (nth-child an+b)"
        '(* (: (nth-child (:an+b -3 4))))
        (parse-css-selector-string ":nth-child(-3n+4)"))
 

--- a/test/www.scm
+++ b/test/www.scm
@@ -386,4 +386,8 @@ Content-Disposition: form-data; name=bbb
 
 (run-css-test)
 
+(test* "parse-css-selector-string (failure)"
+       #f
+       (parse-css-selector-string ":::"))
+
 (test-end)


### PR DESCRIPTION
`www.css` のCSS3 An+B microsyntaxのサポートです。

なるべく小さい変更でと思っていたのですが、関連する所を直していたら当初の予想より大きくなってしまいました。

変更
- `%pseudo-fn` にnth系の場合(An+B)を足したのと、擬似クラス名をfoldcaseするようにしました。
- `%component-value+` が再帰的に `%function-call` を呼びますが、これは空白を保存しないので、ネストしたfunction callの内側の空白は保存されない挙動になっていました。An+Bを厳密にパーズするのに必要だと思ったので `%function-call+` を追加して直しましたが、このPRに含まれる他の変更と違って `parse-css-selector-string` 以外のAPIに影響があるかもしれません。テストは通りました。
- `parse-selectors` がパーズに失敗した時例外が飛ぶようになっていたので、コメントに合わせて `#f` を返すように修正しました。
- `%pseudo-selector` の出力を修正しました。
- rendererに :an+b の対応を追加しました。
- `render-arg` の `(/ v ...)` は `('/ v ...)` の間違いっぽいのでついでに直しました。

その他気付き
- `parser.peg` の `$match1` はresult式を `return-result` する形になっていますが、それだとパーズ失敗を全部パターンマッチの失敗で表さないといけなくなるので、 `$let` のように `$return` を書かせる形の方が使いやすい(&分かりやすい)のではないでしょうか。と思ったのでそういう `%match1` を書いてあります。
  あと、 `parser.peg` の$match系のreturn-failureにtypoがあります(このPRには入っていません)。
- CSS3の関数の形の擬似クラスにはnth系と `:not` と `:lang` がありますが、それぞれ引数の部分の文法が違い、擬似クラスの引数一般をパーズすることはできないので `%pseudo-fn-arg` は要らない気がします。