### PR TITLE
Fix %appended-range-index

### DIFF
--- a/lib/data/range.scm
+++ b/lib/data/range.scm
@@ -123,7 +123,6 @@
     (let loop ([lo 0] [hi len] [k (ash len -1)])
       (let1 p (vector-ref vec k)
         (cond [(= k lo) (call-indexer p i)]
-              [(= k (- hi 1)) (call-indexer p i)]
               [(> (car p) i) (loop lo k (+ lo (ash (- k lo) -1)))]
               [else (loop k hi (+ k (ash (- hi k) -1)))])))))
 


### PR DESCRIPTION
`(= k (- hi 1))` のケースは、indexerを異なるrangeで呼んでしまっているようです。

```scheme
gosh> (range->list (range-append (numeric-range 1 3) (numeric-range 11 14)))
(9 10 11 12 13)
```