### PR TITLE
Re-export time primitives from gauche.threads for srfi-18 compatibility

### DIFF
--- a/ext/threads/threads.scm
+++ b/ext/threads/threads.scm
@@ -50,6 +50,8 @@
           condition-variable-specific condition-variable-specific-set!
           condition-variable-signal! condition-variable-broadcast!
 
+          current-time time? time->seconds seconds->time
+
           join-timeout-exception? abandoned-mutex-exception?
           terminated-thread-exception? uncaught-exception?
           uncaught-exception-reason


### PR DESCRIPTION
SRFI-18 defines time primitives, but currently they aren't imported by `(srfi 18)`