### PR TITLE
Fix gauche.pputil shorthand handling

### DIFF
--- a/test/io2.scm
+++ b/test/io2.scm
@@ -715,6 +715,12 @@
        (call-with-output-string
          (cut pprint ''(,@(the quick brown fox jumps over the ,@lazy dog))
               :port <> :width 25)))
+(test* "shorthand notation" (test-none-of)
+       (call-with-output-string
+         (cut pprint `(,((with-module gauche.internal make-identifier)
+                         'quote (current-module) '())
+                       foo)
+              :port <>)))
 
 ;;===============================================================
 ;; utf-8 with BOM


### PR DESCRIPTION
quote等がリネームされているものを `pprint` しようとするとエラーになるので、修正案です。
```
gosh> (macroexpand '(define-record-type foo #f #f) #t)
*** ERROR: string required, but got #f
```

`match` でシンボルと比較すると `equal?` が使われるので、`memq` の方に揃えて括り出しました。