### PR TITLE
Update mingw-dist.sh about version specification of Gauche for build v2

### DIFF
--- a/src/mingw-dist.sh
+++ b/src/mingw-dist.sh
@@ -8,6 +8,10 @@
 
 set -e
 
+# TRANSIENT: Disabled version specification of Gauche for build.
+# Consider to enable it after 0.9.14 release.
+DISABLE_BUILD_GOSH_FLAGS="BUILD_GOSH_FLAGS="
+
 # Set MINGWDIR if MinGW is installed in different place.
 case "$MSYSTEM" in
   MINGW64)
@@ -134,7 +138,7 @@ if [ "$SKIP_CONFIG" != yes ]; then
               --with-tls=$tlslibs \
               --with-dbm=ndbm,odbm $buildopt
 fi
-make BUILD_GOSH_FLAGS=
+make $DISABLE_BUILD_GOSH_FLAGS
 
 if [ $? -ne 0 ]; then
   echo "Build failed.  Aborting packaging."
@@ -142,9 +146,9 @@ if [ $? -ne 0 ]; then
 fi
 
 # prepare precompiled directory tree.
-make install
-(cd src; make install-mingw)
-make install-examples
+make install $DISABLE_BUILD_GOSH_FLAGS
+(cd src; make install-mingw $DISABLE_BUILD_GOSH_FLAGS)
+make install-examples $DISABLE_BUILD_GOSH_FLAGS
 rm -rf $distdir/lib/libgauche.dll*
 case "$MSYSTEM" in
   MINGW64|MINGW32)


### PR DESCRIPTION
現状だと、(Gauche 0.9.13 がインストールされていても)
WARNING: No installed Gauche with version 0.9.13 under C:\Program Files\Gauche\lib\. Using the current version.
がたくさんでたため、バージョン指定を無効のままにしています。

次のバージョンで有効にすることを検討するように、コメントを入れました。

また、make install でバージョン指定が起動することがあったため、そちらも無効にしました。
