### PR TITLE
Add document generator in ePub format

### DIFF
--- a/doc/Makefile.in
+++ b/doc/Makefile.in
@@ -57,10 +57,10 @@ infodir     = @infodir@
 DESTDIR =
 
 .PHONY: all install uninstall pre-package check test \
-	texi html htmls dvi pdf info \
+	texi html htmls dvi pdf info epub \
 	clean distclean maintainer-clean
 
-.SUFFIXES: .texi .html .info.gz .pdf .dvi
+.SUFFIXES: .texi .html .info.gz .pdf .dvi .epub
 
 all: info
 
@@ -108,6 +108,9 @@ test :
 %.dvi : %.texi
 	$(MAKEDOC) dvi $< "$(MAKEINFO)"
 
+%.epub : %.texi
+	$(MAKEDOC) epub $< "$(MAKEINFO)"
+
 # special rule to regenerate srfis.texi in case srfis.scm is modified.
 srfis.texi : $(top_builddir)/src/srfis.scm
 	cd $(top_builddir)/src; $(MAKE) libsrfis.scm
@@ -120,6 +123,7 @@ htmls-draft : gauche-refe-draft/index.html gauche-refj-draft/index.html
 dvi : gauche-refe.dvi gauche-refj.dvi
 pdf : gauche-refe.pdf gauche-refj.pdf
 info : gauche-refe.info.gz gauche-refj.info.gz
+epub : gauche-refe.epub gauche-refj.epub
 
 gauche-refe.texi : $(TEXIS) $(PREPROCESSOR)
 	$(GOSH) $(PREPROCESSOR) -en -o gauche-refe.texi $(srcdir)/gauche-ref.texi
@@ -139,6 +143,7 @@ clean:
 	      $(EXTRACTED:.texi=.dvi)   \
 	      $(EXTRACTED:.texi=.info*) \
 	      $(EXTRACTED:.texi=.html)  \
+	      $(EXTRACTED:.texi=.epub)  \
 	      $(EXTRACTED)
 	rm -rf $(EXTRACTED:.texi=/) $(EXTRACTED:.texi=-draft/)
 	rm -rf $(EXTRACTED:.texi=.t2d/)

--- a/doc/intro.texi
+++ b/doc/intro.texi
@@ -91,14 +91,14 @@ Gauche is a Scheme script engine; it reads Scheme programs,
 compiles it on-the-fly and executes it on a virtual machine.
 Gauche conforms the language standard
 "Revised^7 Report on the Algorithmic Language Scheme"
-(@uref{https://bitbucket.org/cowan/r7rs/raw/tip/rnrs/r7rs.pdf}),
+(@uref{https://standards.scheme.org/official/r7rs.pdf}),
 and supports various common libraries defined in SRFIs
 (@uref{https://srfi.schemers.org}).
 @c JP
 GaucheはScheme言語のスクリプトエンジンです。
 Schemeプログラムを読み込み、直ちにコンパイルして仮想マシンで実行します。
 Scheme言語の標準である、"Revised^7 Report on the Algorithmic Language Scheme"
-(@uref{https://bitbucket.org/cowan/r7rs/raw/tip/rnrs/r7rs.pdf})
+(@uref{https://standards.scheme.org/official/r7rs.pdf})
 に準拠しています。また、SRFI
 (@uref{https://srfi.schemers.org}) に規定されている数多くのライブラリを
 サポートしています。

--- a/doc/makedoc.scm
+++ b/doc/makedoc.scm
@@ -21,6 +21,7 @@
         [("htmls" input makeinfo version) (do-htmls input makeinfo version)]
         [("pdf" input makeinfo)           (do-pdf input makeinfo)]
         [("dvi" input makeinfo)           (do-dvi input makeinfo)]
+        [("epub" input makeinfo)          (do-epub input makeinfo)]
         [_ (usage)])
     0 1))
 
@@ -32,6 +33,7 @@
   (print "  htmls input MAKEINFO VERSION-STRING - generate html files in subdir")
   (print "  pdf input MAKEINFO                  - generate pdf")
   (print "  dvi input MAKEINFO                  - generate dvi")
+  (print "  epub input MAKEINFO                 - generate ePub")
   #f)
 
 (define (make-cmd cmd-list)
@@ -163,3 +165,6 @@
       (sys-putenv "TEX=dviluatex"))]
    [else])
   (do-process (make-cmd `(,makeinfo "--dvi" "--Xopt" "--tidy" ,input))))
+
+(define (do-epub input makeinfo)
+  (do-process (make-cmd `(,makeinfo "--epub3" ,input))))


### PR DESCRIPTION
Add ePub document generator.

Texinfo 7 can provides ePub output.
ePub format can be used for many devices.