### PR TITLE
module-exportsがnegative bindingを含まないように

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -754,7 +754,9 @@ ScmObj Scm_ModuleExports(ScmModule *module)
     Scm_HashIterInit(&iter, SCM_HASH_TABLE_CORE(module->external));
     ScmDictEntry *e;
     while ((e = Scm_HashIterNext(&iter)) != NULL) {
-        SCM_APPEND1(h, t, SCM_DICT_KEY(e));
+        if (!(SCM_GLOC(SCM_DICT_VALUE(e)))->hidden) {
+            SCM_APPEND1(h, t, SCM_DICT_KEY(e));
+        }
     }
     (void)SCM_INTERNAL_MUTEX_UNLOCK(modules.mutex);
     return h;


### PR DESCRIPTION
renameやexceptのimportで作られる中間モジュールの `module-exports` がnegative bindingを含まないように修正したものです。