### PR TITLE
Fix do-check in SRFI-78

### DIFF
--- a/lib/srfi/78.scm
+++ b/lib/srfi/78.scm
@@ -96,7 +96,7 @@
                       name expected))
             (inc! (~ results'pass-count)))
           (begin
-            (when (and (eq? result *global-results*)
+            (when (and (eq? results *global-results*)
                        (memq (check-mode) '(report report-failed)))
               (format #t "Checking ~s, expecting ~s => ERROR: got ~s\n"
                       name expected result))


### PR DESCRIPTION
テスト失敗時に表示が出なくなっていたため修正しました。
