### PR TITLE
Change GitHub Actions to use macos-11 (Big Sur)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       TESTLOG_NAME: testlog-linux
       TESTLOG_PATH: testlog-linux
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: shirok/setup-gauche@v2
     - name: Run release version of Gauche
       run: |
@@ -35,7 +35,7 @@ jobs:
         cp $GAUCHE_TEST_PATH/ext/threads/test.log $TESTLOG_PATH/$TESTLOG_NAME/test-threads.log
     - name: Upload testlog
       if: always()
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       with:
         name: ${{ env.TESTLOG_NAME }}
         path: ${{ env.TESTLOG_PATH }}
@@ -72,7 +72,7 @@ jobs:
         cp $GAUCHE_TEST_PATH/ext/threads/test.log $TESTLOG_PATH/$TESTLOG_NAME/test-threads.log
     - name: Upload testlog
       if: always()
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       with:
         name: ${{ env.TESTLOG_NAME }}
         path: ${{ env.TESTLOG_PATH }}
@@ -99,7 +99,7 @@ jobs:
       TESTLOG_PATH: testlog-windows-${{ matrix.arch }}
     steps:
     - run: git config --global core.autocrlf false
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: msys2/setup-msys2@v2
       with:
         msystem: MINGW${{ matrix.bit }}
@@ -161,13 +161,13 @@ jobs:
         cp ext/threads/test.log $TESTLOG_PATH/$TESTLOG_NAME/test-threads.log
     - name: Upload testlog
       if: always()
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       with:
         name: ${{ env.TESTLOG_NAME }}
         path: ${{ env.TESTLOG_PATH }}
     #- name: Upload result
     #  if: always()
-    #  uses: actions/upload-artifact@v1
+    #  uses: actions/upload-artifact@v3
     #  with:
     #    name: Gauche-${{ matrix.arch }}
     #    path: ../Gauche-mingw-dist/Gauche-${{ matrix.arch }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, macos-12]
+        os: [macos-latest, macos-11]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
     env:


### PR DESCRIPTION
- GitHub Actions で、
  macos-latest が macos-12 と同じになるらしいので、
  macos-11 の方を明示的に指定するようにしました。

- ただ、Gauche の本家リポジトリでは、すでに切り替わっているようですが、
  自分の fork では、まだ切り替わっていないようです。
  (切替期間が 10/3 ～ 12/1 とのこと)
  ＜実行結果＞
  https://github.com/Hamayama/Gauche/actions/runs/3369481116

- 実行 OS のバージョンは、
  GitHub Actions のログで、先頭の「Set up job」内の
  「Operating System」を開くと確認できます。

- 現状、Gauche の本家リポジトリでは、以下となっていました。
  |OS          |version                                            |
  |------------|---------------------------------------------------|
  |linux       |Ubuntu 20.04.5 LTS                                 |
  |macos-latest|macOS 12.6 21G115                                  |
  |macos-12    |macOS 12.6 21G115                                  |
  |macos-11    |macOS 11.7 20G817                                  |
  |windows     |Microsoft Windows Server 2022 10.0.20348 Datacenter|

- あと、実行結果のページに warning が出ていたので、
  いくつかの action のバージョンを、最新にしました。
