### PR TITLE
More SRE integration to Gauche

### DIFF
--- a/lib/gauche/regexp.scm
+++ b/lib/gauche/regexp.scm
@@ -101,6 +101,10 @@
             [strp (string? temp)])
        (rxmatch-case #t temp strp ?clause ...))]))
 
+(define-syntax rx
+  (syntax-rules ()
+    [(_ sre ...) (regexp-compile-sre `(: sre ...))]))
+
 ;; Extract all matches (including entire match).  Allows match to be #f.
 (define (rxmatch-substrings match :optional (start 0) (end #f))
   (if match

--- a/lib/srfi-115.scm
+++ b/lib/srfi-115.scm
@@ -34,7 +34,7 @@
 (define-module srfi-115
   (use scheme.charset)
   (use gauche.regexp.sre)
-  (export rx regexp regexp->sre char-set->sre valid-sre?
+  (export rx regexp regexp? regexp->sre char-set->sre valid-sre?
           regexp-matches regexp-matches? regexp-search
           regexp-fold regexp-extract regexp-split regexp-partition
           regexp-replace regexp-replace-all
@@ -42,10 +42,6 @@
           regexp-match-submatch-start regexp-match-submatch-end
           regexp-match->list))
 (select-module srfi-115)
-
-(define-syntax rx
-  (syntax-rules ()
-    [(_ sre ...) (regexp `(: sre ...))]))
 
 (define (regexp re)
   (if (regexp? re) re (regexp-compile-sre re)))
@@ -60,9 +56,6 @@
   (guard (e [(<regexp-invalid-sre> e) #f][else (raise e)])
     (regexp-parse-sre sre)
     #t))
-
-;; regexp? is already defined by gauche.regexp and is builtin.
-;; do we even need to export it in pure R7RS environment?
 
 (define (regexp-matches re str :optional start end)
   (if (regexp? re)

--- a/src/autoloads.scm
+++ b/src/autoloads.scm
@@ -100,7 +100,7 @@
           (:macro get-optional get-keyword* fluid-let while until))
 
 (autoload gauche.regexp
-          (:macro rxmatch-let rxmatch-if rxmatch-cond rxmatch-case)
+          (:macro rx rxmatch-let rxmatch-if rxmatch-cond rxmatch-case)
           regexp-unparse rxmatch-substrings rxmatch-positions)
 
 (autoload gauche.regexp.sre


### PR DESCRIPTION
The main purpose of this is to make rxmatch and friends take SRE. We
could make these procedures interpret a list as SRE. But then there's
ambiguity with strings, which could be interpreted as RE strings, or
SREs.

So I though it may be better to just reuse "rx" macro from srfi-115.
This way it's also clearer that it's an SRE:

    (rxmatch (rx (* (/ "az"))) "foo")

And we can void the ambiguity with strings.

This is not as efficient as #// read syntax. But in theory rx macro
could be made to compile the sre at compile time if no unquote is found
in the SRE. I haven't found a way to do it, but if we could then it
benefits srfi-115 as well.