### PR TITLE
Make version specification option to work on Windows

### DIFF
--- a/src/paths.c
+++ b/src/paths.c
@@ -143,7 +143,7 @@ static const char *get_executable_path()
 
 static const char *get_install_dir()
 {
-    /* path is either $PREFIX\lib\gauche-$ABI\$VERSION\$ARCH or $PRFIX\lib */
+    /* path is either $PREFIX\lib\gauche-$ABI\$VERSION\$ARCH or $PREFIX\lib */
     const char *path = get_libgauche_path();
     if (path != NULL) {
         /* remove libgauche-$ABI.dll */
@@ -361,7 +361,7 @@ static const char *get_executable_path()
 
 static const char *get_install_dir()
 {
-    /* path is either $PREFIX/lib/gauche-$ABI/$VERSION/$ARCH or $PRFIX/lib */
+    /* path is either $PREFIX/lib/gauche-$ABI/$VERSION/$ARCH or $PREFIX/lib */
     const char *path = get_libgauche_path();
     if (path != NULL) {
         /* remove libgauche-$ABI.so */


### PR DESCRIPTION
Windows上で、-v と -v: オプションが動作するようにしました。

- src/libeval.scm
  Windowsでは、拡張子を付けないと glob に失敗するため対応した。
  そして、sys-exec (execvp) ではなく sys-fork-and-exec (CreateProcess) を使うようにした。
  そして、起動したプロセスの終了を待って、終了コードを返すようにした。

- src/paths.c
  Windows 用の get_install_dir() を、Linux と同様にした。
  Linux 用の get_install_dir() を、1箇所修正した。
  (dir と dir1 のところ。ないと思いますが、もしこれで逆に不具合が出たら、連絡ください…)
  あと、現状、get_install_dir() が4個あって、
  3個目のもの (旧Mac用?) は、$PREFIX/lib/gauche-$ABI/$VERSION/$ARCH に非対応だと思う。
  (-v: オプションができたので、ビルドできないということはないと思うが…)

＜テスト＞

- とりあえず main.c の maybe_invoke_other_version() の同一バージョンチェックを外し、
  gosh -v0.9.13 で、以下の2個のプロセスが起動することを確認しました。
  C:\Program Files\Gauche\bin\gosh.exe
  C:\Program Files\Gauche\lib\gauche-0.98\0.9.13\x86_64-w64-mingw32\gosh.exe

- 以下の内容が正しい位置を指していることを確認しました。
  ```
  (gauche-library-directory)
  (gauche-architecture-directory)
  (gauche-site-library-directory)
  (gauche-site-architecture-directory)
  (with-module gauche.internal (%gauche-executable-path))
  (with-module gauche.internal (%gauche-runtime-directory))
  (with-module gauche.internal (%gauche-libgauche-path))
  ```

- mintty上で、以下が動作することを確認しました。
  ```
  echo "(print 123)" | gosh -v0.9.13 | cat
  echo $?
  gosh -v0.9.13 -e"(exit 10)"
  echo $?
  ```
