### PR TITLE
Improve mintty-pager (cursor key, etc.)

### DIFF
--- a/libsrc/text/console.scm
+++ b/libsrc/text/console.scm
@@ -222,8 +222,8 @@
     [(#\[ #\H)         . KEY_HOME]
     [(#\[ #\2 #\~)     . KEY_INS]
     [(#\[ #\3 #\~)     . KEY_DEL]
-    [(#\[ #\5 #\~)     . KEY_PGDN]
-    [(#\[ #\6 #\~)     . KEY_PGUP]
+    [(#\[ #\6 #\~)     . KEY_PGDN]
+    [(#\[ #\5 #\~)     . KEY_PGUP]
     [(#\O #\P)         . KEY_F1]  ; original vt100
     [(#\O #\Q)         . KEY_F2]
     [(#\O #\R)         . KEY_F3]


### PR DESCRIPTION
mintty-pager の変更を行いました。

(1) カーソルキー等でスクロールできるようにしました。
    (キーの割り当ては、less を参考にしました)

(2) Page down, Page up キーの割り当てが逆になっていたため、
    console.scm の割り当てを直しました。

(3) [q] キーで抜けることを表示するようにしました。

(4) 終了時にカーソル位置を指定するようにしました。
    (自分の環境では、微妙な位置に移動していたため)
