### PR TITLE
line-edit: hide cursor during redisplay

### DIFF
--- a/lib/text/line-edit.scm
+++ b/lib/text/line-edit.scm
@@ -407,6 +407,7 @@
          [else
           (inc! y)])))
 
+    (hide-cursor con)
     (reset-character-attribute con)
     (move-cursor-to con y 0)
     (show-prompt ctx)
@@ -457,7 +458,8 @@
           (set! pos-y y))
 
         (loop (+ n 1))))
-    (move-cursor-to con pos-y pos-x)))
+    (move-cursor-to con pos-y pos-x)
+    (show-cursor con)))
 
 (define (current-char-attr pos sel oparen)
   (cond-list


### PR DESCRIPTION
Suggested by Lassi Kortela. Since our update involves moving the cursor
around a lot, it's a good idea to hide it at the beginning, do our stuff
then show it in the end.