### PR TITLE
Reduce MSYS2 installation time in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,7 +108,7 @@ jobs:
     env:
       MSYSTEM: MINGW${{ matrix.bit }}
       MSYS2_PATH_TYPE: inherit
-      MSYS2_PATH_LIST: C:\msys64\mingw${{ matrix.bit }}\bin;C:\msys64\usr\local\bin;C:\msys64\usr\bin;C:\msys64\bin
+      MSYS2_PATH_LIST: ___\msys64\mingw${{ matrix.bit }}\bin;___\msys64\usr\local\bin;___\msys64\usr\bin;___\msys64\bin
       GAUCHE_VERSION_URL: https://practical-scheme.net/gauche/releases/latest.txt
       GAUCHE_INSTALLER_URL: https://prdownloads.sourceforge.net/gauche
       GAUCHE_PATH: ${{ matrix.devtool_path }}\Gauche\bin
@@ -117,15 +117,16 @@ jobs:
     steps:
     - run: git config --global core.autocrlf false
     - uses: actions/checkout@v2
-    - uses: msys2/setup-msys2@v1
+    - uses: msys2/setup-msys2@v2
       with:
         msystem: MINGW${{ matrix.bit }}
         path-type: inherit
-        release: false
+        release: true
         update: true
-        cache: true
+        install: 'base-devel mingw-w64-${{ matrix.arch }}-toolchain'
     - name: Add MSYS2 path
       run: |
+        $env:MSYS2_PATH_LIST=$env:MSYS2_PATH_LIST.replace('___', "$env:RUNNER_TEMP\msys")
         echo "::set-env name=PATH::$env:MSYS2_PATH_LIST;$env:PATH"
     - name: Run MSYS2 once
       run: |


### PR DESCRIPTION
- 最近、GitHub Actions の MSYS2 のインストールに時間がかかっていたため、
  見直しを行いました。

- 原因は、Windows の image に含まれている MSYS2 のパッケージが多いために、
  update に時間がかかっているようでした。
  (64-bit 版のビルドをする場合に、32-bit 版の gcc も更新していたり、
  また、clang や llvm 等の更新も行っているようです。
  (資源の節約になるはずが、逆効果になるとは。。。))

- 仕方がないので、image 内のものを使うのを止めて、
  必要な分をインストールして使うようにしました。

- 変更は、msys2/setup-msys2 ( https://github.com/msys2/setup-msys2 )
  の設定で対応できました。
  (release: を true にすると、image を使わなくなります。
  (このとき、インストールパスが $RUNNER_TEMP/msys/msys64
  (実体は D:/a/_temp/msys/msys64 ) に変わってしまいますが、
  これは変えられないようです))

- MSYS2 のインストール時間を、20分 → 3分 程度に短縮できました。

＜テスト結果＞
https://github.com/Hamayama/Gauche/actions/runs/183148687

＜関連プルリクエスト＞
https://github.com/shirok/Gauche/pull/702
