### PR TITLE
Fix do-process test on Windows

### DIFF
--- a/ext/gauche/test-process.scm
+++ b/ext/gauche/test-process.scm
@@ -216,7 +216,7 @@
 
 (test* "do-process :on-abnormal-exit #f" #f
        (do-process (cmd cat "NoSuchFile") :output :null :error :null))
-(test* "do-process :on-abnormal-exit #f" #t
+(test* "do-process :on-abnormal-exit #t" #t
        (do-process (cmd cat "test.o") :output :null :error :null))
 (test* "do-process :on-abnormal-exit :error"
        (test-error <process-abnormal-exit>)
@@ -228,7 +228,7 @@
                    :on-abnormal-exit :error :output :null :error :null))
 (test* "do-process :on-abnormal-exit :exit-code"
        1
-       (do-process (cmd grep "ThereCantBeSuchLine" "test.o")
+       (do-process (cmd grep "ThereCantBeSuchLine") :input "test.o"
                    :on-abnormal-exit :exit-code :output :null :error :null))
 
 ;; NB: how to test :wait and :fork?


### PR DESCRIPTION
Windows 環境で do-process のテストが固まっていたので修正しました。

(GitHub Action 上では、固まりませんが…)

あと、テストの説明を一箇所直しました。

＜テスト結果＞
OS : Windows 10 (version 22H2) (64bit)
開発環境 : MSYS2/MinGW-w64 (64bit) (gcc version 13.2.0 (Rev2, Built by MSYS2 project)))
Gauche : コミット 05bd751 + 本変更
make check
Total: 35900 tests, 35900 passed,     0 failed,     0 aborted.
