### PR TITLE
typeutilの細かい修正と <method> の適用可能性

### DIFF
--- a/lib/gauche/typeutil.scm
+++ b/lib/gauche/typeutil.scm
@@ -166,7 +166,6 @@
   (if (eq? (~ type'arguments) '*)
     (or (is-a? obj <procedure>)
         (is-a? obj <generic>)
-        (is-a? obj <method>)
         (let1 k (class-of obj)
           (let loop ([ms (~ object-apply'methods)])
             (cond [(null? ms) #f]

--- a/lib/gauche/typeutil.scm
+++ b/lib/gauche/typeutil.scm
@@ -108,7 +108,7 @@
 
 ;;;
 ;;; Class: <^>  (maybe we want to name it <λ>)
-;;;   Creates a function type.
+;;;   Creates a procedure type.
 ;;;   The signature can be specified as
 ;;;
 ;;;       <argtype1> <argtype2> ... :- <rettype1> <rettype2> ...
@@ -148,7 +148,7 @@
           [(and (null? rs) (eq? (car xs) '*) (null? (cdr xs)))
            (values args '*)]
           [(is-a? (car xs) <class>) 
-           (scan-results (cdr xs) args (cons (car xs) as))]
+           (scan-results (cdr xs) args (cons (car xs) rs))]
           [else
            (error "Non-class argument in the procedure type constructor:"
                   (car xs))]))

--- a/src/libproc.scm
+++ b/src/libproc.scm
@@ -221,7 +221,6 @@
                 nargs (slot-ref proc 'required))))]
           [(eq? c <generic>)
            (any (^m (apply method-applicable? m arg-types)) (~ proc'methods))]
-          [(eq? c <method>)  (apply method-applicable? m arg-types)]
           [else (apply applicable? object-apply c arg-types)])))
 
 (select-module gauche.internal)


### PR DESCRIPTION
一つ目のコミットはtypeutilの細かい修正です。コメントとエラーメッセージで用語が違ったのをprocedure typeに揃えたのと、typoです。

二つ目のコミットは、`<method>` のインスタンスは実際には適用可能でないので、`of-type?` や `applicable?` で適用可能なものとして扱うのは不適当ではないかという話です。`applicable?` の方はメソッドを与えると `unbound variable: m` になる状態なので、このパスは利用されてもいないはずです。