### PR TITLE
Fix line-edit for string interpolation

### DIFF
--- a/src/libstr.scm
+++ b/src/libstr.scm
@@ -594,6 +594,7 @@
                          [(eqv? c2 #\\)
                           (and (not (eof-object? (read-char)))
                                (begin (skip-token) (rec closer)))]
+                         [(eqv? c2 #\") (and (rec-escaped #\") (rec closer))]
                          [(eqv? c2 #\/) (and (rec-escaped #\/) (rec closer))]
                          [(eqv? c2 #\[) (and (rec-escaped #\]) (rec closer))]
                          [(eqv? c2 #\,)

--- a/test/listener.scm
+++ b/test/listener.scm
@@ -42,6 +42,8 @@
 (sexp-tester #f " \"\\\"er\\\"")
 (sexp-tester #t " \"\\\"er\"")
 (sexp-tester #t " \"\\\"(\"")
+(sexp-tester #t "#\"\"")
+(sexp-tester #t "#\"abc\"")
 (sexp-tester #t "#\\a")
 (sexp-tester #f "#\\")
 (sexp-tester #t "#\\abunaga")


### PR DESCRIPTION
REPL の line-edit で、文字列補間の #"～" が、うまく認識されない件を修正しました。
