### PR TITLE
Fix variable clobbered warning in lazy.c

### DIFF
--- a/src/lazy.c
+++ b/src/lazy.c
@@ -627,7 +627,7 @@ ScmObj Scm_GeneratorToLazyPair(ScmObj generator)
  */
 ScmObj Scm_ForceLazyPair(volatile ScmLazyPair *obj)
 {
-    volatile ScmRealLazyPair *lp = REAL_LAZY_PAIR(obj);
+    volatile ScmRealLazyPair * volatile lp = REAL_LAZY_PAIR(obj);
     static const ScmTimeSpec req = {0, 1000000};
     ScmTimeSpec rem;
     ScmVM *vm = Scm_VM();


### PR DESCRIPTION
以下の warning が出ていたため修正しました。

```
gcc -DHAVE_CONFIG_H -I. -I. -I./../gc/include -I../gc/include `./get-atomic-ops-flags.sh .. .. --cflags`   -g -O2 -Wall -Wextra -Wno-unused-label -DUNICODE -D__USE_MINGW_ANSI_STDIO  -march=i686 -DUSE_I686_PREFETCH -c lazy.c
lazy.c: In function 'Scm_ForceLazyPair':
lazy.c:630:31: warning: variable 'lp' might be clobbered by 'longjmp' or 'vfork' [-Wclobbered]
  630 |     volatile ScmRealLazyPair *lp = REAL_LAZY_PAIR(obj);
      |                               ^~
```
