### PR TITLE
Add .gitignore to exclude installed.stamp files

### DIFF
--- a/ext/.gitignore
+++ b/ext/.gitignore
@@ -1,0 +1,1 @@
+installed.stamp


### PR DESCRIPTION
These are added in 56e4705b5 (Run install-check in ext/* submodule only
if it is installed, 2021-02-09)