### PR TITLE
Add macos-12 (Monterey) to GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,8 +59,8 @@ jobs:
     env:
       GET_GAUCHE_URL: https://raw.githubusercontent.com/shirok/get-gauche/master
       GAUCHE_TEST_PATH: ../Gauche-tmp-self-host-test/stage2
-      TESTLOG_NAME: testlog-osx
-      TESTLOG_PATH: testlog-osx
+      TESTLOG_NAME: testlog-osx-${{ matrix.os }}
+      TESTLOG_PATH: testlog-osx-${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
     - name: Install Gauche

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,11 @@ jobs:
         path: ${{ env.TESTLOG_PATH }}
 
   build-osx:
-    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, macos-12]
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 90
     env:
       GET_GAUCHE_URL: https://raw.githubusercontent.com/shirok/get-gauche/master


### PR DESCRIPTION
- GitHub Actions に macos-12 (Monterey) を追加してみました。
  現状、#819 のエラーが出ます。
  (エラーの修正方法は、ちょっと分かりませんでした…)
  ＜実行結果＞
  https://github.com/Hamayama/Gauche/actions/runs/2284787829
  ```
  Testing system ...                                               failed.
  discrepancies found.  Errors are:
  test sys-sigwait: expects 1 => got #<<system-error> "sigwait failed: Invalid argument">
  test sys-sigwait / signal handler restoration: expects foo => got #<undef>
  ```

- 実行 OS のバージョンは、
  GitHub Actions のログで、先頭の「Set up job」内の
  「Operating System」を開くと確認できます。

- 今のところ、各 OS のバージョンは、以下となっているようです。
  |OS          |version                                            |
  |------------|---------------------------------------------------|
  |linux       |Ubuntu 20.04.4 LTS                                 |
  |macos-latest|macOS 11.6.5 20G527                                |
  |macos-12    |macOS 12.3.1 21E258                                |
  |windows     |Microsoft Windows Server 2022 10.0.20348 Datacenter|
