### PR TITLE
Fix fast lock on windows (reassignment oldval)

### DIFF
--- a/src/system.c
+++ b/src/system.c
@@ -2977,6 +2977,8 @@ int Scm__WinFastLockLock(ScmInternalFastlock spin)
     if (spin != NULL) {
         ScmAtomicVar idle = 0;
         while (!AO_compare_and_swap_full(&spin->lock_state, idle, 1)) {
+            /* idle might be changed */
+            idle = 0;
             /* it might be slow */
             Sleep(0);
         }


### PR DESCRIPTION
- コミット 07ed42b (2023-10-28) で、Windows の fast lock (spin lock) が、
  ScmAtomicVar を使うように変更されましたが、
  このときにロックできなくなっていたため修正しました。

- 以下の test_0002_write で不具合を確認しました。
  https://gist.github.com/Hamayama/fda48fd11d3583653edbbdd9d7d7e714

- 原因は、src/gauche/priv/atomicP.h で、
  AO_compare_and_swap_full() が 3 パターン定義されていますが、
  元々の libatomic_ops のもの以外は、
  条件不成立時に oldval を現在の値で置き換えるという仕様があったためです。

- この仕様のために、スピンの2周目で、条件が逆転していました。

＜関連 Issue＞
- #901
- #937
- #951
- #952
- #955
