### PR TITLE
interactive.scm: delete outdated comment

### DIFF
--- a/lib/gauche/interactive.scm
+++ b/lib/gauche/interactive.scm
@@ -246,10 +246,9 @@
           expr)))))
 
 ;; EXPERIMENTAL: Environment GAUCHE_READ_EDIT enables editing mode.
-;; Note that, at this moment, text.line-edit isn't complete; it doesn't
-;; handle multibyte characters nor the multiline expressions bigger
-;; than the screen height.  Once we complete text.line-edit, we make
-;; the feature available through command-line options of gosh.
+;; Note that, at this moment, text.line-edit isn't complete. Once we
+;; complete text.line-edit, we make the feature available through
+;; command-line options of gosh.
 
 (define-values (%prompter %reader %line-edit-ctx)
   (receive (r rl skipper ctx)


### PR DESCRIPTION
It seems multibyte chars have been supported (likely done by Hamayama based on git history). Cursor movement works, deleting, inserting, cutting and pasting work (but I did not test adding text with an IM). Line wrapping seems fine too.

The screen height problem seems fixed too (also likely by Hamayama). When the expressions are longer than screen height, we only display the lines that contain the cursor (and fit in the terminal).

It flickers like hell though on those long expressions. But at least it displays correctly.