### PR TITLE
Fixed an error in source-location

### DIFF
--- a/lib/gauche/procedure.scm
+++ b/lib/gauche/procedure.scm
@@ -196,7 +196,8 @@
     (and (pair? x)
          ($ (with-module gauche.internal pair-attribute-get)
             x 'source-info #f)))
-  (or (extract (~ proc'info))
+  (or (and (slot-exists? proc 'info)
+           (extract (~ proc'info)))
       (extract (source-code proc))))
 
 ;; disassembler ------------------------------------------------


### PR DESCRIPTION
```
% gosh -V
Gauche scheme shell, version 0.9.9 [utf-8,pthreads], x86_64-apple-darwin19.2.0
% gosh
gosh> (use gauche.sequence)
gosh> (source-location group-sequence)
*** ERROR: object of class #<class <generic>> doesn't have such slot: info
```

Calling `source-location` may result in an error.
This seems to be caused by accessing an non-existent slot `info`.
As a workaround, we now check for the existence of the slot before accessing it.