### PR TITLE
Fix port hash for ASLR and high-entropy-va for MinGW-w64 (64-bit)

### DIFF
--- a/ext/native/test.scm
+++ b/ext/native/test.scm
@@ -3,7 +3,7 @@
 (use gauche.ffitest)
 
 (cond-expand
- [gauche.windows (exit 0)]
+ [gauche.os.windows (exit 0)]
  [else
   (unless (#/^x86_64-/ (gauche-config "--arch"))
     (exit 0))])

--- a/src/port.c
+++ b/src/port.c
@@ -1014,7 +1014,7 @@ static struct {
 } active_buffered_ports;
 
 #define PORT_HASH(port)  \
-    ((((SCM_WORD(port)>>3) * 2654435761UL)>>16) % PORT_VECTOR_SIZE)
+    ((u_long)(((SCM_WORD(port)>>3) * 2654435761UL)>>16) % PORT_VECTOR_SIZE)
 
 static void register_buffered_port(ScmPort *port)
 {


### PR DESCRIPTION
MSYS2/MinGW-w64 (64-bit) 環境で、正常にビルドできない件、
エラー箇所が分かったため修正しました。

原因は、最近、MSYS2/MinGW-w64 (64-bit) 環境の更新で、
リンカ (ld) の ASLR および high-entropy-va オプションが、
デフォルトで ON になったのですが、
それによってアドレスの値が大きくなり、
剰余の計算時に結果が負になっていました。
(src/port.c)

また、ext/native については、Windows で test が異常終了していたため、
とりあえずスキップしました。
(cond-expand を修正)

＜テスト結果＞
https://github.com/Hamayama/Gauche/actions/runs/583749482

＜関連プルリクエスト＞
#745
