### PR TITLE
Stop conversion of enter key input on Windows

### DIFF
--- a/ext/termios/termios.scm
+++ b/ext/termios/termios.scm
@@ -268,9 +268,9 @@
          (define saved-buffering (port-buffering port))
          (define new-attr
            (case mode
-             [(raw)    "-echo -icanon -iexten -isig"]
-             [(rare)   "-echo -icanon -iexten  isig"]
-             [(cooked) " echo  icanon  iexten  isig"]
+             [(raw)    "-echo -icanon -iexten -isig -icrnl"]
+             [(rare)   "-echo -icanon -iexten  isig -icrnl"]
+             [(cooked) " echo  icanon  iexten  isig  icrnl"]
              [else
               (error "terminal mode needs to be one of cooked, rare or raw, \
                       but got:" mode)]))

--- a/lib/text/console/windows.scm
+++ b/lib/text/console/windows.scm
@@ -148,9 +148,6 @@
       (enqueue! (~ con'keybuf) `(ALT ,(integer->char ch)))]
      [(logtest ctls CTRL_PRESSED)
       (enqueue! (~ con'keybuf) (get-ctrl-char vk))]
-     [(eqv? ch #x0a)] ; drop a newline character
-     [(eqv? ch #x0d)  ; convert a return character to a newline character
-      (enqueue! (~ con'keybuf) #\x0a)]
      [else
       (enqueue! (~ con'keybuf) (integer->char ch))]))
   (dolist [ks (win-keystate)]


### PR DESCRIPTION
Windows 上で、環境変数 GAUCHE_READ_EDIT を設定した場合に、
Enter キーを入力すると、
#\return を #\newline に変換してしまっていたため、
変換しないように修正しました。

(当時は、変換するものだと思い込んでいました。
最近、C-j と Enter キーを使い分けるように設定が変わったため、
Enter キーで評価できなくなっていました。)

```
Linux
  Enter : #\return
  C-j   : #\newline
  C-m   : #\return

cmd.exe (ConEmu)
  Enter : #\newline ==> #\return
  C-j   : #\newline
  C-m   : #\return

mintty
  Enter : #\newline ==> #\return
  C-j   : #\newline
  C-m   : #\newline ==> #\return
```
