### PR TITLE
Rename version gauche.threads -> threads

### DIFF
--- a/lib/gauche/version-alist.scm
+++ b/lib/gauche/version-alist.scm
@@ -19,10 +19,10 @@
       (build.configure ,@($ cdr $ shell-tokenize-string
                             $ gauche-config "--reconfigure"))
       (scheme.path ,@*load-path*)
-      (gauche.threads ,(cond
-                        [(assq 'gauche.sys.pthreads fs) 'pthreads]
-                        [(assq 'gauche.sys.wthreads fs) 'wthreads]
-                        [else 'none]))
+      (threads ,(cond
+                 [(assq 'gauche.sys.pthreads fs) 'pthreads]
+                 [(assq 'gauche.sys.wthreads fs) 'wthreads]
+                 [else 'none]))
       (gauche.net.tls ,@(cond-list
                          [(assq 'gauche.net.tls.axtls fs) 'axtls]
                          [(assq 'gauche.net.tls.mbedtls fs) 'mbedtls])))))


### PR DESCRIPTION
(SRFI 176 / `version-alist`)

Since STklos is also using a `threads` property, we decided to give it a [standard name](https://registry.scheme.org/#version-properties).

Do you know if anyone is using the `gauche.threads` property yet? If so, we could keep it.