### PR TITLE
Fix windows home directory

### DIFF
--- a/src/libsys.scm
+++ b/src/libsys.scm
@@ -91,9 +91,8 @@
       path))
   (define (get-windows-home)
     (or (sys-getenv "HOME") ; MSYS
-        (sys-getenv "HOMEDRIVE") ; cmd.exe
-        (sys-getenv "HOMEPATH")
-        "\\"))
+        (sys-getenv "USERPROFILE") ; cmd.exe
+        ""))
   (define (get-unix-home pw)
     (if pw (~ pw'dir) (error "Couldn't obtain username for :" pathname)))
   (define (absolute? path)

--- a/test/system.scm
+++ b/test/system.scm
@@ -193,13 +193,16 @@
        (sys-normalize-pathname "." :absolute #t))
 (test* "normalize" (n (string-append (get-pwd-via-pwd) "/"))
        (sys-normalize-pathname "" :absolute #t))
-(cond-expand
- (gauche.os.windows #t)
- (else
-  (test* "normalize"
-         (n (string-append (slot-ref (sys-getpwuid (sys-getuid)) 'dir) "/abc"))
-         (sys-normalize-pathname "~/abc" :expand #t))))
-
+(test* "normalize"
+       (cond-expand
+        [gauche.os.windows
+         (n (string-append (or (sys-getenv "HOME") ; MSYS
+                               (sys-getenv "USERPROFILE") ; cmd.exe
+                               "")
+                           "/abc"))]
+        [else
+         (n (string-append (slot-ref (sys-getpwuid (sys-getuid)) 'dir) "/abc"))])
+       (sys-normalize-pathname "~/abc" :expand #t))
 (test* "normalize" (n "/a/b/c/d/e")
        (sys-normalize-pathname "/a/b//.///c//d/./e"
                                :canonicalize #t))


### PR DESCRIPTION
- windows の ホームディレクトリを取得する処理を修正しました。

- 元は、sys-normalize-pathname で、`~` を展開したときに、
  ドライブ名のみに展開されていました。
