### PR TITLE
Fix GC setting

### DIFF
--- a/DIST
+++ b/DIST
@@ -40,9 +40,9 @@ check_version () {
 }
 
 do_gen () {
-#    maintainer_clean
-#    rm -f configure gc/configure gc/configure.gnu
-#    cp tools/gc-configure.gnu gc/configure.gnu
+    maintainer_clean
+    rm -f configure gc/configure gc/configure.gnu
+    cp tools/gc-configure.gnu gc/configure.gnu
     autoconf
     (cd gc; ./autogen.sh)
 }


### PR DESCRIPTION
- GC の設定がされなくなっていた件を修正しました。

- コミット b56a47d (2023-6-5) で、
  DIST が tools/gc-configure.gnu を gc/configure.gnu にコピーしないようになっており、
  このため、GC の LARGE_CONFIG や DONT_ADD_BYTE_AT_END 等の設定が行われませんでした。

- これにより、Windows の 32 bit 版 のテスト項目の
  「advanced read/write features」の「deep list doesn't bust C stack」で、
  ヒープ不足エラーが出ていました。
  (「Fatal error in GC：Too many heap sections」)

＜テスト結果＞
https://github.com/Hamayama/Gauche/actions/runs/5572936923
