### PR TITLE
Fix Makefile-pure-scheme.in (TAB)

### DIFF
--- a/ext/package-templates/Makefile-pure-scheme.in
+++ b/ext/package-templates/Makefile-pure-scheme.in
@@ -33,22 +33,22 @@ GAUCHE_PKGARCHDIR = "$(DESTDIR)@GAUCHE_PKGARCHDIR@"
 all : $(TARGET)
 
 check : all
-        @rm -f test.log
-        $(GOSH) -I. -I$(srcdir) $(srcdir)/test.scm > test.log
+	@rm -f test.log
+	$(GOSH) -I. -I$(srcdir) $(srcdir)/test.scm > test.log
 
 install : all
-        $(INSTALL) -m 444 -T $(GAUCHE_PKGLIBDIR) $(SCMFILES)
-        $(INSTALL) -m 444 -T $(GAUCHE_PKGLIBDIR)/.packages $(PACKAGE).gpd
+	$(INSTALL) -m 444 -T $(GAUCHE_PKGLIBDIR) $(SCMFILES)
+	$(INSTALL) -m 444 -T $(GAUCHE_PKGLIBDIR)/.packages $(PACKAGE).gpd
 
 uninstall :
-        $(INSTALL) -U $(GAUCHE_PKGLIBDIR) $(SCMFILES)
-        $(INSTALL) -U $(GAUCHE_PKGLIBDIR)/.packages $(PACKAGE).gpd
+	$(INSTALL) -U $(GAUCHE_PKGLIBDIR) $(SCMFILES)
+	$(INSTALL) -U $(GAUCHE_PKGLIBDIR)/.packages $(PACKAGE).gpd
 
 clean :
-        rm -rf core $(TARGET) $(GENERATED) *~ test.log so_locations
+	rm -rf core $(TARGET) $(GENERATED) *~ test.log so_locations
 
 distclean : clean
-        rm -rf $(CONFIG_GENERATED)
+	rm -rf $(CONFIG_GENERATED)
 
 maintainer-clean : clean
-        rm -rf $(CONFIG_GENERATED) @@configure@@ VERSION
+	rm -rf $(CONFIG_GENERATED) @@configure@@ VERSION


### PR DESCRIPTION
gauche-package genarate の scheme-only のときの Makefile テンプレートで、
インデントが TAB でないと動かないようだったので、修正しました。

＜確認＞
(MSYS2 の MINGW64 Shell 上で確認)
```
gauche-package generate -S testmod
cd testmod
./configure
make check
```
