### PR TITLE
Fix file.util test failure

### DIFF
--- a/lib/gauche/test.scm
+++ b/lib/gauche/test.scm
@@ -568,7 +568,8 @@
 ;; file.util; but this can be used _before_ we test file.util.
 (define (test-remove-files . paths)
   (define (remove-1 path)
-    (if (file-is-directory? path)
+    (if (and (file-is-directory? path)
+             (not (eq? (slot-ref (sys-lstat path)'type) 'symlink)))
       (begin (for-each (^e (unless (member e '("." ".."))
                              (remove-1 (string-append path "/" e))))
                        (sys-readdir path))


### PR DESCRIPTION
The unit test of file.util fails due to this error.

```
Testing file.util ...                                            *** SYSTEM-ERROR: rmdir failed for test.out/test2.d: Not a directory
    While loading "././test.scm" at line 328
Stack Trace:
_______________________________________
  0  (for-each (^e (unless (member e '("." "..")) (remove-1 (strin ...
        at "/home/naoki/work/Gauche/src/../lib/gauche/test.scm":572
```

ext/file/test.out/test2.d is a symlink, but sys-rmdir is called for the path. This change fixes the problem.