### PR TITLE
line-edit: interpret #\newline as C-m

### DIFF
--- a/libsrc/text/line-edit.scm
+++ b/libsrc/text/line-edit.scm
@@ -1313,6 +1313,8 @@
 (define-key *default-keymap* (ctrl #\k) kill-line)
 (define-key *default-keymap* (ctrl #\l) refresh-display)
 (define-key *default-keymap* (ctrl #\m) commit-or-newline) ; return
+;; ; return after being put in background and back in foreground
+(define-key *default-keymap* #\newline commit-or-newline)
 (define-key *default-keymap* (ctrl #\n) next-line-or-history)
 ;;(define-key *default-keymap* (ctrl #\o) undefined-command)
 (define-key *default-keymap* (ctrl #\p) prev-line-or-history)


### PR DESCRIPTION
How abouto this (for the "enter" part in #715), a bit hacky...

When line-edit is running normally, the tty is configured so that we should get C-m instead of #\newline.  However if the command prompt is put in background then back in foreground, the tty settings are lost.

It looks like from now on we get #\newline instead when Enter is pressed. So if we catch this, consider it the same as C-m. If we manage to commit the expression, the tty should be reset the next time the command prompt is ready to accept new input.

If the expression is incomplete, one can only hope the user will end up typing either Ctrl-C or Ctrl-D. Either way the prompt is finished and the next prompt resets the tty.

PS. We probably could take the hint that #\newline means the tty is screwed and reset the tty now (since Enter is one of the most obvious keys to type when you're not seeing anything). But that might have unseen consequences.

Related to issue #715