### PR TITLE
Fix gauche-package install for windows

### DIFF
--- a/lib/gauche/package/fetch.scm
+++ b/lib/gauche/package/fetch.scm
@@ -48,22 +48,22 @@
 (select-module gauche.package.fetch)
 
 ;; Default programs
-(define *wget-program*     (find-file-in-paths "wget"))
-(define *ncftpget-program* (find-file-in-paths "ncftpget"))
+(define *wget-program*     (%find-file-in-paths "wget"))
+(define *ncftpget-program* (%find-file-in-paths "ncftpget"))
 
 (define (gauche-package-ensure uri :key (config '()))
   (let* ([build-dir (assq-ref config 'build-dir ".")]
-         [wget      (assq-ref config 'wget *wget-program*)]
-         [ncftpget  (assq-ref config 'ncftpget *ncftpget-program*)]
+         [wget      (%fix-path (assq-ref config 'wget *wget-program*))]
+         [ncftpget  (%fix-path (assq-ref config 'ncftpget *ncftpget-program*))]
          [dest      (build-path build-dir (sys-basename uri))])
     (rxmatch-case uri
       (#/^https?:/ (#f)
                    (sys-unlink dest)
-                   (run #"~wget -P \"~build-dir\" \"~uri\"")
+                   (run (%shell #"~wget -P ~(%fix-path build-dir) \"~uri\""))
                    dest)
       (#/^ftp:/ (#f)
                 (guard (e (else (sys-unlink dest) (raise e)))
-                  (run #"~ncftpget -c \"~uri\" > \"~dest\""))
+                  (run (%shell #"~ncftpget -c \"~uri\" > ~(%fix-path dest)")))
                 dest)
       (else
        (unless (file-is-readable? uri)


### PR DESCRIPTION
- gauche-package install が windows 上で動作するように修正したものです。

- MSYS2 の MINGW64 Shell 上で動作を確認しました。

- run で実行するときに、`cmd.exe /c bash -c ...` のように、
  Shell をかませれば 動作するようだったので、 %shell を作成しました。

- ただ、Shell をかませた場合、
  ファイルパスは `(shell-escape-string path 'posix)`
  でエスケープする必要があったため、%fix-path を作成しました。


＜確認＞

```
gauche-package generate -S testmod

cd testmod
gauche-package make-tarball

cd ..
gauche-package install testmod-1.0.tgz

gauche-package install https://github.com/Hamayama/lineseg/releases/download/v1.3/lineseg-1.3.tgz
```

最後のものは、最近作成した小さなモジュールで、
URL からのインストールを確認したものです。
