### PR TITLE
Add text.console.framebuffer for flicker-free line-edit

### DIFF
--- a/lib/text/console/framebuffer.scm
+++ b/lib/text/console/framebuffer.scm
@@ -1,0 +1,118 @@
+(define-module text.console.framebuffer
+  (use srfi-13)
+  (use text.console)
+  (export <framebuffer-console> init-framebuffer draw-framebuffer))
+(select-module text.console.framebuffer)
+
+;;; Framebuffer console.
+;; This is a virtual console that records all updates in an internal
+;; buffer, then updates a real console later with draw-framebuffer
+;; call. The last draw is kept, so next time it only updates the
+;; changed parts.
+;;
+;; This is made for text.line-edit and supports just enough operations
+;; for it to work. It also assumes that init-framebuffer starts with a
+;; cleared console. This is true for line-edit, but not always.
+(define-class <framebuffer-console> ()
+  ((width)
+   (height)
+   ;; Two dimensional array of cons whose car is the character and cdr
+   ;; is the attribute.
+   (buffer :init-form (make-vector 0))
+   (prev-buffer :init-form (make-vector 0))
+
+   ;; current cursor / attribute
+   (x :init-value 0)
+   (y :init-value 0)
+   (attr :init-value #f)
+   ))
+
+(define-syntax yx->pos
+  (syntax-rules ()
+    ((_ con row col)
+     (+ col (* row (~ con'width))))))
+
+(define (init-framebuffer fb w h)
+  (set! (~ fb'width) w)
+  (set! (~ fb'height) h)
+  (let ([size (* w h)])
+    (if (and (vector? (~ fb'buffer))
+             (>= (vector-length (~ fb'buffer)) size))
+      ;; reuse the vector to reduce GC pressure a bit
+      (begin
+        (vector-fill! (~ fb'buffer) #f)
+        (vector-fill! (~ fb'prev-buffer) #f))
+      (begin
+        (set! (~ fb'buffer) (make-vector size #f))
+        (set! (~ fb'prev-buffer) (make-vector size #f))))))
+
+(define (draw-framebuffer con console init-row init-col)
+  (let ([curbuf (~ con'buffer)]
+        [prevbuf (~ con'prev-buffer)]
+        [width (~ con'width)]
+        [height (~ con'height)]
+        [clear-to-eos? #f]              ; FIXME
+        [empty (cons #\space #f)])
+
+    ;; in case we detect clearing the screen or something (e.g. the
+    ;; majority of updates is to write whitespaces) then better to
+    ;; just clear the whole thing first and skip all whitespace
+    ;; updates
+    (when clear-to-eos?
+      (move-cursor-to console init-row init-col)
+      (clear-to-eos console))
+
+    (let loop ((x init-col) (y init-row))
+      (let ([prev (or (vector-ref prevbuf (+ x (* y width))) empty)]
+            [cur (or (vector-ref curbuf (+ x (* y width))) empty)])
+        (unless (or (equal? prev cur)
+                    (and clear-to-eos?
+                         (eq? (car cur) #\space)))
+          (move-cursor-to console y x)
+          (putch console (if (pair? cur) (car cur) #\space)))
+        (let ([next-x (+ x 1)]
+              [next-y (+ y 1)])
+          (cond
+           [(and (eq? next-x width)
+                 (eq? next-y height))
+            (move-cursor-to console (~ con'y) (~ con'x))]
+           [(eq? next-x width)
+            (loop 0 next-y)]
+           [else
+            (loop next-x y)]))))
+
+    (vector-copy! (~ con'prev-buffer) 0 (~ con'buffer))))
+
+(define-method clear-to-eos ((con <framebuffer-console>))
+  (vector-fill! (~ con'buffer)
+                '(#\space . #f)
+                (+ (~ con'x) (* (~ con'width) (~ con'y)))))
+
+(define-method cursor-down/scroll-up ((con <framebuffer-console>)
+                                      :optional (y #f) (height #f)
+                                      (full-column-flag #f))
+  ;; FIXME: needs more work here, probably
+  (if (< (~ con'y) (- (~ con'height) 1))
+    (inc! (~ con'y)))
+  ;; copied from text.console.generic, maybe there's a better way?
+  (if (and y height (>= y (- height 1))) 0 1))
+
+(define-method move-cursor-to ((con <framebuffer-console>) y x)
+  (set! (~ con'x) x)
+  (set! (~ con'y) y))
+
+(define-method putch ((con <framebuffer-console>) c)
+  ;; fixme: wide char support
+  (vector-set! (~ con'buffer)
+               (yx->pos con  (~ con'y) (~ con'x))
+               (cons c (~ con'attr)))
+  (inc! (~ con'x)))
+
+(define-method putstr ((con <framebuffer-console>) s)
+  (string-for-each (cut putch con <>) s))
+
+(define-method reset-character-attribute ((con <framebuffer-console>))
+  (set! (~ con'attr) #f))
+
+(define-method set-character-attribute ((con <framebuffer-console>) newattr)
+  (set! (~ con'attr) newattr))

--- a/lib/text/console/framebuffer.scm
+++ b/lib/text/console/framebuffer.scm
@@ -54,7 +54,9 @@
         [width (~ con'width)]
         [height (~ con'height)]
         [clear-to-eos? #f]              ; FIXME
-        [empty (cons #\space #f)])
+        [empty (cons #\space #f)]
+        [rx 0]
+        [ry 0])
 
     (hide-cursor console)
 
@@ -72,8 +74,11 @@
         (unless (or (equal? prev cur)
                     (and clear-to-eos?
                          (eq? (car cur) #\space)))
-          (move-cursor-to console y x)
-          (putch console (if (pair? cur) (car cur) #\space)))
+          (unless (and (= x rx) (= y ry))
+            (move-cursor-to console y x))
+          (putch console (if (pair? cur) (car cur) #\space))
+          (set! rx (+ x 1))
+          (set! ry y))
         (let ([next-x (+ x 1)]
               [next-y (+ y 1)])
           (cond

--- a/lib/text/console/framebuffer.scm
+++ b/lib/text/console/framebuffer.scm
@@ -55,6 +55,7 @@
         [height (~ con'height)]
         [clear-to-eos? #f]              ; FIXME
         [empty (cons #\space #f)]
+        [rattr #f]
         [rx 0]
         [ry 0])
 
@@ -74,6 +75,12 @@
         (unless (or (equal? prev cur)
                     (and clear-to-eos?
                          (eq? (car cur) #\space)))
+          (let ([newattr (if (pair? cur) (cdr cur) #f)])
+            (unless (equal? rattr newattr)
+              (if newattr
+                (set-character-attribute console newattr)
+                (reset-character-attribute console))
+              (set! rattr newattr)))
           (unless (and (= x rx) (= y ry))
             (move-cursor-to console y x))
           (putch console (if (pair? cur) (car cur) #\space))

--- a/lib/text/console/wide-char-setting.scm
+++ b/lib/text/console/wide-char-setting.scm
@@ -1,0 +1,69 @@
+(define-module text.console.wide-char-setting
+  (use gauche.unicode)
+  (export <wide-char-setting> get-char-width))
+(select-module text.console.wide-char-setting)
+
+;; <wide-char-setting>
+;; Initializable slots:
+;;   mode    - specify the mode for determining widths of wide characters.
+;;             If 'Unicode is specified, character widths are determined
+;;             by East Asian Width of Unicode.
+;;             If 'Surrogate is specified, character widths are determined
+;;             by checking surrogate pairs of Unicode.
+;;             If 'Wide is specified, character widths are determined
+;;             by only character codes.
+;;             Otherwise, wide character support is disabled.
+;;   wide-char-width - a width of wide characters.
+;;   surrogate-char-width - a width of surrogate pair characters of Unicode.
+;;   ambiguous-char-width - a width of ambiguous width characters of Unicode.
+;;             To the above 3 slots, specify a multiple of the width of
+;;             half-width characters.
+;;   emoji-char-workaround - if this is not #f, emoji characters are
+;;             treated as wide characters.
+;;
+(define-class <wide-char-setting> ()
+  ((mode :init-keyword :mode :init-value 'Unicode)
+   (wide-char-width :init-keyword :wide-char-width :init-value 2)
+   (surrogate-char-width :init-keyword :surrogate-char-width :init-value 2)
+   (ambiguous-char-width :init-keyword :ambiguous-char-width :init-value 2)
+   (emoji-char-workaround :init-keyword :emoji-char-workaround :init-value #t)
+   ))
+
+;; Get a character width
+(define (get-char-width wide-char-setting ch)
+  (define wide-char-mode        (~ wide-char-setting'mode))
+  (define wide-char-width       (~ wide-char-setting'wide-char-width))
+  (define surrogate-char-width  (~ wide-char-setting'surrogate-char-width))
+  (define ambiguous-char-width  (~ wide-char-setting'ambiguous-char-width))
+  (define emoji-char-workaround (~ wide-char-setting'emoji-char-workaround))
+  (define chcode (char->integer ch))
+  (cond
+   [(<= 0 chcode #x7f)
+    1]
+   [else
+    (cond-expand
+     [gauche.ces.utf8
+      (case wide-char-mode
+        [(Unicode)
+         (if (and emoji-char-workaround
+                  (<= #x1f000 chcode #x1ffff))
+           wide-char-width
+           (case (char-east-asian-width ch)
+             [(A)      ambiguous-char-width]
+             [(F W)    wide-char-width]
+             [(H N Na) 1]
+             [else     ambiguous-char-width]))]
+        [(Surrogate)
+         (if (>= chcode #x10000)
+           surrogate-char-width
+           wide-char-width)]
+        [(Wide)
+         wide-char-width]
+        [else
+         1])]
+     [else
+      (case wide-char-mode
+        [(Unicode Surrogate Wide)
+         wide-char-width]
+        [else
+         1])])]))

--- a/lib/text/line-edit.scm
+++ b/lib/text/line-edit.scm
@@ -279,7 +279,7 @@
     (set! (~ ctx'screen-height) h)
     (set! (~ ctx'screen-width) w)
     (if (~ ctx'framebuffer)
-      (init-framebuffer (~ ctx'framebuffer) w h))))
+      (init-framebuffer (~ ctx'framebuffer) w h (~ ctx'wide-char-pos-setting)))))
 
 ;; Show prompt.  Returns the current column.
 (define (show-prompt ctx)

--- a/lib/text/line-edit.scm
+++ b/lib/text/line-edit.scm
@@ -39,8 +39,8 @@
   (use util.match)
   (use text.console)
   (use text.console.framebuffer)
+  (use text.console.wide-char-setting)
   (use text.gap-buffer)
-  (use gauche.unicode)
   (export <line-edit-context> read-line/edit
           read-line/load-history read-line/save-history)
   )
@@ -48,32 +48,6 @@
 
 (define *kill-ring-size* 60)
 (define *history-size* 200)
-
-;; <wide-char-setting>
-;; Initializable slots:
-;;   mode    - specify the mode for determining widths of wide characters.
-;;             If 'Unicode is specified, character widths are determined
-;;             by East Asian Width of Unicode.
-;;             If 'Surrogate is specified, character widths are determined
-;;             by checking surrogate pairs of Unicode.
-;;             If 'Wide is specified, character widths are determined
-;;             by only character codes.
-;;             Otherwise, wide character support is disabled.
-;;   wide-char-width - a width of wide characters.
-;;   surrogate-char-width - a width of surrogate pair characters of Unicode.
-;;   ambiguous-char-width - a width of ambiguous width characters of Unicode.
-;;             To the above 3 slots, specify a multiple of the width of
-;;             half-width characters.
-;;   emoji-char-workaround - if this is not #f, emoji characters are
-;;             treated as wide characters.
-;;
-(define-class <wide-char-setting> ()
-  ((mode :init-keyword :mode :init-value 'Unicode)
-   (wide-char-width :init-keyword :wide-char-width :init-value 2)
-   (surrogate-char-width :init-keyword :surrogate-char-width :init-value 2)
-   (ambiguous-char-width :init-keyword :ambiguous-char-width :init-value 2)
-   (emoji-char-workaround :init-keyword :emoji-char-workaround :init-value #t)
-   ))
 
 ;; <line-edit-context>
 ;; Initializable slots:
@@ -323,45 +297,6 @@
 (define (get-tab-char-width ctx x w)
   (define tab-char-width (~ ctx'tab-char-width))
   (min (- w x) (- tab-char-width (modulo x tab-char-width))))
-
-;; Get a character width
-(define (get-char-width wide-char-setting ch)
-  (define wide-char-mode        (~ wide-char-setting'mode))
-  (define wide-char-width       (~ wide-char-setting'wide-char-width))
-  (define surrogate-char-width  (~ wide-char-setting'surrogate-char-width))
-  (define ambiguous-char-width  (~ wide-char-setting'ambiguous-char-width))
-  (define emoji-char-workaround (~ wide-char-setting'emoji-char-workaround))
-  (define chcode (char->integer ch))
-  (cond
-   [(<= 0 chcode #x7f)
-    1]
-   [else
-    (cond-expand
-     [gauche.ces.utf8
-      (case wide-char-mode
-        [(Unicode)
-         (if (and emoji-char-workaround
-                  (<= #x1f000 chcode #x1ffff))
-           wide-char-width
-           (case (char-east-asian-width ch)
-             [(A)      ambiguous-char-width]
-             [(F W)    wide-char-width]
-             [(H N Na) 1]
-             [else     ambiguous-char-width]))]
-        [(Surrogate)
-         (if (>= chcode #x10000)
-           surrogate-char-width
-           wide-char-width)]
-        [(Wide)
-         wide-char-width]
-        [else
-         1])]
-     [else
-      (case wide-char-mode
-        [(Unicode Surrogate Wide)
-         wide-char-width]
-        [else
-         1])])]))
 
 (define (redisplay ctx buffer)
   (if (~ ctx'framebuffer)

--- a/lib/text/line-edit.scm
+++ b/lib/text/line-edit.scm
@@ -85,7 +85,8 @@
    (initpos-x)
    (screen-height)
    (screen-width)
-   (framebuffer :init-value #f) ; :init-form (make <framebuffer-console>)
+   (framebuffer :init-form (and (sys-getenv "GAUCHE_READ_EDIT_WITH_FB")
+                                (make <framebuffer-console>)))
 
    ;; Selection
    ;; selection is between marker-pos and the current cursor pos.


### PR DESCRIPTION
This is a preliminary work to keep all console updates in memory, then
display to a real console in the end. Because the last display is kept,
only damaged positions in the console will be redisplayed this
time. This reduces the flicker caused by clear-to-eos at the beginnning
of each redisplay in line-edit.

The entire code is currently disabled. It's not ready for use
yet. Remaining work includes:

- wide character support
- cursor-down/scroll-up handling (and optimizing too if possible)
- cursor-up/scroll-down handling (if detected somehow)
- clear-to-eos optimization (e.g. M-< C-k or something like that)
- perhaps avoid vectors of conses to reduce GC pressure a bit

Part of #665