### PR TITLE
Fix reset/shift and eval combination problem v2

### DIFF
--- a/lib/gauche/partcont.scm
+++ b/lib/gauche/partcont.scm
@@ -3,15 +3,17 @@
 (select-module gauche.partcont)
 
 (define %reset (with-module gauche.internal %reset))
+(define %reset-with-cont-frame-wrapper
+  (with-module gauche.internal %reset-with-cont-frame-wrapper))
 (define %call/pc (with-module gauche.internal %call/pc))
 
 (define-syntax reset
   (syntax-rules ()
     [(reset expr ...)
-     (%reset (^[] expr ...))]))
+     (%reset-with-cont-frame-wrapper (^[] expr ...))]))
 
 (define (call/pc proc)
-  (%call/pc (^k (proc (^ args (reset (apply k args)))))))
+  (%call/pc (^k (proc (^ args (%reset (^[] (apply k args))))))))
 
 (define-syntax shift
   (syntax-rules ()

--- a/src/gauche.h
+++ b/src/gauche.h
@@ -660,6 +660,7 @@ SCM_EXTERN ScmObj Scm_VMCall(ScmObj *args, int argcnt, void *data);
 SCM_EXTERN ScmObj Scm_VMCallCC(ScmObj proc);
 SCM_EXTERN ScmObj Scm_VMCallPC(ScmObj proc);
 SCM_EXTERN ScmObj Scm_VMReset(ScmObj proc);
+SCM_EXTERN ScmObj Scm_VMResetWithContFrameWrapper(ScmObj proc);
 SCM_EXTERN void   Scm_VMPushDynamicHandlers(ScmObj, ScmObj, ScmObj);
 SCM_EXTERN ScmObj Scm_VMDynamicWind(ScmObj pre, ScmObj body, ScmObj post);
 SCM_EXTERN int    Scm_ContinuationP(ScmObj proc);

--- a/src/libproc.scm
+++ b/src/libproc.scm
@@ -77,8 +77,10 @@
 
 (select-module gauche.internal)
 ;; for partial continuation.  See lib/gauche/partcont.scm
-(define-cproc %call/pc (proc) (return (Scm_VMCallPC proc)))
-(define-cproc %reset (proc) (return (Scm_VMReset proc)))
+(define-cproc %call/pc (proc) Scm_VMCallPC)
+(define-cproc %reset (proc) Scm_VMReset)
+(define-cproc %reset-with-cont-frame-wrapper (proc)
+  Scm_VMResetWithContFrameWrapper)
 
 ;; Continuaton prompts
 (select-module gauche)

--- a/test/continuation.scm
+++ b/test/continuation.scm
@@ -893,6 +893,32 @@
                next
                (lambda () (display "[D02]"))))))))
 
+(test* "reset/shift + guard 2"
+       "catch error!!"
+       (let1 k1 #f
+         (reset
+          (guard (e [else "catch error!!"])
+            (shift k (set! k1 k))
+            (error "err")))
+         (k1 100)))
+
+(test* "reset/shift + eval 1"
+       42
+       (reset (eval '(shift k (k 42)) (current-module))))
+
+(test* "reset/shift + eval 2"
+       42
+       (reset (eval '(+ (shift k (k 42))) (current-module))))
+
+(test* "reset/shift + eval 3"
+       42
+       (reset (+ (eval '(shift k (k 42)) (current-module)))))
+
+(test* "reset/shift + eval 4"
+       '(42 43 44)
+       (receive vals (reset (eval '(shift k (k 42 43 44)) (current-module)))
+         vals))
+
 (test* "dynamic-wind + reset/shift 1"
        "[d01][d02][d03][d04]"
        ;"[d01][d02][d04][d01][d03][d04]"


### PR DESCRIPTION
**＜＜本件は、急いでマージする必用はありません。＞＞**

#848 を更新したものです。

現状の HEAD に移植しました。

本件は、以下の問題を修正したものです。
```
(use gauche.partcont)
(reset (eval '(shift k (k 42)) (current-module)))
;; ==> #<undef> ( 42 になるのが正しい )
```

```
(use gauche.partcont)
(define k1 #f)
(reset (guard (e (else e))
         (shift k (set! k1 k))
         (raise "raised")))
(k1)
;; ==> *** ERROR: attempt to return from a ghost continuation. ( "raised" になるのが正しい )
```

どちらも、部分継続の終端マーカーのセットと、
Scm_VMDynamicWind() の継続フレーム追加との
競合によるものであり、
reset 実行時に継続フレームを一段追加することで対策しています。

ただ、今見ると、
vm.c の「Fix memory leak of the empty partial continuation.」のところが、
若干あやしいような気もします。


＜補足情報＞
この改造をしないで回避したい場合、
以下のように reset と eval/guard の間に何か命令をはさむとうまくいくことがあります。
ただ、ループにするとメモリリークするので、この方向で一般化はできないようです。

```
(use gauche.partcont)
(reset (values (eval '(shift k (k 42)) (current-module))))
;; ==> 42
```

```
(use gauche.partcont)
(define k1 #f)
(reset (values (guard (e (else e))
                 (shift k (set! k1 k))
                 (raise "raised"))))
(k1)
;; ==> "raised"
```


＜テスト結果＞
(1) [Gauche-effects](https://github.com/Hamayama/Gauche-effects) の effects.scm で、
    `*use-native-reset*` を #t にして、各サンプルを実行 ==> OK

(2) 以下のメモリリークのテスト ==> OK
(出典 : http://okmij.org/ftp/continuations/against-callcc.html#memory-leak )
(これは (use gauche.partcont-meta) だとメモリリークします)
```
(use gauche.partcont)
(define (leak-test1 identity-thunk)
  (let loop ((id (lambda (x) x)))
    (loop (id (identity-thunk)))))
(leak-test1 (lambda () (reset (shift k k))))
```

(3) Kahua の nqueen を実行 ==> OK

(4) https://practical-scheme.net/wiliki/wiliki.cgi?Gauche%3ABugs#H-2dgngv
    の pcdemo10.scm を実行 ==> OK
