### PR TITLE
Fix mbedtls-internal on Windows

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -867,12 +867,13 @@ m4_include([ext/zlib/zlib.ac])
 m4_include([ext/tls/tls.ac])
 
 dnl Setup STATIC_LIBS
-STATIC_LIBS=
-for lib in $EXT_LIBS $LIBS; do
-  AS_IF([ echo "${STATIC_LIBS}" | grep -F -w -e "${lib}" > /dev/null 2>&1 ],
-        [], dnl lib is alreay in STATIC_LIBS.  do nothing
-        [STATIC_LIBS="$STATIC_LIBS $lib"])
-done
+#STATIC_LIBS=
+#for lib in $EXT_LIBS $LIBS; do
+#  AS_IF([ echo "${STATIC_LIBS}" | grep -F -w -e "${lib}" > /dev/null 2>&1 ],
+#        [], dnl lib is alreay in STATIC_LIBS.  do nothing
+#        [STATIC_LIBS="$STATIC_LIBS $lib"])
+#done
+STATIC_LIBS="$EXT_LIBS $LIBS"
 STATIC_LIBS="`echo $LIBGAUCHE_STATIC | sed s/^lib/-l/` $STATIC_LIBS"
 AC_SUBST(STATIC_LIBS)
 

--- a/ext/tls/tls.ac
+++ b/ext/tls/tls.ac
@@ -56,6 +56,12 @@ AS_CASE([$tls],
               MBEDTLS_LDFLAGS="-L ../../tools/tls"
               GAUCHE_TLS_SWITCH_MBEDTLS_INTERNAL_yes=
               GAUCHE_TLS_SWITCH_MBEDTLS_INTERNAL_no="@%:@"
+              AS_CASE([$host],
+                [*mingw*], [
+                  AS_IF([cmake -G 2>&1 | grep -q 'MSYS Makefiles'], [
+                    MBEDTLS_CMAKE_OPTIONS="-G'MSYS Makefiles'"
+                  ])
+                ])
             ])],
            [
             AC_MSG_ERROR([Invalid ---with-tls choice; it must be comma-separated
@@ -138,6 +144,7 @@ AS_IF([echo $TLSLIBS | grep -F -w -q mbedtls], [
       AC_DEFINE(GAUCHE_USE_MBEDTLS, 1, [Define if you use mbed TLS])
       AC_SUBST(MBEDTLS_CFLAGS)
       AC_SUBST(MBEDTLS_LIBS)
+      AC_SUBST(MBEDTLS_CMAKE_OPTIONS)
       GAUCHE_TLS_TYPES="mbedtls $GAUCHE_TLS_TYPES"
       GAUCHE_TLS_SWITCH_MBEDTLS=
       GAUCHE_TLS_SWITCH_NONE="@%:@"

--- a/tools/tls/Makefile.in
+++ b/tools/tls/Makefile.in
@@ -30,7 +30,11 @@ include/mbedtls: libmbedtls.a
 $(MBEDTLS_LIBS_XTRA) : libmbedtls.a
 
 libmbedtls.a: mbedtls-$(MBEDTLS_VERSION)
-	cd mbedtls-$(MBEDTLS_VERSION) && cmake . && make -f CMakeFiles/Makefile2 library/all && cd library && cp $(MBEDTLS_LIBS) ../..
+	cd mbedtls-$(MBEDTLS_VERSION)                \
+	 && cmake @MBEDTLS_CMAKE_OPTIONS@ .          \
+	 && make -f CMakeFiles/Makefile2 library/all \
+	 && cd library                               \
+	 && cp $(MBEDTLS_LIBS) ../..
 
 mbedtls-$(MBEDTLS_VERSION): v$(MBEDTLS_VERSION).tgz
 	tar xzvf v$(MBEDTLS_VERSION).tgz


### PR DESCRIPTION
configure オプションの --with-tls=mbedtls-internal の処理について、
以下の変更を行いました。

1. MinGW のとき、cmake のオプションに -G'MSYS Makefiles' を追加
   Windows 用の cmake には、いくつか種類があるようです。
   (1) MSYS2 パッケージの cmake
   (2) MSYS2 パッケージの mingw-w64-{x86_64|i686}-cmake
   (3) Windowsのインストーラで配布されている cmake
   それで、(2) と (3) については、
   デフォルトのジェネレータ指定が MS の nmake になっており、
   cmake のオプションに -G'MSYS Makefiles' を指定する必要がありました。
   (指定しないとエラーになる)
   一方 (1) については、オプションが不要で、
   逆に -G'MSYS Makefiles' を指定するとエラーになりました。
   このため、cmake -G の出力結果によって、
   オプションを指定する/しないを変えるようにしました。

2. static link executable のテストでエラー
   configure.ac の STATIC_LIBS を生成する処理で、
   重複するライブラリは追加しないようになっていました。
   このため、-lws2_32 が -lmbedtls より後に必要だったものが、
   前方に -lws2_32 があったために追加されず、
   結果として以下の socket 関連のリンクエラーが発生していました。
   このため、重複のチェックをやめるように変更しました。

```
Testing utility scripts ...
C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/10.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: ../../tools/tls/libmbedtls.a(net_sockets.c.obj):net_sockets.c:(.text+0x145): undefined reference to `__imp_socket'
C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/10.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: ../../tools/tls/libmbedtls.a(net_sockets.c.obj):net_sockets.c:(.text+0x2cf): undefined reference to `__imp_socket'
C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/10.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: ../../tools/tls/libmbedtls.a(net_sockets.c.obj):net_sockets.c:(.text+0x421): undefined reference to `__imp_WSAGetLastError'
C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/10.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: ../../tools/tls/libmbedtls.a(net_sockets.c.obj):net_sockets.c:(.text+0x56d): undefined reference to `__imp_WSAGetLastError'
C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/10.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: ../../tools/tls/libmbedtls.a(net_sockets.c.obj):net_sockets.c:(.text+0x657): undefined reference to `__imp_socket'
C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/10.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: ../../tools/tls/libmbedtls.a(net_sockets.c.obj):net_sockets.c:(.text+0x7ef): undefined reference to `__imp_ioctlsocket'
C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/10.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: ../../tools/tls/libmbedtls.a(net_sockets.c.obj):net_sockets.c:(.text+0x828): undefined reference to `__imp_ioctlsocket'
C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/10.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: ../../tools/tls/libmbedtls.a(net_sockets.c.obj):net_sockets.c:(.text+0xb6b): undefined reference to `__imp_WSAGetLastError'
C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/10.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: ../../tools/tls/libmbedtls.a(net_sockets.c.obj):net_sockets.c:(.text+0xd02): undefined reference to `__imp_WSAGetLastError'
C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/10.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: ../../tools/tls/libmbedtls.a(net_sockets.c.obj):net_sockets.c:(.text+0xdbb): undefined reference to `__imp_WSAGetLastError'
collect2.exe: error: ld returned 1 exit status
failed.
discrepancies found.  Errors are:
test static link executable: expects "ARGS: (A b CdE)" => got #<<system-error> "cannot find program 'test.o/staticmain': The system cannot find the file specified.\r\n(error code = 2)">
```

＜テスト結果＞

(1) make check
Total: 30363 tests, 30363 passed,     0 failed,     0 aborted.

(2) TLS通信の確認 → 200 OK
```
;(use rfc.tls)
;(default-tls-class <mbed-tls>)
;; https://curl.haxx.se/ca/cacert.pem
;(tls-ca-bundle-path "c:\\work\\ca\\cacert.pem")
(use rfc.http)
(receive (status header-list body)
    (http-get "syosetu.org" "/" :secure #t)
  (print status))
```

(3)依存ファイルの確認 → OK
libmbedtls.dll      - 依存なし
libmbedx509.dll     - 依存なし
libmbedcrypto.dll   - 依存なし
libwinpthread-1.dll - 依存なし
libgcc_s_seh-1.dll  - 依存なし
