### PR TITLE
Improve read edit v2 (fix #756)

### DIFF
--- a/lib/gauche/interactive.scm
+++ b/lib/gauche/interactive.scm
@@ -361,12 +361,12 @@
             sys-has-windows-console?
             sys-windows-terminal?
             sys-windows-console-legacy?)
-  ;; check if we have a windows console
-  ;; (except for windows terminal (windows 10))
-  (when (and (sys-has-windows-console?)
-             (not (sys-windows-terminal?)))
-    ;; wide character settings for text.line-edit
-    (if-let1 ctx %line-edit-ctx
+  ;; wide character settings for text.line-edit
+  (if-let1 ctx %line-edit-ctx
+    ;; check if we have a windows console
+    ;; (except for windows terminal (windows 10))
+    (when (and (sys-has-windows-console?)
+               (not (sys-windows-terminal?)))
       (case (sys-get-console-output-cp)
         [(65001)
          (set! (~ ctx 'wide-char-disp-setting 'mode) 'Surrogate)


### PR DESCRIPTION
すいません #756 の修正になります。

- lib/gauche/interactive.scm
  autoload の直後に対象を使用していて、
  autoload の意味がなくなっていました。。。
  %line-edit-ctx のチェックを先に行うように修正しました。

- ext/windows/windows.scm
  sys-windows-console-legacy? の処理を少し見直ししました。
  また、コメントを少し追加しました。
