### PR TITLE
Fix gc unexpected mark stack overflow v2 (for pthreads)

### DIFF
--- a/gc/include/private/pthread_support.h
+++ b/gc/include/private/pthread_support.h
@@ -43,8 +43,6 @@ EXTERN_C_BEGIN
 /* The set of all known threads.  We intercept thread creation and      */
 /* joins.                                                               */
 /* Protected by allocation/GC lock.                                     */
-/* Some of this should be declared volatile, but that's inconsistent    */
-/* with some library routine declarations.                              */
 typedef struct GC_Thread_Rep {
 #   ifdef THREAD_SANITIZER
       char dummy[sizeof(oh)];     /* A dummy field to avoid TSan false  */
@@ -149,7 +147,7 @@ typedef struct GC_Thread_Rep {
                        ^ NUMERIC_THREAD_ID(id)) % THREAD_TABLE_SZ)
 #endif
 
-GC_EXTERN volatile GC_thread GC_threads[THREAD_TABLE_SZ];
+GC_EXTERN GC_thread GC_threads[THREAD_TABLE_SZ];
 
 GC_EXTERN GC_bool GC_thr_initialized;
 

--- a/gc/pthread_support.c
+++ b/gc/pthread_support.c
@@ -542,7 +542,7 @@ GC_INNER void GC_start_mark_threads_inner(void)
 
 GC_INNER GC_bool GC_thr_initialized = FALSE;
 
-GC_INNER volatile GC_thread GC_threads[THREAD_TABLE_SZ] = {0};
+GC_INNER GC_thread GC_threads[THREAD_TABLE_SZ] = {0};
 
 /* It may not be safe to allocate when we register the first thread.    */
 /* As "next" and "status" fields are unused, no need to push this       */


### PR DESCRIPTION
#932 の続きになります。

https://github.com/ivmai/bdwgc/commit/f60b451faff01a20257552a839b384f2cc73b1a1
のコミットログに記載されていた
https://github.com/ivmai/bdwgc/commit/394b6e2909a25bb4658248cc1425a8f5b06c8e70
の修正を反映しました。

＜テスト結果＞
https://github.com/Hamayama/Gauche/actions/runs/6116273184

build-linux で、以下のログが出ないことを確認しました。

```
In file included from /home/runner/work/Gauche/Gauche/gc/extra/gc.c:76:
/home/runner/work/Gauche/Gauche/gc/extra/../pthread_support.c: In function ‘GC_push_thread_structures’:
/home/runner/work/Gauche/Gauche/gc/extra/../pthread_support.c:555:17: warning: passing argument 1 of ‘GC_push_all’ discards ‘volatile’ qualifier from pointer target type [-Wdiscarded-array-qualifiers]
  555 |     GC_push_all(&GC_threads, (ptr_t)(&GC_threads) + sizeof(GC_threads));
      |                 ^~~~~~~~~~~
In file included from /home/runner/work/Gauche/Gauche/gc/extra/gc.c:57:
/home/runner/work/Gauche/Gauche/gc/extra/../mark.c:1197:39: note: expected ‘void *’ but argument is of type ‘struct GC_Thread_Rep * volatile (*)[256]’
 1197 | GC_API void GC_CALL GC_push_all(void *bottom, void *top)
      |                                 ~~~~~~^~~~~~
```

＜参考情報＞
https://github.com/ivmai/bdwgc/issues/572
