### PR TITLE
Fix gc unexpected mark stack overflow on MSYS2/MinGW-w64 32-bit

### DIFF
--- a/gc/include/private/gc_priv.h
+++ b/gc/include/private/gc_priv.h
@@ -1936,9 +1936,11 @@ GC_INNER void GC_initiate_gc(void);
 GC_INNER GC_bool GC_collection_in_progress(void);
                         /* Collection is in progress, or was abandoned. */
 
-#define GC_PUSH_ALL_SYM(sym) \
-                GC_push_all((/* no volatile */ void *)&(sym), \
-                            (/* no volatile */ void *)(&(sym) + 1))
+/* Push contents of the symbol residing in the static roots area        */
+/* excluded from scanning by the the collector for a reason.            */
+/* Note: it should be used only for symbols of relatively small size    */
+/* (one or several words).                                              */
+#define GC_PUSH_ALL_SYM(sym) GC_push_all_eager(&(sym), &(sym) + 1)
 
 GC_INNER void GC_push_all_stack(ptr_t b, ptr_t t);
                                     /* As GC_push_all but consider      */

--- a/gc/pthread_support.c
+++ b/gc/pthread_support.c
@@ -552,7 +552,7 @@ static struct GC_Thread_Rep first_thread;
 void GC_push_thread_structures(void)
 {
     GC_ASSERT(I_HOLD_LOCK());
-    GC_PUSH_ALL_SYM(GC_threads);
+    GC_push_all(&GC_threads, (ptr_t)(&GC_threads) + sizeof(GC_threads));
 #   ifdef E2K
       GC_PUSH_ALL_SYM(first_thread.backing_store_end);
 #   endif

--- a/gc/win32_threads.c
+++ b/gc/win32_threads.c
@@ -1266,7 +1266,7 @@ void GC_push_thread_structures(void)
     } else
 # endif
   /* else */ {
-    GC_PUSH_ALL_SYM(GC_threads);
+    GC_push_all(&GC_threads, (ptr_t)(&GC_threads) + sizeof(GC_threads));
   }
 # if defined(THREAD_LOCAL_ALLOC) && defined(USE_CUSTOM_SPECIFIC)
     GC_PUSH_ALL_SYM(GC_thread_key);


### PR DESCRIPTION
MSYS2/MinGW-w64 32-bit でビルドすると、テスト時に

「Unexpected mark stack overflow」というメッセージボックスが出て止まってしまう件の修正になります。

MSYS2/MinGW-w64 64-bit でビルドした場合には発生しません。

また、GC 8.0.6 では発生しません。GC 8.2.4 で発生します。

https://github.com/ivmai/bdwgc/issues/572

で、修正の情報をもらいました。
