### PR TITLE
Change environment variable setting in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
         ./get-gauche.sh --auto --home
     - name: Add Gauche path
       run: |
-        echo "::set-env name=PATH::$HOME/bin:$PATH"
+        echo "PATH=$HOME/bin:$PATH" >> $GITHUB_ENV
     - name: Run Gauche once
       run: |
         gosh -V
@@ -67,7 +67,7 @@ jobs:
         ./get-gauche.sh --auto --home
     - name: Add Gauche path
       run: |
-        echo "::set-env name=PATH::$HOME/bin:$PATH"
+        echo "PATH=$HOME/bin:$PATH" >> $GITHUB_ENV
     - name: Run Gauche once
       run: |
         gosh -V
@@ -140,7 +140,7 @@ jobs:
         cmd.exe //c "start /wait msiexec /a $GAUCHE_INSTALLER /quiet /qn /norestart TARGETDIR=${{ matrix.devtool_path }}"
     - name: Add Gauche path
       run: |
-        echo "::set-env name=PATH::$env:GAUCHE_PATH;$env:PATH"
+        echo "PATH=$env:GAUCHE_PATH;$env:PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
     - name: Run Gauche once
       shell: msys2 {0}
       run: |


### PR DESCRIPTION
GitHub Actions で、環境変数の更新方法が変わったようで、
実行結果に warning が表示されるようになったため、対応しました。

( ::set-env コマンドが deprecated になって、
環境変数ファイル ($GITHUB_ENV) に "NAME=VALUE" という形式で文字列を追記すると、
環境変数が更新されるようになりました。(セキュリティ関連の変更?))

＜参考URL＞
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

＜テスト結果＞
https://github.com/Hamayama/Gauche/actions/runs/300033478
