### PR TITLE
Implement fast lock on windows

### DIFF
--- a/src/gauche/pthread.h
+++ b/src/gauche/pthread.h
@@ -117,7 +117,9 @@ typedef pthread_spinlock_t ScmInternalFastlock;
     pthread_spin_unlock(&(spin))
 #define SCM_INTERNAL_FASTLOCK_DESTROY(spin) \
     pthread_spin_destroy(&(spin))
+#define SCM_INTERNAL_FASTLOCK_FINALIZATION_NOT_REQUIRED
 #else  /*!HAVE_PTHREAD_SPINLOCK_T*/
+/* We don't provide fast lock */
 typedef pthread_mutex_t ScmInternalFastlock;
 #define SCM_INTERNAL_FASTLOCK_INIT(fl)   SCM_INTERNAL_MUTEX_INIT(fl)
 #define SCM_INTERNAL_FASTLOCK_LOCK(fl)   SCM_INTERNAL_MUTEX_LOCK(fl)


### PR DESCRIPTION
- Windows で、fast lock (spin lock) を実装しました。

- いろいろ調べたのですが、C11 の Atomic を使用するようにしました。
  競合時のループ処理は、CPU によっては最適な命令があるようでしたが、
  非対応の CPU で固まるのも困るので Sleep(0) にしています。

- あと、win_spinlock_t 構造体に padding 用の dummy を入れていますが、
  これがないとテスト時に、
  `WARNING: allocating instance of class #<class <buffered-input-port>>: coresize argument 272 doesn't match the class definition's (280)`
  というメッセージが出て、テストが中断していました。

＜テスト＞

1. まずは単体のテストプログラムを作って確認。
   https://gist.github.com/Hamayama/0eb5234311054d6dbbe8e75727040aef

2. Gauche に組み込んでテスト。
   https://gist.github.com/Hamayama/fda48fd11d3583653edbbdd9d7d7e714

3. Windows XP (32bit) で動作確認。
   普通に Gauche をビルドすると、もう WIndows XP では動作しない。
   (MSYS2 がもう対象を Windows 8.1 以後としているもよう)
   まず、Windows 10 の PC で、configure.ac に
   CFLAGS="$CFLAGS -DWINVER=0x0502 -D_WIN32_WINNT=0x0502" を挿入し、
   MSYS2/MinGW-w64 (32bit) 開発環境で、
   Gauche をビルドした ( ./DIST gen && src/mingw-dist.sh ) 。
   これで、Windows XP で起動する Gauche ができたため、
   Gauche-mingw-dist\Gauche-i686 フォルダを、
   Windows XP の PC にコピーし、上記 1. 2. を実行した。
   一応、大丈夫そうではあった。

＜関連 Issue＞
- #901
- #937
- #951
- #952
