### PR TITLE
Fix utf-16 surrogate pair to utf-8 conversion

### DIFF
--- a/ext/charconv/jconv.c
+++ b/ext/charconv/jconv.c
@@ -1240,7 +1240,7 @@ static ScmSize utf16_utf8(ScmConvInfo *cinfo,
 
     ScmChar ch;
 
-    if ((u[0] & 0xdc) == 0xd8) {
+    if ((u[0] & 0xfc) == 0xd8) {
         /* surrogate */
         inptr += 2;
         inroom -= 2;
@@ -1253,7 +1253,7 @@ static ScmSize utf16_utf8(ScmConvInfo *cinfo,
             v[0] = inptr[1];
             v[1] = inptr[0];
         }
-        if ((v[0] & 0xdc) == 0xdc) {
+        if ((v[0] & 0xfc) == 0xdc) {
             ch = (((u[0] & 0x03) << 18)
                   | (u[1] << 10)
                   | ((v[0] & 0x03) << 8)
@@ -1268,9 +1268,10 @@ static ScmSize utf16_utf8(ScmConvInfo *cinfo,
             cinfo->istate = istate;
             return inread;
         }
-    } else if ((u[0] & 0xdc) == 0xdc) {
+    } else if ((u[0] & 0xfc) == 0xdc) {
         /* Stray second half of a surrogate pair. */
         DO_SUBST;
+        cinfo->istate = istate;
         return inread;
     } else {
         inread += 2;

--- a/ext/charconv/jconv.c
+++ b/ext/charconv/jconv.c
@@ -1253,7 +1253,7 @@ static ScmSize utf16_utf8(ScmConvInfo *cinfo,
             v[0] = inptr[1];
             v[1] = inptr[0];
         }
-        if ((v[1] & 0xdc) == 0xdc) {
+        if ((v[0] & 0xdc) == 0xdc) {
             ch = (((u[0] & 0x03) << 18)
                   | (u[1] << 10)
                   | ((v[0] & 0x03) << 8)


### PR DESCRIPTION
gauche.charconv の内蔵の utf-16 → utf-8 の変換で、
サロゲートペアの変換に誤りがあったため、修正しました。
