### PR TITLE
Add sys-strsignal procedure

### DIFF
--- a/src/libsys.scm
+++ b/src/libsys.scm
@@ -540,6 +540,8 @@
 ;; various systems.
 (define-cproc sys-strerror (errno_::<int>) ::<const-cstring> strerror)
 
+(define-cproc sys-strsignal (signum::<int>) ::<const-cstring> strsignal)
+
 ;;---------------------------------------------------------------------
 ;; sys/loadavg.h
 


### PR DESCRIPTION
Wraps strsignal() which was added to POSIX in 2017.