### PR TITLE
Reduce screen flickering in line-edit

### DIFF
--- a/lib/gauche/interactive/editable-reader.scm
+++ b/lib/gauche/interactive/editable-reader.scm
@@ -57,7 +57,7 @@
   (if-let1 console (make-default-console :if-not-available #f)
     (let ([ctx (make <line-edit-context>
                  :console console
-                 :prompt (^[] (putstr console (get-prompt-string)))
+                 :prompt (^[] (display (get-prompt-string)))
                  :input-continues (^s (not (%input-complete? s))))]
           [buffer (open-input-string "")])
       (define (read-1 reader)

--- a/lib/text/console/replay.scm
+++ b/lib/text/console/replay.scm
@@ -1,0 +1,56 @@
+(define-module text.console.replay
+  (use text.console)
+  (export <replay-console>
+          start-recording finish-recording play-recording))
+(select-module text.console.replay)
+
+(define-class <replay-console> ()
+  ((commands :init-value '())
+   ))
+
+(define (start-recording con)
+  (set! (~ con'commands) '()))
+
+(define (finish-recording con)
+  (set! (~ con'commands) (reverse (~ con'commands))))
+
+(define (play-recording con real-con)
+  (let loop ((cmds (~ con'commands)))
+    (unless (null? cmds)
+      (let ([cmd #?=(car cmds)]
+            [rest (cdr cmds)])
+        ((cdr cmd) real-con)
+        (loop rest)))))
+
+(define (save-cmd con name proc)
+  (set! (~ con'commands) (cons (cons name proc) (~ con'commands))))
+
+(define-method clear-to-eos ((con <replay-console>))
+  (save-cmd con 'clear-to-eos
+            (cut clear-to-eos <>)))
+
+(define-method cursor-down/scroll-up ((con <replay-console>) y height full-column-flag)
+  (save-cmd con 'cursor-down/scroll-up
+            (cut cursor-down/scroll-up <> y height full-column-flag))
+  ;; copied from text.console.generic, maybe there's a better way?
+  (if (and y height (>= y (- height 1))) 0 1))
+
+(define-method move-cursor-to ((con <replay-console>) y x)
+  (save-cmd con 'move-cursor-to
+            (cut move-cursor-to <> y x)))
+
+(define-method putch ((con <replay-console>) c)
+  (save-cmd con 'putch
+            (cut putch <> c)))
+
+(define-method putstr ((con <replay-console>) s)
+  (save-cmd con 'putstr
+            (cut putstr <> #?=s)))
+
+(define-method reset-character-attribute ((con <replay-console>))
+  (save-cmd con 'reset-character-attribute
+            (cut reset-character-attribute <>)))
+
+(define-method set-character-attribute ((con <replay-console>) newattr)
+  (save-cmd con 'set-character-attribute
+            (cut set-character-attribute <> newattr)))

--- a/lib/text/line-edit.scm
+++ b/lib/text/line-edit.scm
@@ -38,6 +38,7 @@
   (use file.util)
   (use util.match)
   (use text.console)
+  (use text.console.replay)
   (use text.gap-buffer)
   (use gauche.unicode)
   (export <line-edit-context> read-line/edit
@@ -304,16 +305,16 @@
     (set! (~ ctx'screen-width) w)))
 
 ;; Show prompt.  Returns the current column.
-(define (show-prompt ctx)
+(define (show-prompt ctx :optional (con #f))
   (let* ([p (~ ctx'prompt)]
          [s (if (applicable? p) (with-output-to-string p) (x->string p))])
-    (putstr (~ ctx'console) s)))
+    (putstr (or con (~ ctx'console)) s)))
 
 ;; Show secondary prompt
 ;; TODO: make this customizable
-(define (show-secondary-prompt ctx)
+(define (show-secondary-prompt ctx con)
   (when (> (~ ctx'initpos-x) 0)
-    (putstr (~ ctx'console) (make-string (~ ctx'initpos-x) #\.))))
+    (putstr con (make-string (~ ctx'initpos-x) #\.))))
 
 ;; Get a tab character width
 (define (get-tab-char-width ctx x w)
@@ -365,7 +366,8 @@
   (if (< (~ ctx'initpos-y) 0)
     (set! (~ ctx'initpos-y) 0))
 
-  (let* ([con     (~ ctx'console)]
+  (let* ([real-con (~ ctx'console)]
+         [con     (make <replay-console>)]
          [y       (~ ctx'initpos-y)]
          [x       (~ ctx'initpos-x)]
          [w       (~ ctx'screen-width)]
@@ -407,9 +409,10 @@
          [else
           (inc! y)])))
 
+    (start-recording con)
     (reset-character-attribute con)
     (move-cursor-to con y 0)
-    (show-prompt ctx)
+    (show-prompt ctx con)
     (clear-to-eos con)
     (let loop ([n 0])
       (glet1 ch (g)
@@ -425,7 +428,7 @@
            (line-wrapping w w)
            (when (display-area?)
              (switch-char-attr-when-needed con newattr '(#f #f))
-             (show-secondary-prompt ctx)
+             (show-secondary-prompt ctx con)
              (switch-char-attr-when-needed con '(#f #f) newattr))
            (set! x      (~ ctx'initpos-x))
            (set! disp-x x)]
@@ -457,7 +460,9 @@
           (set! pos-y y))
 
         (loop (+ n 1))))
-    (move-cursor-to con pos-y pos-x)))
+    (move-cursor-to con pos-y pos-x)
+    (finish-recording con)
+    (play-recording con real-con)))
 
 (define (current-char-attr pos sel oparen)
   (cond-list


### PR DESCRIPTION
This is not a real fix for #665 yet. I just wanted to check if this is a good direction to go. Most of the changes are in the second commit, which adds a virtual console to record command sequence and replay it on a real console later. If we have the command sequences, we can start comparing and find out where we need to update instead of redrawing the whole thing...