### PR TITLE
Add uploading test log of ext/threads in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,7 @@ jobs:
       run: |
         mkdir -p $TESTLOG_PATH/$TESTLOG_NAME
         cp $GAUCHE_TEST_PATH/src/test.log $TESTLOG_PATH/$TESTLOG_NAME
+        cp $GAUCHE_TEST_PATH/ext/threads/test.log $TESTLOG_PATH/$TESTLOG_NAME/test-threads.log
     - name: Upload testlog
       if: always()
       uses: actions/upload-artifact@v1
@@ -82,6 +83,7 @@ jobs:
       run: |
         mkdir -p $TESTLOG_PATH/$TESTLOG_NAME
         cp $GAUCHE_TEST_PATH/src/test.log $TESTLOG_PATH/$TESTLOG_NAME
+        cp $GAUCHE_TEST_PATH/ext/threads/test.log $TESTLOG_PATH/$TESTLOG_NAME/test-threads.log
     - name: Upload testlog
       if: always()
       uses: actions/upload-artifact@v1
@@ -208,6 +210,7 @@ jobs:
           cd $GITHUB_WORKSPACE
           mkdir -p $TESTLOG_PATH/$TESTLOG_NAME
           cp src/test.log $TESTLOG_PATH/$TESTLOG_NAME
+          cp ext/threads/test.log $TESTLOG_PATH/$TESTLOG_NAME/test-threads.log
         '@
     - name: Upload testlog
       if: always()


### PR DESCRIPTION
以下の failure 事例の `14.` のログを取得するものです。

https://gist.github.com/Hamayama/3cc0e9c0c5283e7fc422360c6e5bd372

`3.` の GC の関係かとも思いますが、すぐには分からなそうなので、
まずは、発生箇所を特定しようと思います。

現状、未解決は `3. 4. 7. 8. 9. 14.` で、
`7.` ( osx の fork & sigint ? ) 以外は、windows only です。

自分の PC では、あまり発生した記憶がありませんが。。。
(`9.` は、ごくまれにあったかも)
