### PR TITLE
Add SRFI 215 - Central Log Exchange

### DIFF
--- a/doc/modsrfi.texi
+++ b/doc/modsrfi.texi
@@ -90,6 +90,7 @@ R7RSライブラリとしては@code{(srfi 13)})ということに注意して�
 * String-notated bytevectors::  srfi.207
 * Enums and enum sets::         srfi.209
 * Procedures and syntax for multiple values::  srfi.210
+* Central Log Exchange::        srfi.215
 * SICP prerequisites::          srfi.216
 * Integer sets::                srfi.217
 * Define higher-order lambda::  srfi.219
@@ -13241,6 +13242,129 @@ the result(s) of those procedures.  These can be written using
   @equiv{} ((compose-left proc @dots{}) obj)
 @end example
 @end defun
+
+@c ----------------------------------------------------------------------
+@node Central Log Exchange
+@section @code{srfi.215} - Central Log Exchange
+@c NODE 中央ログ交換,  @code{srfi.215} - 中央ログ交換
+
+@deftp {Module} srfi.215
+@mdindex srfi.215
+@c EN
+This module provides a central log exchange that connects log
+producers with log consumers, allowing code to produce log messages
+without knowledge of which log system is actually used.
+@c COMMON
+
+@c EN
+This module is built on, and compatible with, the
+@pxref{User-level logging} interface.
+@c COMMON
+@end deftp
+
+@deffn {Parameter} current-log-callback
+[SRFI-215]
+@c MOD srfi.215
+@c EN
+This parameter is bound to the current log callback, which is a
+procedure that takes a log message as its single argument. Log
+messages are passed as association lists.
+@c COMMON
+@end deffn
+
+@deffn {Parameter} current-log-fields
+[SRFI-215]
+@c MOD srfi.215
+@c EN
+This parameter contains a list of additional keys and values that are
+automatically appended to the fields passed to @code{send-log}. The
+effect is as if that procedure was always invoked as
+@code{(apply send-log severity message [key value] ... (current-log-fields))}.
+@c COMMON
+@end deffn
+
+@defun send-log SEVERITY MESSAGE @dots{}
+[SRFI-215]
+@c MOD srfi.215
+@c EN
+Constructs a log message that contains the arguments and the current
+log fields. The resulting log message is passed as an argument to the
+current log callback. The optional arguments are grouped into pairs of
+keys and values and are added to the log message, as in an association
+list. An error is signaled if an odd number of arguments is passed, or
+if one of the keys is not a symbol.
+@c COMMON
+
+@example
+(send-log INFO (string-append "User " username " logged in")
+          'USERNAME username 'REMOTE_IP remote-ip)
+@end example
+@end defun
+
+@defvr {Constant} EMERGENCY
+[SRFI-215]
+@c MOD srfi.215
+@c EN
+Log message severity constant for when the system is unusable.
+@c COMMON
+@end defvr
+
+@defvr {Constant} ALERT
+[SRFI-215]
+@c MOD srfi.215
+@c EN
+Log message severity constant for when action must be taken
+immediately.
+@c COMMON
+@end defvr
+
+@defvr {Constant} CRITICAL
+[SRFI-215]
+@c MOD srfi.215
+@c EN
+Log message severity constant for critical conditions.
+@c COMMON
+@end defvr
+
+@defvr {Constant} ERROR
+[SRFI-215]
+@c MOD srfi.215
+@c EN
+Log message severity constant for error conditions.
+@c COMMON
+@end defvr
+
+@defvr {Constant} WARNING
+[SRFI-215]
+@c MOD srfi.215
+@c EN
+Log message severity constant for warning conditions.
+@c COMMON
+@end defvr
+
+@defvr {Constant} NOTICE
+[SRFI-215]
+@c MOD srfi.215
+@c EN
+Log message severity constant for normal but significant conditions.
+@c COMMON
+@end defvr
+
+@defvr {Constant} INFO
+[SRFI-215]
+@c MOD srfi.215
+@c EN
+Log message severity constant for information messages.
+@c COMMON
+@end defvr
+
+@defvr {Constant} DEBUG
+[SRFI-215]
+@c MOD srfi.215
+@c EN
+Log message severity constant for debug-level messages.
+@c COMMON
+@end defvr
 
 @c ----------------------------------------------------------------------
 @node SICP prerequisites, Integer sets, Procedures and syntax for multiple values, Library modules - SRFIs

