### PR TITLE
Re-export regexp? in scheme.regex

### DIFF
--- a/lib/scheme/regex.scm
+++ b/lib/scheme/regex.scm
@@ -35,7 +35,7 @@
 (define-module scheme.regex
   (use scheme.charset)
   (use gauche.regexp.sre)
-  (export rx regexp regexp->sre char-set->sre valid-sre?
+  (export rx regexp regexp->sre char-set->sre valid-sre? regexp?
           regexp-matches regexp-matches? regexp-search
           regexp-fold regexp-extract regexp-split regexp-partition
           regexp-replace regexp-replace-all


### PR DESCRIPTION
To answer the question on line 65: in pure R7RS, regexp? is not available, so this should make it available.

I haven't tested this, so your mileage may vary.