### PR TITLE
Don't check full apply's argument list if possible

### DIFF
--- a/src/vmcall.c
+++ b/src/vmcall.c
@@ -71,11 +71,11 @@
 #else /*APPLY_CALL*/
 #define ADJUST_ARGUMENT_FRAME(proc, argc)                               \
     do {                                                                \
-        int rargc = check_arglist_tail_for_apply(vm, *(vm->sp - 1));    \
         ScmObj p, a;                                                    \
         int reqargs = SCM_PROCEDURE_REQUIRED(proc);                     \
         int optargs = SCM_PROCEDURE_OPTIONAL(proc);                     \
         if (optargs) {                                                  \
+            int rargc = check_arglist_tail_for_apply(vm, *(vm->sp - 1), -1); \
             if ((rargc+argc-1) < reqargs) {                             \
                 wna(vm, VAL0, rargc+argc-1, rargc); RETURN_OP(); NEXT;  \
             }                                                           \
@@ -102,7 +102,12 @@
             }                                                           \
         } else {                                                        \
             /* no optargs */                                            \
+            int max_rargc = reqargs-argc+1+1;                           \
+            int rargc = check_arglist_tail_for_apply(vm, *(vm->sp - 1), max_rargc); \
             if ((rargc+argc-1) != reqargs) {                            \
+                if (rargc >= max_rargc) {                               \
+                    rargc = check_arglist_tail_for_apply(vm, *(vm->sp - 1), -1); \
+                }                                                       \
                 wna(vm, VAL0, rargc+argc-1, rargc); RETURN_OP(); NEXT;  \
             }                                                           \
             POP_ARG(p);  /* tail of arglist */                          \

--- a/src/vminsn.scm
+++ b/src/vminsn.scm
@@ -1055,10 +1055,10 @@
   ;;   ARGP>| arg0 |        VAL0=proc
   ;;        | proc |< original ARGP postiion (proc unused) 
   (let* ([rest VAL0]
-         [rargc::int (check_arglist_tail_for_apply vm rest)]
+         ;; we only check rargc <= 0, so set max limit to 1
+         [rargc::int (check_arglist_tail_for_apply vm rest 1)]
          [nargc::int (- (SCM_VM_INSN_ARG code) 2)]
          [proc (* (- SP nargc 1))])
-    (when (< rargc 0) ($vm-err "improper list not allowed: %S" rest))
     (set! VAL0 proc)
     (post++ ARGP)
     ;; a micro-optimization: if VAL0 is (), we just omit it and


### PR DESCRIPTION
The function check_arglist_tail_for_apply() goes to the end of the list
to determine the length, and whether it's circular. In many cases we
don't really need to know its full length, just whether it's above a
certain limit.

Make the function accept an upper limit and terminate early in these
cases. We could be a bit faster in the pathological case where we know
in advance how many number a procedure may take and we have to handle a
list of a zillion elements.

In one case where we have to unpack the entire argument list, there will
be no upper limit.

This could be the first step to fixing issue #686 too.