### PR TITLE
Fix bit shift warning in mmap.c on MinGW 32bit

### DIFF
--- a/src/mmap.c
+++ b/src/mmap.c
@@ -121,16 +121,26 @@ static void *mmap_int(void *addrhint, size_t len, int prot,
         Scm_Error("PROT_NONE mmap protection isn't allowed on MinGW");
     }
 
+#if SIZEOF_SIZE_T > 4
     DWORD size_hi = len >> 32;
     DWORD size_lo = len & 0xffffffffULL;
+#else
+    DWORD size_hi = 0;
+    DWORD size_lo = len;
+#endif
     HANDLE mapping = CreateFileMappingA(fhandle, NULL, wprot,
                                         size_hi, size_lo, NULL);
     if (mapping == NULL) {
         Scm_SysError("CreateFileMapping failed");
     }
 
+#if SIZEOF_SIZE_T > 4
     DWORD off_hi = off >> 32;
     DWORD off_lo = off & 0xffffffffULL;
+#else
+    DWORD off_hi = 0;
+    DWORD off_lo = off;
+#endif
     DWORD accmode = 0;
     if (prot & PROT_WRITE) accmode = FILE_MAP_WRITE;
     else accmode = FILE_MAP_READ;


### PR DESCRIPTION
MinGW 32bit のビルドで、以下の warning が出ていたため修正しました。

```
gcc -DHAVE_CONFIG_H -I. -I. -I./../gc/include -I../gc/include `./get-atomic-ops-flags.sh .. .. --cflags`   -g -O2 -Wall -Wextra -Wno-unused-label -DUNICODE -D__USE_MINGW_ANSI_STDIO  -march=i686 -DUSE_I686_PREFETCH -c mmap.c
mmap.c: In function 'mmap_int':
mmap.c:124:25: warning: right shift count >= width of type [-Wshift-count-overflow]
  124 |     DWORD size_hi = len >> 32;
      |                         ^~
mmap.c:132:24: warning: right shift count >= width of type [-Wshift-count-overflow]
  132 |     DWORD off_hi = off >> 32;
      |                        ^~
```

どうも 32bit の変数を 32bit シフトするのは、未定義動作になるとのこです。
