### PR TITLE
Fix reset/shift and eval combination problem

### DIFF
--- a/lib/gauche/partcont.scm
+++ b/lib/gauche/partcont.scm
@@ -3,15 +3,19 @@
 (select-module gauche.partcont)
 
 (define %reset (with-module gauche.internal %reset))
+(define %reset-with-cont-frame-wrapper
+  (with-module gauche.internal %reset-with-cont-frame-wrapper))
 (define %call/pc (with-module gauche.internal %call/pc))
 
 (define-syntax reset
-  (syntax-rules ()
+  (syntax-rules (shift)
+    [(reset expr1 ... (shift k expr2 ...))
+     (%reset (^[] expr1 ... (shift k expr2 ...)))]
     [(reset expr ...)
-     (%reset (^[] expr ...))]))
+     (%reset-with-cont-frame-wrapper (^[] expr ...))]))
 
 (define (call/pc proc)
-  (%call/pc (^k (proc (^ args (reset (apply k args)))))))
+  (%call/pc (^k (proc (^ args (%reset (^[] (apply k args))))))))
 
 (define-syntax shift
   (syntax-rules ()

--- a/lib/gauche/partcont.scm
+++ b/lib/gauche/partcont.scm
@@ -8,9 +8,7 @@
 (define %call/pc (with-module gauche.internal %call/pc))
 
 (define-syntax reset
-  (syntax-rules (shift)
-    [(reset expr1 ... (shift k expr2 ...))
-     (%reset (^[] expr1 ... (shift k expr2 ...)))]
+  (syntax-rules ()
     [(reset expr ...)
      (%reset-with-cont-frame-wrapper (^[] expr ...))]))
 

--- a/src/gauche.h
+++ b/src/gauche.h
@@ -668,7 +668,7 @@ SCM_EXTERN ScmObj Scm_VMCall(ScmObj *args, int argcnt, void *data);
 
 SCM_EXTERN ScmObj Scm_VMCallCC(ScmObj proc);
 SCM_EXTERN ScmObj Scm_VMCallPC(ScmObj proc);
-SCM_EXTERN ScmObj Scm_VMReset(ScmObj proc);
+SCM_EXTERN ScmObj Scm_VMReset(ScmObj proc, ScmObj use_cont_frame_wrapper);
 SCM_EXTERN ScmObj Scm_VMDynamicWind(ScmObj pre, ScmObj body, ScmObj post);
 
 SCM_EXTERN ScmObj Scm_VMWithErrorHandler(ScmObj handler, ScmObj thunk);

--- a/src/libproc.scm
+++ b/src/libproc.scm
@@ -74,7 +74,9 @@
 (select-module gauche.internal)
 ;; for partial continuation.  See lib/gauche/partcont.scm
 (define-cproc %call/pc (proc) (return (Scm_VMCallPC proc)))
-(define-cproc %reset (proc) (return (Scm_VMReset proc)))
+(define-cproc %reset (proc) (return (Scm_VMReset proc SCM_FALSE)))
+(define-cproc %reset-with-cont-frame-wrapper (proc)
+  (return (Scm_VMReset proc SCM_TRUE)))
 
 ;;;
 ;;; Useful gadgets

--- a/test/dynwind.scm
+++ b/test/dynwind.scm
@@ -745,6 +745,32 @@
                next
                (lambda () (display "[D02]"))))))))
 
+(test* "reset/shift + guard 2"
+       "catch error!!"
+       (let1 k1 #f
+         (reset
+          (guard (e [else "catch error!!"])
+            (shift k (set! k1 k))
+            (error "err")))
+         (k1 100)))
+
+(test* "reset/shift + eval 1"
+       42
+       (reset (eval '(shift k (k 42)) (current-module))))
+
+(test* "reset/shift + eval 2"
+       42
+       (reset (eval '(+ (shift k (k 42))) (current-module))))
+
+(test* "reset/shift + eval 3"
+       42
+       (reset (+ (eval '(shift k (k 42)) (current-module)))))
+
+(test* "reset/shift + eval 4"
+       '(42 43 44)
+       (receive vals (reset (eval '(shift k (k 42 43 44)) (current-module)))
+         vals))
+
 (test* "dynamic-wind + reset/shift 1"
        "[d01][d02][d03][d04]"
        ;"[d01][d02][d04][d01][d03][d04]"


### PR DESCRIPTION
- Chaton で報告されていた、
  reset/shift と eval を組み合わせた場合の不具合を修正しました。
  ( http://chaton.practical-scheme.net/gauche/a/2022/09/15 )
  ```
  (use gauche.partcont)
  (reset (eval '(shift k (k 42)) (current-module)))
  ;; ==> #<undef> ( 42 になるのが正しい )
  ```

- 原因ですが、reset の末尾位置に eval がある場合、(shift 実行時に)
  eval の継続 (vm->cont) に、部分継続の終端マーカーがセットされます。

- 一方, eval はモジュールの変更/復帰を行うために、
  内部で Scm_VMDynamicWind を使用しますが、
  Scm_VMDynamicWind は、実行時に Scm_VMPushCC で、継続を追加しながら処理を行います。
  https://github.com/shirok/Gauche/blob/ba97f743589b47457249568ae642cdf76cfd91b9/src/vm.c#L2166

- この 2 つの継続の操作の競合により、
  Scm_VMDynamicWind の処理が終わる前に、部分継続の終端が検出され、
  reset を脱出することになりました。

- (正確には、vm.c で dynwind_after_cc だけが呼び出されず、
  ここで、(after ではなく) body の戻り値を VM に返すはずが、
  呼ばれないため、after の戻り値の undefined がそのまま返されていました)

- それで、対策としては、reset の実行時に Scm_VMPushCC で継続を 1 段追加し、
  そちらに終端マーカーがセットされるようにしました。

- これにより、それより内側の Scm_VMDynamicWind 等の継続には、
  終端マーカーがセットされなくなります。

- ただ、この修正により、部分継続が空っぽの場合に、
  メモリリークのテストがメモリを消費するようになったため、
  対策として、partcont.scm の reset マクロで、
  部分継続が空っぽの場合は、今まで通りの処理とするように分岐を入れました。

- あと、本修正により、
  https://practical-scheme.net/wiliki/wiliki.cgi?Gauche%3ABugs#H-2dgngv
  の pcdemo10.scm の問題 (ghost continuation エラー) も解消されました。


＜テスト結果＞
(1) https://github.com/Hamayama/Gauche/actions/runs/3162757352

(2) [Gauche-effects](https://github.com/Hamayama/Gauche-effects) の effects.scm で、
    `*use-native-reset*` を #t にして、各サンプルを実行 ==> OK

(3) 以下のメモリリークのテスト ==> OK
(出典 : http://okmij.org/ftp/continuations/against-callcc.html#memory-leak )
```
(use gauche.partcont)
(define (leak-test1 identity-thunk)
  (let loop ((id (lambda (x) x)))
    (loop (id (identity-thunk)))))
(leak-test1 (lambda () (reset (shift k k))))
```

(4) Kahua の nqueen を実行 ==> OK
