### PR TITLE
Fix gc unexpected mark stack overflow v3 (for pthreads)

### DIFF
--- a/gc/pthread_support.c
+++ b/gc/pthread_support.c
@@ -552,7 +552,8 @@ static struct GC_Thread_Rep first_thread;
 void GC_push_thread_structures(void)
 {
     GC_ASSERT(I_HOLD_LOCK());
-    GC_push_all(&GC_threads, (ptr_t)(&GC_threads) + sizeof(GC_threads));
+    GC_push_all((/* no volatile */ void *)&GC_threads,
+                (ptr_t)(&GC_threads) + sizeof(GC_threads));
 #   ifdef E2K
       GC_PUSH_ALL_SYM(first_thread.backing_store_end);
 #   endif


### PR DESCRIPTION
#932 の続きになります。

これで、GC 8.2 系の以下のパッチと同じになります。
https://github.com/ivmai/bdwgc/commit/a850a27142065ec7ea37ca81369b333feace4d07

＜テスト結果＞
https://github.com/Hamayama/Gauche/actions/runs/6120731498

build-linux で、以下のログが出ないことを確認しました。

```
In file included from /home/runner/work/Gauche/Gauche/gc/extra/gc.c:76:
/home/runner/work/Gauche/Gauche/gc/extra/../pthread_support.c: In function ‘GC_push_thread_structures’:
/home/runner/work/Gauche/Gauche/gc/extra/../pthread_support.c:555:17: warning: passing argument 1 of ‘GC_push_all’ discards ‘volatile’ qualifier from pointer target type [-Wdiscarded-array-qualifiers]
  555 |     GC_push_all(&GC_threads, (ptr_t)(&GC_threads) + sizeof(GC_threads));
      |                 ^~~~~~~~~~~
In file included from /home/runner/work/Gauche/Gauche/gc/extra/gc.c:57:
/home/runner/work/Gauche/Gauche/gc/extra/../mark.c:1197:39: note: expected ‘void *’ but argument is of type ‘struct GC_Thread_Rep * volatile (*)[256]’
 1197 | GC_API void GC_CALL GC_push_all(void *bottom, void *top)
      |                                 ~~~~~~^~~~~~
```

＜参考情報＞
https://github.com/ivmai/bdwgc/issues/572
