### PR TITLE
Fix compiler warnings on gcc-9.2.0

### DIFF
--- a/doc/corelib.texi
+++ b/doc/corelib.texi
@@ -10792,7 +10792,7 @@ Returns a scheme regexp (SRE) describing the regexp @var{regexp}.
 @c JP
 正規表現@var{regexp}を生成するScheme正規表現式(SRE)を返します。
 SREについて詳しくは@ref{R7RS regular expressions}を参照してください。
-@c COMON
+@c COMMON
 @end defun
 
 @defun regexp-num-groups regexp

--- a/src/core.c
+++ b/src/core.c
@@ -120,7 +120,9 @@ static void init_cond_features(void);
 
 #ifdef GAUCHE_USE_PTHREADS
 /* a trick to make sure the gc thread object is linked */
-static int (*ptr_pthread_create)(void) = NULL;
+static int (*ptr_pthread_create)(pthread_t *,
+                                 GC_PTHREAD_CREATE_CONST pthread_attr_t *,
+                                 void *(*)(void *), void * /* arg */) = NULL;
 #endif
 
 /* flag to see if Scheme infrastructure is fully initialized or not */
@@ -216,7 +218,7 @@ void Scm_Init(const char *signature)
 
 #ifdef GAUCHE_USE_PTHREADS
     /* a trick to make sure the gc thread object is linked */
-    ptr_pthread_create = (int (*)(void))GC_pthread_create;
+    ptr_pthread_create = GC_pthread_create;
 #endif
 
     scheme_initialized = TRUE;

--- a/src/paths.c
+++ b/src/paths.c
@@ -359,7 +359,7 @@ static const char *substitute_all(const char *input,
     char *q = buf;
     for (p = input; noccurs > 0; noccurs--) {
         const char *p1 = strstr(p, mark);
-        strncpy(q, p, p1-p);
+        memcpy(q, p, p1-p);
         q += p1-p;
         memcpy(q, subst, slen);
         q += slen;


### PR DESCRIPTION
This is to spot new warnings easier (and I could run with -Werrror).

The -Wcast-function-type problem with ptr_pthread_create is caught even
before 9.2.0. strncpy is flagged by -Wstringop-truncation because NUL
may not be copied. But that's fine because we append NUL at the end anyway.