### PR TITLE
Display additional stack trace for r7rs#import error v2

### DIFF
--- a/src/error.c
+++ b/src/error.c
@@ -1128,6 +1128,25 @@ void Scm_DumpStackTrace(ScmVM *vm, ScmPort *port)
     SCM_PUTZ("Stack Trace:\n", -1, port);
     SCM_PUTZ("_______________________________________\n", -1, port);
     Scm_ShowStackTrace(port, stack, 0, 0, 0, 0);
+
+    /* display additional stack trace */
+    if (vm->errorCont) {
+        ScmContFrame *vmcont = vm->cont;
+        ScmCompiledCode *vmbase = vm->base;
+        vm->cont = vm->errorCont;
+        vm->base = NULL;
+        ScmObj stack2 = Scm_VMGetStackLite(vm);
+        if (!Scm_EqualP(stack, stack2)) {
+            SCM_PUTZ("Stack Trace on Error:\n", -1, port);
+            SCM_PUTZ("_______________________________________\n", -1, port);
+            Scm_ShowStackTrace(port, stack2, 0, 0, 0, 0);
+        }
+        vm->cont = vmcont;
+        vm->base = vmbase;
+        /* reset information for additional stack trace */
+        vm->errorCont = NULL;
+    }
+
     if (SCM_PAIRP(calls)) {
         SCM_PUTZ("Call Trace:\n", -1, port);
         SCM_PUTZ("_______________________________________\n", -1, port);

--- a/src/gauche/vm.h
+++ b/src/gauche/vm.h
@@ -580,6 +580,10 @@ struct ScmVMRec {
                                    appears in 'reset' and the end marker of
                                    partial continuation is set. */
 
+    /* for additional stack trace */
+    ScmContFrame *errorCont;    /* continuation saved on error.
+                                   this is used to display stack trace
+                                   that is dropped during import. */
 };
 
 SCM_EXTERN ScmVM *Scm_NewVM(ScmVM *proto, ScmObj name);


### PR DESCRIPTION
**＜＜本件は、急いでマージする必用はありません。＞＞**

#528 を更新したものです。

現状の HEAD に移植しました。

これは、import 中にエラーが発生すると、(スタックトレースが捨てられるために)
エラーの発生箇所が分からないという問題に対応したものです。

import 中にエラーが発生した場合に、
(最初の1個分だけ) スタックトレースを保存し、
現状のスタックトレースの後ろに表示します。

ただ、アドホックであまり良くないかもしれない。

(あと、GAUCHE_SPLIT_STACK と機能がかぶっている気もしましたが、
ちょっとよく分かりませんでした)


＜補足情報＞
この改造をしないでデバッグする場合、
import を load に置き変えるという方法があります。
(load だと (実行時の読み込みになり) スタックトレースが捨てられません。)
ただ、ライブラリ内でさらに import を使っていた場合には、
エラーにつながるすべての import を load に置き換える必要があります。


＜テスト結果＞
テストデータを、以下に作成しました。
https://gist.github.com/Hamayama/937320546e05b4d889f35cfae50a6310

**変更前**
```
> gosh -I. library-test.scm
*** ERROR: invalid application: (() ())
    While loading "./library1.sld" at line 5
    While compiling "./library2.sld" at line 1: (define-library (library2) (import (scheme base) (library1)))
    While loading "./library2.sld" at line 7
    While compiling "./library-test.scm" at line 9: (import (library2))
    While loading "./library-test.scm" at line 9
Stack Trace:
_______________________________________
  0  (%require feature)
  1  (%map1c pass1 (cdr form) cenv)
  2  (pass1 program cenv)
  3  (eval s #f)
  4  (with-error-handler (lambda (e) (cond (else (let1 e2 (if (con ...
  5  (load-from-port (if ignore-coding port (open-coding-aware-por ...
```

**変更後**
```
> gosh -I. library-test.scm
*** ERROR: invalid application: (() ())
    While loading "./library1.sld" at line 5
    While compiling "./library2.sld" at line 1: (define-library (library2) (import (scheme base) (library1)))
    While loading "./library2.sld" at line 7
    While compiling "./library-test.scm" at line 9: (import (library2))
    While loading "./library-test.scm" at line 9
Stack Trace:
_______________________________________
  0  (%require feature)
  1  (%map1c pass1 (cdr form) cenv)
  2  (pass1 program cenv)
  3  (eval s #f)
  4  (with-error-handler (lambda (e) (cond (else (let1 e2 (if (con ...
  5  (load-from-port (if ignore-coding port (open-coding-aware-por ...
Stack Trace on Error:
_______________________________________
  0  (() '())
        at "./library1.scm":3
  1  (define reverse-rconj (case-lambda (() '()) ((lst) lst) ((lst ...
        at "./library1.scm":1
  2  (eval s #f)
  3  (with-error-handler (lambda (e) (cond (else (let1 e2 (if (con ...
  4  (load-from-port (if ignore-coding port (open-coding-aware-por ...
  5  (%require feature)
  6  (%map1c pass1 (cdr form) cenv)
  7  (%map1c pass1 body newenv)
  8  (pass1 program cenv)
  9  (eval s #f)
 10  (with-error-handler (lambda (e) (cond (else (let1 e2 (if (con ...
 11  (load-from-port (if ignore-coding port (open-coding-aware-por ...
 12  (%require feature)
 13  (%map1c pass1 (cdr form) cenv)
 14  (pass1 program cenv)
 15  (eval s #f)
 16  (with-error-handler (lambda (e) (cond (else (let1 e2 (if (con ...
 17  (load-from-port (if ignore-coding port (open-coding-aware-por ...
```
