### PR TITLE
Use msys2/setup-msys2 to update MSYS2 in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,6 +117,13 @@ jobs:
     steps:
     - run: git config --global core.autocrlf false
     - uses: actions/checkout@v2
+    - uses: msys2/setup-msys2@v1
+      with:
+        msystem: MINGW${{ matrix.bit }}
+        path-type: inherit
+        release: false
+        update: true
+        cache: true
     - name: Add MSYS2 path
       run: |
         echo "::set-env name=PATH::$env:MSYS2_PATH_LIST;$env:PATH"
@@ -127,12 +134,6 @@ jobs:
           cd $GITHUB_WORKSPACE
           pwd
           echo $PATH
-        '@
-    - name: Update MSYS2
-      run: |
-        bash -lc @'
-          pacman --version
-          pacman -Syyuu --noconfirm
         '@
     - name: Install Gauche
       run: |


### PR DESCRIPTION
Github Actions の MSYS2 の更新を、
msys2/setup-msys2 ( https://github.com/msys2/setup-msys2 ) という、
最近公式になった action で行うようにしました。

action の設定で `release: false` と指定すると、
既に Windows の image に入っている MSYS2 を更新してくれます。

＜テスト結果＞
https://github.com/Hamayama/Gauche/actions/runs/149486929

＜関連プルリクエスト＞
https://github.com/shirok/Gauche/pull/699
