### PR TITLE
Remove partHandlers from escape point structure (ScmEscapePoint)

### DIFF
--- a/src/gauche/priv/vmP.h
+++ b/src/gauche/priv/vmP.h
@@ -80,7 +80,9 @@ typedef struct ScmEscapePointRec {
     struct ScmEscapePointRec *floating;
     ScmObj ehandler;            /* handler closure */
     ScmContFrame *cont;         /* saved continuation */
-    ScmObj handlers;            /* saved dynamic handler chain */
+    ScmObj handlers;            /* saved dynamic handler chain
+                                   NB: for partial continuation, partial
+                                   dynamic handler chain is saved. */
     ScmCStack *cstack;          /* vm->cstack when escape point is created.
                                    this will be used to rewind cstack.
                                    this is NULL for partial continuations,
@@ -88,7 +90,6 @@ typedef struct ScmEscapePointRec {
                                    w.r.t. cstack. */
     ScmObj xhandler;            /* saved exception handler */
     ScmObj resetChain;          /* for reset/shift */
-    ScmObj partHandlers;        /* for reset/shift */
     int errorReporting;         /* state of SCM_VM_ERROR_REPORTING flag
                                    when this ep is captured.  The flag status
                                    should be restored when the control

--- a/src/gauche/vm.h
+++ b/src/gauche/vm.h
@@ -472,7 +472,7 @@ struct ScmVMRec {
     /* for reset/shift */
     ScmObj resetChain;          /* list of reset information,
                                    where reset information is
-                                   (delimited . <dynamic handlers chain>).
+                                   (delimited . <dynamic handler chain>).
                                    the delimited flag is set when 'shift'
                                    appears in 'reset' and the end marker of
                                    partial continuation is set. */


### PR DESCRIPTION
#696 で、部分継続については、
ep->handlers に (フルの) 動的環境のハンドラチェーン を格納しないようにしましたが、
今回、そこに 切り取った動的環境のハンドラチェーン を格納するようにしました。

これによって、ep->partHandlers が不要になったため削除しました。

その他、コメント等少し見直ししました。

＜テスト結果＞
(1) https://github.com/Hamayama/Gauche/actions/runs/134266178

(2) [Gauche-effects](https://github.com/Hamayama/Gauche-effects) の effects.scm で、
    `*use-native-reset*` を #t にして、各サンプルを実行 ==> OK

(3) 以下のリークテスト ==> OK
( http://okmij.org/ftp/continuations/against-callcc.html#memory-leak )
```
(use gauche.partcont)
(define (leak-test1 identity-thunk)
  (let loop ((id (lambda (x) x)))
    (loop (id (identity-thunk)))))
(leak-test1 (lambda () (reset (shift k k))))
```

(4) 以下のリークテスト ==> OK
pcdemo3.scm ( https://gist.github.com/nkoguro/7fd58e919c0ae0050280e874ab22ddf2 )

(5) Kahua の nqueen を実行 ==> OK

(関連プルリクエスト #696)
