### PR TITLE
match-else to placeholder `_`

### DIFF
--- a/doc/modutil.texi
+++ b/doc/modutil.texi
@@ -30685,17 +30685,17 @@ quasipatternの例です。最初の式では、パターンのうち@code{value
 @example
 (match '(the answer is 42)
   [`(the answer is ,value) value]
-  [else #f])
+  [_ #f])
  @result{} 42
 
 (match '(the answer was 42)
   [`(the answer is ,value) value]
-  [else #f])
+  [_ #f])
  @result{} #f
 
 (match '(a b c d)
   [(the answer is value) value]
-  [else #f])
+  [_ #f])
  @result{} d
 @end example
 
@@ -30719,7 +30719,7 @@ operation to balance a red-black tree.
          ($ T 'B a x ($ T 'R ($ T 'R b y c) z d))
          ($ T 'B a x ($ T 'R b y ($ T 'R c z d))))
      (make-T 'R (make-T 'B a x b) y (make-T 'B c z d))]
-    [else t]))
+    [_ t]))
 @end example
 
 @c ----------------------------------------------------------------------


### PR DESCRIPTION
info の記述が理由か syntax が変更されたのか分からないのですが match 構文に else があると、ずっと勘違いしていました。

else でも多くの場合は動くのですが、こういう条件を追加すると cond-else が意図通りではなくなることを知ったので _ にしてみました。

```scheme
(match #f [else (cond [else (print 'else-else)])])
```

\# 久し振りに pull-request を作ったのでおかしなところあったらすみません。
