### PR TITLE
subsection 6.1.5: title should be in English.

### DIFF
--- a/doc/corelib.texi
+++ b/doc/corelib.texi
@@ -589,7 +589,7 @@ is zero and @var{max-length} is @code{inf.0}.
 @end deftp
 
 @node Native types,  , Type expressions and type constructors, Types and classes
-@subsection ネイティブタイプ
+@subsection Native types
 @c NODE ネイティブタイプ
 
 Native types are a set of predefined descriptive types that bridge


### PR DESCRIPTION
There is a Japanese subsection title in English version of reference manual:

<img width="425" alt="Screen Shot 2022-12-20 at 23 13 28" src="https://user-images.githubusercontent.com/388775/208687105-3972c6c0-dfcc-4160-833f-0131edc6955f.png">

http://practical-scheme.net/gauche/man/gauche-refe/Types-and-classes.html#Native-types
