### PR TITLE
Write newline after Ctrl+D in REPL

### DIFF
--- a/src/libeval.scm
+++ b/src/libeval.scm
@@ -444,10 +444,11 @@
            (let loop2 ()
              (prompter)
              (let1 exp (reader)
-               (and (not (eof-object? exp))
-                    (receive results (evaluator exp (vm-current-module))
-                      (apply printer results)
-                      (loop2)))))))
+               (if (eof-object? exp)
+                 (begin (newline) #f)
+                 (receive results (evaluator exp (vm-current-module))
+                   (apply printer results)
+                   (loop2)))))))
        (loop1)))))
 
 ;;;


### PR DESCRIPTION
Implements #728

When gosh is exited via `(exit)` or Ctrl+D, the Unix shell prompt will now start on a fresh line in both cases.