### PR TITLE
Add MacOS to compiler products to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ Makefile
 *.so
 *.sci
 *.dll
+*.dSYM
+*.dylib
 *.exe
 stamp-h1
 /src/libatomic_ops_pic.a


### PR DESCRIPTION
.dylib is the Mac equivalent to .dll on Windows and .so on Linux.

.dSYM is a directory with debug information generated by `cc -g`.