### PR TITLE
srfi-152.scm - Check arg to avoid infinite loop

### DIFF
--- a/lib/srfi-152.scm
+++ b/lib/srfi-152.scm
@@ -74,6 +74,9 @@
             (substring s cur end))))
 
 (define (string-segment s k)
+  (unless (and (exact-integer? k)
+               (positive? k))
+    (error "positive exact integer required, but got:" k))
   (let loop ([r '()] [s s])
     (if (< (string-length s) k)
       (if (equal? s "")


### PR DESCRIPTION
Hello,
This fixes the other part of #828 (`string-segment` had the same problem).