### PR TITLE
Change value of SCM_CHAR_INVALID to not conflict with EOF

### DIFF
--- a/ext/vport/test.scm
+++ b/ext/vport/test.scm
@@ -133,6 +133,27 @@
                              buf)))))
          (read-block 10 p)))
 
+;; regression tests for peek consuming EOF
+(test* "peek-char EOF regression" (make-list 3 (eof-object))
+       (let* ((state #f)
+              (p (make <virtual-input-port>
+                   :getc (lambda ()
+                           (set! state (not state))
+                           (if state (eof-object) #\a)))))
+         (list (peek-char p)
+               (peek-byte p)
+               (read-char p))))
+
+(test* "peek-byte EOF regression" (make-list 3 (eof-object))
+       (let* ((state #f)
+              (p (make <virtual-input-port>
+                   :getc (lambda ()
+                           (set! state (not state))
+                           (if state (eof-object) #\a)))))
+         (list (peek-byte p)
+               (peek-char p)
+               (read-byte p))))
+
 ;;-----------------------------------------------------------
 (test-section "virtual-output-port")
 

--- a/src/gauche.h
+++ b/src/gauche.h
@@ -394,7 +394,7 @@ typedef struct ScmFlonumRec {
 #define SCM_CHAR_VALUE(obj)     SCM_CHAR(((unsigned long)SCM_WORD(obj)) >> 8)
 #define SCM_MAKE_CHAR(ch)       SCM_OBJ((intptr_t)(((unsigned long)(ch))<<8) + 3)
 
-#define SCM_CHAR_INVALID        ((ScmChar)(-1)) /* indicate invalid char */
+#define SCM_CHAR_INVALID        ((ScmChar)(-2)) /* indicate invalid char (-2 is used to avoid conflict with libc's EOF) */
 #define SCM_CHAR_MAX            (0xffffff)
 
 #define SCM_CHAR_ASCII_P(ch)    ((ch) < 0x80)

--- a/src/libio.scm
+++ b/src/libio.scm
@@ -544,7 +544,7 @@
 (define-cproc peek-char (:optional (port::<input-port> (current-input-port)))
   (inliner PEEK-CHAR)
   (let* ([ch::ScmChar (Scm_Peekc port)])
-    (return (?: (== ch SCM_CHAR_INVALID) SCM_EOF (SCM_MAKE_CHAR ch)))))
+    (return (?: (== ch EOF) SCM_EOF (SCM_MAKE_CHAR ch)))))
 
 (define-cproc eof-object? (obj) ::<boolean> :fast-flonum
   (inliner EOFP) SCM_EOFP)

--- a/src/port.c
+++ b/src/port.c
@@ -1629,12 +1629,12 @@ ScmObj Scm__GetRemainingInputStringCompat(ScmPort *port)
 /* default dummy procedures */
 static int null_getb(ScmPort *dummy SCM_UNUSED)
 {
-    return SCM_CHAR_INVALID;
+    return EOF;
 }
 
 static int null_getc(ScmPort *dummy SCM_UNUSED)
 {
-    return SCM_CHAR_INVALID;
+    return EOF;
 }
 
 static ScmSize null_getz(char *buf SCM_UNUSED,

--- a/src/regexp.c
+++ b/src/regexp.c
@@ -328,7 +328,7 @@ static ScmObj rc1_lex(regcomp_ctx *ctx)
     ScmObj cs;
 
     ScmChar ch = Scm_GetcUnsafe(ctx->ipat);
-    if (ch == SCM_CHAR_INVALID) return SCM_EOF;
+    if (ch == EOF) return SCM_EOF;
     switch (ch) {
     case '(': return rc1_lex_open_paren(ctx);
     case ')': return SCM_SYM_CLOSE_PAREN;
@@ -343,7 +343,7 @@ static ScmObj rc1_lex(regcomp_ctx *ctx)
     case '?': return rc1_rep(ctx, SCM_SYM_QUESTION, SCM_SYM_QUESTIONQ, SCM_SYM_QUESTIONP);
     case '\\':
         ch = Scm_GetcUnsafe(ctx->ipat);
-        if (ch == SCM_CHAR_INVALID) {
+        if (ch == EOF) {
             Scm_Error("stray backslash at the end of pattern: %S",
                       ctx->pattern);
         }
@@ -520,8 +520,8 @@ static ScmObj rc1_read_integer(regcomp_ctx *ctx)
     do {
         Scm_DStringPutc(&ds, ch);
         ch = Scm_GetcUnsafe(ctx->ipat);
-    } while (ch != SCM_CHAR_INVALID && isdigit(ch));
-    if (ch != SCM_CHAR_INVALID) {
+    } while (ch != EOF && isdigit(ch));
+    if (ch != EOF) {
         Scm_UngetcUnsafe(ch, ctx->ipat);
     }
     ScmObj r = Scm_StringToNumber(SCM_STRING(Scm_DStringGet(&ds, 0)), 10, 0);
@@ -539,13 +539,13 @@ static ScmObj rc1_group_name(regcomp_ctx *ctx)
 
     for (;;) {
         ScmChar ch = Scm_GetcUnsafe(ctx->ipat);
-        if (ch == SCM_CHAR_INVALID) return SCM_FALSE;
+        if (ch == EOF) return SCM_FALSE;
         if (ch == '>') {
             return Scm_Intern(SCM_STRING(Scm_DStringGet(&ds, 0)));
         }
         if (ch == '\\') {
             ch = Scm_GetcUnsafe(ctx->ipat);
-            if (ch == SCM_CHAR_INVALID) return SCM_FALSE;
+            if (ch == EOF) return SCM_FALSE;
             /* fall through */
         }
         Scm_DStringPutc(&ds, ch);
@@ -654,7 +654,7 @@ static ScmObj rc1_lex_conditional_pattern(regcomp_ctx *ctx, int bolp,
                                           ScmObj grps)
 {
     ScmChar ch = Scm_GetcUnsafe(ctx->ipat);
-    if (ch == SCM_CHAR_INVALID)
+    if (ch == EOF)
         goto error;
     if (isdigit(ch)) {
         Scm_UngetcUnsafe(ch, ctx->ipat);


### PR DESCRIPTION
This fixes an issue where peeking an `EOF` will consume it, because `EOF` and `SCM_CHAR_INVALID` were both `-1`. `Scm_Get*` and `Scm_Peek*` were changed to properly handle peeking `EOF`s, including between byte and character variants. Other files where changed wherever they used `SCM_CHAR_INVALID` as `EOF`.

I've also added tests for this.

fixes #837 
