### PR TITLE
Make `emergency-exit`'s exit code handling consistent with `exit`

### DIFF
--- a/lib/r7rs-setup.scm
+++ b/lib/r7rs-setup.scm
@@ -457,7 +457,11 @@
   (import r7rs.aux)
   (export command-line emergency-exit exit
           get-environment-variable get-environment-variables)
-  (define (emergency-exit :optional (obj 0)) (sys-exit obj))
+  (define (emergency-exit :optional (code 0))
+    (sys-exit
+      (cond
+        [(and (integer? code) (not (negative? code))) code]
+        [else 70]))) ; EX_SOFTWARE
   (define get-environment-variable  sys-getenv)
   (define get-environment-variables sys-environ->alist)
   (provide "scheme/process-context"))

--- a/lib/r7rs-setup.scm
+++ b/lib/r7rs-setup.scm
@@ -460,6 +460,7 @@
   (define (emergency-exit :optional (code 0))
     (sys-exit
       (cond
+        [(eqv? code #t) 0]
         [(and (integer? code) (not (negative? code))) code]
         [else 70]))) ; EX_SOFTWARE
   (define get-environment-variable  sys-getenv)


### PR DESCRIPTION
This PR makes status code handling consistent between `exit` and `emergency-exit` procedures.

I'm not sure if there is a better way to share this logic between them...
Also, where should I write tests that `exit`s?

Thanks ahead!