### PR TITLE
Fix bug in SRFI 69 hash-table-update!

### DIFF
--- a/lib/srfi/69.scm
+++ b/lib/srfi/69.scm
@@ -72,9 +72,7 @@
 (define (hash-table-update! ht key proc :optional (thunk no-key-thunk))
   ((with-module gauche hash-table-update!)
    ht key
-   (^[v] (if (eq? v *unique*)
-           (thunk)
-           (proc v)))
+   (^[v] (proc (if (eq? v *unique*) (thunk) v)))
    *unique*))
 
 (define (hash-table-update!/default ht key proc default)


### PR DESCRIPTION
Test program:

```Scheme
(import (scheme base) (scheme write) (srfi 69))

(define (writeln x) (write x) (newline))

(define outer-table (make-hash-table))

(define (put outer-key inner-key inner-value)
  (hash-table-update! outer-table
                      outer-key
                      (lambda (inner-table)
                        (hash-table-set! inner-table
                                         inner-key
                                         inner-value)
                        inner-table)
                      make-hash-table))

(put 'a 2 3)
(put 'a 3 4)
(writeln (hash-table-keys outer-table))
(writeln (hash-table-keys (hash-table-ref outer-table 'a)))
```

Correct output:

```
(a)
(3 2)
```