### PR TITLE
doc: minor update in r7rs regexp-replace

### DIFF
--- a/doc/modr7rs.texi
+++ b/doc/modr7rs.texi
@@ -8105,7 +8105,7 @@ replacement, or a list of those.
 The special symbols @code{pre} and @code{post} use the substring to
 the left or right of the match as replacement, respectively.
 
-As a Gauche extension, @var{subst} could also be a procedure, which is
+@var{subst} could also be a procedure, which is
 called with the given match object and the result will be used as the
 replacement.
 


### PR DESCRIPTION
There's a new post-final note in srfi-115 about regexp-replace accepting
a procedure, which will be adopted as normative in r7rs-large, so we
don't need the "As a Gauche extension" part anymore.