--- a/lib/srfi/215.scm
+++ b/lib/srfi/215.scm
@@ -1,0 +1,116 @@
+;;;
+;;; SRFI-215 - Central Log Exchange
+;;;
+;;;   Copyright (c) 2020  Goran Weinholt
+;;;   Copyright (c) 2024  Antero Mejr  <mail@antr.me>
+;;;
+;;;   This module is a Gauche port of the SRFI 215 sample implementation,
+;;;   and is therefore MIT-licensed.
+;;;
+;;;   Permission is hereby granted, free of charge, to any person
+;;;   obtaining a copy of this software and associated documentation files
+;;;   (the "Software"), to deal in the Software without restriction,
+;;;   including without limitation the rights to use, copy, modify, merge,
+;;;   publish, distribute, sublicense, and/or sell copies of the Software,
+;;;   and to permit persons to whom the Software is furnished to do so,
+;;;   subject to the following conditions:
+;;;
+;;;   The above copyright notice and this permission notice (including the
+;;;   next paragraph) shall be included in all copies or substantial
+;;;   portions of the Software.
+;;;
+;;;   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;;;   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+;;;   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;;;   NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+;;;   BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+;;;   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+;;;   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+;;;   SOFTWARE.
+
+(define-module srfi.215
+  (use gauche.logger)
+  (use gauche.uvector)
+  (export send-log
+          current-log-fields
+          current-log-callback
+          EMERGENCY ALERT CRITICAL ERROR WARNING NOTICE INFO DEBUG
+          ))
+(select-module srfi.215)
+
+;; These severities are from RFC 5424 ("The Syslog Protocol").
+(define EMERGENCY 0)                ; system is unusable
+(define ALERT 1)                    ; action must be taken immediately
+(define CRITICAL 2)                 ; critical conditions
+(define ERROR 3)                    ; error conditions
+(define WARNING 4)                  ; warning conditions
+(define NOTICE 5)                   ; normal but significant condition
+(define INFO 6)                     ; informational messages
+(define DEBUG 7)                    ; debug-level messages
+
+(define severity-strings
+  '((0 . "EMERGENCY")
+    (1 . "ALERT")
+    (2 . "CRITICAL")
+    (3 . "ERROR")
+    (4 . "WARNING")
+    (5 . "NOTICE")
+    (6 . "INFO")
+    (7 . "DEBUG")))
+
+(define (field-list->alist plist)
+  (let f ((fields plist))
+    (cond ((null? fields)
+           '())
+          ((or (not (pair? fields)) (not (pair? (cdr fields))))
+           (error "short field list" plist))
+          (else
+           (let ((k (car fields)) (v (cadr fields)))
+             (if (not v)
+                 (f (cddr fields))
+                 (let ((k^ (cond ((symbol? k) k)
+                                 (else
+                                  (error "invalid key" k plist))))
+                       (v^ (cond ((string? v) v)
+                                 ((and (integer? v) (exact? v)) v)
+                                 ((bytevector? v) v)
+                                 ((error-object? v) v) ;R7RS
+                                 (else
+                                  (let ((p (open-output-string)))
+                                    (write v p)
+                                    (get-output-string p))))))
+                   (cons (cons k^ v^)
+                         (f (cddr fields))))))))))
+
+(define current-log-fields
+  (make-parameter '()
+                  (lambda (plist)
+                    (field-list->alist plist)
+                    plist)))
+
+(define current-log-callback
+  (make-parameter (lambda (log-entry)
+                    (log-format "~a: ~a ~a"
+                                (assoc-ref severity-strings
+                                           (assoc-ref log-entry 'SEVERITY))
+                                (assoc-ref log-entry 'MESSAGE)
+                                (alist-delete
+                                 'SEVERITY
+                                 (alist-delete 'MESSAGE log-entry eq?) eq?)))
+                  (lambda (hook)
+                    (unless (procedure? hook)
+                      (error "current-log-callback: expected a procedure" hook))
+                    hook)))
+
+(define (send-log severity message . plist)
+  (unless (and (exact? severity) (integer? severity) (<= 0 severity 7))
+    (error "send-log: expected a severity from 0 to 7"
+           severity message plist))
+  (unless (string? message)
+    (error "send-log: expected message to be a string"
+           severity message plist))
+  (let* ((fields (append plist (current-log-fields)))
+         (alist (field-list->alist fields)))
+    ((current-log-callback) `((SEVERITY . ,severity)
+                              (MESSAGE . ,message)
+                              ,@alist))))


### PR DESCRIPTION
Provides a generic way to send log messages for implementation-independent code.

For Gauche, it's just a small layer over `gauche.logger`.
