### PR TITLE
Disable version specification on Windows build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -363,6 +363,18 @@ dnl the use of ac_configure_args depends on autoconf 2.52.
 GAUCHE_CONFIGURE_ARGS=`echo "$ac_configure_args" | sed 's/@<:@\\"\`\$@:>@/\\\\&/g'`
 AC_SUBST(GAUCHE_CONFIGURE_ARGS)
 
+
+dnl ===========================================================
+dnl Set up gosh flags for build.
+dnl On MinGW, gosh -v option doesn't work, so we disable it.
+BUILD_GOSH_FLAGS='-v$(BUILD_GOSH_VERSION)'
+AS_CASE([$host],
+   [*mingw*], [
+     BUILD_GOSH_FLAGS=""
+     ])
+AC_SUBST(BUILD_GOSH_FLAGS)
+
+
 dnl ==========================================================
 dnl Checks for programs.
 

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -124,7 +124,7 @@ BUILD_CFLAGS = -O2 -I$(top_builddir)/src -I$(top_srcdir)/src
 # be called when building from tarball.)
 # We clear GAUCHE_LOAD_PATH to make sure we won't read nonstandard stuff.
 BUILD_GOSH_VERSION = @BUILD_GOSH_VERSION@
-BUILD_GOSH_FLAGS = -v$(BUILD_GOSH_VERSION)
+BUILD_GOSH_FLAGS = @BUILD_GOSH_FLAGS@
 BUILD_GOSH  = GAUCHE_LOAD_PATH="" GAUCHE_DYNLOAD_PATH="" \
 	      "@BUILD_GOSH@" $(BUILD_GOSH_FLAGS) \
 	      -l$(srcdir)/preload \


### PR DESCRIPTION
- ビルド時の `-v` オプションによるバージョン指定を、Windows 時には無効にしました。

- Windows で `-v` オプションを動作させるには、ハードルがあるようです。
  - (%invoke-other-version) 内の glob が、パス名を展開できない件
    - 拡張子付きで "gosh.exe" にしないと、glob が認識しないもよう。
  - execvp() が動作しない件
    - 実行ファイル指定にはダブルクォート囲みが不要? 各引数には逆にダブルクォート囲みが必要?
    - プロセスが入れ替わる訳ではなく、起動して終了するのみ? 標準入出力は引き継げない?
  - (gauche-library-directory) が正しい位置を示さない件
    - Scm_LibraryDirectory() → replace_install_dir() → get_install_dir()
      src/paths.c の get_install_dir() が OS ごとに異なっており、
      一部のものだけがフォルダ名を正しく設定しているもよう。

- macOS でも `-v` オプションが動作しているのかどうかは、よく分かりませんでした。

＜テスト結果＞

- make check
  OS : Windows 10 (version 22H2) (64bit)
  Gauche : コミット 8d5f82e + 変更
  開発環境 : MSYS2/MinGW-w64 (64bit) (gcc version 12.2.0 (Rev10, Built by MSYS2 project))
  Total: 35542 tests, 35542 passed,     0 failed,     0 aborted.

＜その他＞

- 現状、Gauche 0.9.12 に Gauche 0.9.13_pre3 を上書きした状態で、
  `gosh -v0.9.12` を実行した結果は、以下の通りです。
  ```
  > gosh -v0.9.12
  No installed Gauche with version 0.9.12 under C:\Program Files\Gauche\lib\.
  ```
