### PR TITLE
Fix assertion failed in the combination of reset/shift and guard

### DIFF
--- a/test/dynwind.scm
+++ b/test/dynwind.scm
@@ -727,6 +727,25 @@
               (reset (error "[E02]"))
               (display "[E03]"))))))
 
+(test* "reset/shift + guard 1"
+       "[W01][D01][D02][W01][D01][D01][E01][D02][D02]"
+       (with-output-to-string
+         (^[]
+           (define queue '())
+           (define (yield) (shift k (push! queue k)))
+           (push! queue (lambda ()
+                          (guard (e (else (display (~ e 'message))))
+                            (yield)
+                            (error "[E01]"))))
+           (while (and (pair? queue) (pop! queue))
+             => next
+             (display "[W01]")
+             (reset
+              (dynamic-wind
+               (lambda () (display "[D01]"))
+               next
+               (lambda () (display "[D02]"))))))))
+
 (test* "dynamic-wind + reset/shift 1"
        "[d01][d02][d03][d04]"
        ;"[d01][d02][d04][d01][d03][d04]"


### PR DESCRIPTION
- pcdemo8.scm ( https://gist.github.com/nkoguro/bcb23f9a1913cfced2817680d3fcfb46 )
  が、Gauche 0.9.9 で Assertion failed になる件の修正になります。
  (chaton のログ : http://chaton.practical-scheme.net/gauche/a/2020/06/14 )

- 内容としては、src/vm.c の Scm_VMDefaultExceptionHandler 関数において、
  元々は (フル継続のみであれば) 外側への脱出についてのみ考慮していればよかったものが、
  (部分継続との組み合わせによって) そうでないパターンが見つかった というものです。

- ただ、これで、Assertion failed については 発生しなくなりましたが、
  フル継続と部分継続を組み合わせて うまく使えるようになったかというと、
  まだ難しいところがあります。
  (例えば、以下のページの既知の問題点の件 等
  https://practical-scheme.net/wiliki/wiliki.cgi?Gauche%3A%E9%83%A8%E5%88%86%E7%B6%99%E7%B6%9A%E3%81%A8%E5%8B%95%E7%9A%84%E7%92%B0%E5%A2%83%E3%81%AE%E5%AE%9F%E9%A8%93 )
  これについては、今後の課題という感じです。。。

＜テスト結果＞
(1) https://github.com/Hamayama/Gauche/actions/runs/209724800

(2) [Gauche-effects](https://github.com/Hamayama/Gauche-effects) の effects.scm で、
    `*use-native-reset*` を #t にして、各サンプルを実行 ==> OK

(3) 以下のリークテスト ==> OK
(出典 : http://okmij.org/ftp/continuations/against-callcc.html#memory-leak )
```
(use gauche.partcont)
(define (leak-test1 identity-thunk)
  (let loop ((id (lambda (x) x)))
    (loop (id (identity-thunk)))))
(leak-test1 (lambda () (reset (shift k k))))
```

(4) Kahua の nqueen を実行 ==> OK

(関連プルリクエスト #696)
