### PR TITLE
Fix strftime for windows

### DIFF
--- a/src/gauche/win-compat.h
+++ b/src/gauche/win-compat.h
@@ -227,6 +227,45 @@ _CRTIMP int __cdecl _wstat64(const wchar_t*, struct __stat64*);
 _CRTIMP int __cdecl _fstat64(int, struct __stat64*);
 #endif /* defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR) && (__MINGW32_MAJOR_VERSION < 5) */
 
+/* strftime for windows
+   NB: windows wcsftime is broken. */
+#if defined(UNICODE)
+static inline size_t winstrftime(char *buf, size_t bufsize, const char *format, const struct tm *timeptr)
+{
+    WCHAR *wb = NULL;
+
+    if (bufsize == 0) {
+        return 0;
+    }
+    size_t ret = strftime(buf, bufsize, format, timeptr);
+    if (ret == 0) {
+        goto error;
+    }
+    int nc = MultiByteToWideChar(CP_ACP, 0, buf, -1, NULL, 0);
+    if (nc == 0) {
+        goto error;
+    }
+    wb = (WCHAR*)malloc(nc * sizeof(WCHAR));
+    if (MultiByteToWideChar(CP_ACP, 0, buf, -1, wb, nc) == 0) {
+        goto error;
+    }
+    const char *buf1 = Scm_WCS2MBS(wb);
+    size_t len1 = strlen(buf1);
+    if (len1 >= bufsize) {
+        goto error;
+    }
+    memcpy(buf, buf1, len1 + 1);
+    free(wb);
+    return ret;
+
+error:
+    buf[0] = '\0';
+    free(wb);
+    return 0;
+}
+#define strftime(buf, bufsize, format, timeptr) winstrftime(buf, bufsize, format, timeptr)
+#endif /*UNICODE*/
+
 /*===================================================================
  * Miscellaneous POSIX stuff
  */

--- a/src/gauche/win-compat.h
+++ b/src/gauche/win-compat.h
@@ -234,7 +234,7 @@ static inline size_t winstrftime(char *buf, size_t bufsize, const char *format, 
 {
     WCHAR *wb = NULL;
 
-    if (bufsize == 0) {
+    if (buf == NULL || bufsize == 0) {
         return 0;
     }
     size_t ret = strftime(buf, bufsize, format, timeptr);


### PR DESCRIPTION
- Windows で、sys-strftime の "%Z" の文字化けを修正しました。

- C の strftime を wcsftime に変換したらいけるかと思いましたが、
  wcsftime が変な文字列を返すため、使えませんでした。
  (どうも、マルチバイト文字列の各バイトを、WCHAR にそのまま格納している感じ?)

- このため、strftime の結果を、MultiByteToWideChar の CP_ACP で、
  ワイド文字列に変換し、そこから Scm_WCS2MBS で UTF-8 に変換するようにしました。

- テスト結果を見ると、"%T" とか使えないみたいで、微妙ですが…

＜参考URL＞
- https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/strftime-wcsftime-strftime-l-wcsftime-l?view=msvc-170
  (MSDN strftime)

＜テスト結果＞

```
(define code-list '(a A b B c C d D e F g G h H I j m M n p r R S t T u U V w W x X y Y z Z %))
(define time1     (sys-localtime (sys-time)))
(define (% c :optional (sharp #f))
  (if sharp
    (format #f "%#~a" (x->string c))
    (format #f "%~a"  (x->string c))))

(for-each (^c (print ";; " (% c) ":" (sys-strftime (% c) time1))) code-list)
;; %a:Wed
;; %A:Wednesday
;; %b:Mar
;; %B:March
;; %c:03/16/22 07:48:51
;; %C:
;; %d:16
;; %D:
;; %e:
;; %F:
;; %g:
;; %G:
;; %h:
;; %H:07
;; %I:07
;; %j:075
;; %m:03
;; %M:48
;; %n:
;; %p:AM
;; %r:
;; %R:
;; %S:51
;; %t:
;; %T:
;; %u:
;; %U:11
;; %V:
;; %w:3
;; %W:11
;; %x:03/16/22
;; %X:07:48:51
;; %y:22
;; %Y:2022
;; %z:東京 (標準時)
;; %Z:東京 (標準時)
;; %%:%

(for-each (^c (print ";; " (% c #t) ":" (sys-strftime (% c #t) time1))) code-list)
;; %#a:Wed
;; %#A:Wednesday
;; %#b:Mar
;; %#B:March
;; %#c:Wednesday, March 16, 2022 07:48:51
;; %#C:
;; %#d:16
;; %#D:
;; %#e:
;; %#F:
;; %#g:
;; %#G:
;; %#h:
;; %#H:7
;; %#I:7
;; %#j:75
;; %#m:3
;; %#M:48
;; %#n:
;; %#p:AM
;; %#r:
;; %#R:
;; %#S:51
;; %#t:
;; %#T:
;; %#u:
;; %#U:11
;; %#V:
;; %#w:3
;; %#W:11
;; %#x:Wednesday, March 16, 2022
;; %#X:07:48:51
;; %#y:22
;; %#Y:2022
;; %#z:東京 (標準時)
;; %#Z:東京 (標準時)
;; %#%:%
```
