### PR TITLE
Fix close-paren typo in tree-map object-equal?

### DIFF
--- a/lib/gauche/treeutil.scm
+++ b/lib/gauche/treeutil.scm
@@ -200,5 +200,5 @@
   (tree-map-compare-as-sequences a b))
 
 (define-method object-equal? ((a <tree-map>) (b <tree-map>))
-  (= (tree-map-compare-as-sequences a b)) 0)
+  (= (tree-map-compare-as-sequences a b) 0))
 


### PR DESCRIPTION
The `=` call in `<tree-map>`'s `object-equal?` has only one argument due to a typo. Testing tree maps for equality will always fail. This change fixes the typo.