### PR TITLE
Update SRFI 193 to match last-call draft

### DIFF
--- a/lib/srfi-193.scm
+++ b/lib/srfi-193.scm
@@ -3,39 +3,25 @@
 ;;
 
 (define-module srfi-193
-  (use srfi-13)
   (use file.util)
-  (export os-executable-file os-command-line 
-          command-name command-args command-line 
-          script-file script-directory
-          ;; filename->command-name
-          )
-  )
+  (export command-line command-name command-args
+          script-file script-directory))
 (select-module srfi-193)
 
 ;; utility
 (define (filename->command-name path)
   (cond-expand
-   [gauche.os.windes 
+   [gauche.os.windes
     (regexp-replace #/\.(exe|scm)$/ (sys-basename path) "")]
    [else
     (regexp-replace #/\.scm$/ (sys-basename path) "")]))
 
 ;;; Fundamental
 
-;; can be #f if we can't obtain the info
-(define (os-executable-file)
-  ((with-module gauche.internal %gauche-executable-path)))
-
-;; os-command-line : Built-in
 ;; command-line : Built-in
 ;; script-file : Built-in
 
 ;;; Derived
-
-(define (script-directory)
-  (and-let1 sf (script-file)
-    (string-append (sys-dirname sf) (string (path-separator)))))
 
 (define (command-name)
   (let1 arg0 (car (command-line))
@@ -45,4 +31,6 @@
 (define (command-args)
   (cdr (command-line)))
 
-
+(define (script-directory)
+  (and-let1 sf (script-file)
+    (string-append (sys-dirname sf) (string (path-separator)))))

--- a/src/srfis.scm
+++ b/src/srfis.scm
@@ -1295,3 +1295,12 @@ Supported by the module @code{srfi-189}.
 
 MaybeとEither: オプショナルなコンテナ型
 モジュール@code{srfi-189}でサポートされます。
+
+
+srfi-193, srfi-193
+()
+
+Command lines
+Supported by the module @code{srfi-193}.
+
+Command lines


### PR DESCRIPTION
- filename->command-name was not exported in the SRFI.

- os-executable-file and os-command-line were in Draft 1 of the SRFI,
  but are removed in the new draft since they are not as easy to use
  reliably as was previously thought. They should re-appear in a new
  low-level SRFI.

We're just polishing the last-call draft with Arthur; it should be out very soon.