### PR TITLE
deps: update to use mbedtls v3

### DIFF
--- a/tools/tls/Makefile.in
+++ b/tools/tls/Makefile.in
@@ -5,7 +5,7 @@
 .PHONY: mbedtls
 
 # update these for new MbedTLS version / repo
-MBEDTLS_VERSION = 2.24.0
+MBEDTLS_VERSION = 3.1.0
 MBEDTLS_SOURCE  = https://github.com/ARMmbed/mbedtls/archive/v$(MBEDTLS_VERSION).tar.gz
 
 


### PR DESCRIPTION
👋 updating the mbedtls dependency to the latest (`3.1.0`).

kind of relates to Homebrew/homebrew-core#92124