### PR TITLE
Add SRFI-138's compile-r7rs

### DIFF
--- a/doc/program.texi
+++ b/doc/program.texi
@@ -3168,6 +3168,16 @@ Gaucheのアプリケーションの配布を簡単にするために、
 @c COMMON
 
 @c EN
+Gauche also provides a @code{compile-r7rs} program that is compliant
+with the command-line interface presented in SRFI 138
+(@url{https://srfi.schemers.org/srfi-138/srfi-138.html}).
+@c JP
+Gauche は、準拠する @code{compile-r7rs} プログラムも提供します
+SRFI 138 で提供されるコマンドライン インターフェイスを使用
+(@url{https://srfi.schemers.org/srfi-138/srfi-138.html})
+@c COMMON
+
+@c EN
 @subheading Quick recipe
 @c JP
 @subheading 簡単な使い方

--- a/lib/Makefile.in
+++ b/lib/Makefile.in
@@ -164,6 +164,7 @@ SCMFILES = \
        tools/build-standalone tools/check-script \
        tools/genstub tools/get-cacert \
        tools/make-export-list tools/precomp tools/docprep \
+       tools/compile-r7rs \
        www/cgi.scm www/cgi-test.scm www/cgi/test.scm www/css.scm
 
 all:
@@ -180,6 +181,7 @@ install:
 	if test -f slibcat; then \
 	  $(INSTALL_DATA) slibcat "$(DESTDIR)$(SCM_INSTALL_DIR)/slibcat"; \
 	fi
+	$(INSTALL) -m 555 tools/compile-r7rs "$(bindir)"
 
 uninstall:
 

--- a/lib/tools/compile-r7rs
+++ b/lib/tools/compile-r7rs
@@ -1,0 +1,123 @@
+#! /usr/bin/env gosh
+
+;;; compile-r7rs - compile R7RS programs
+;;;
+;;;   Copyright (c) 2024  Antero Mejr  <mail@antr.me>
+;;;
+;;;   Redistribution and use in source and binary forms, with or without
+;;;   modification, are permitted provided that the following conditions
+;;;   are met:
+;;;
+;;;   1. Redistributions of source code must retain the above copyright
+;;;      notice, this list of conditions and the following disclaimer.
+;;;
+;;;   2. Redistributions in binary form must reproduce the above copyright
+;;;      notice, this list of conditions and the following disclaimer in the
+;;;      documentation and/or other materials provided with the distribution.
+;;;
+;;;   3. Neither the name of the authors nor the names of its contributors
+;;;      may be used to endorse or promote products derived from this
+;;;      software without specific prior written permission.
+;;;
+;;;   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+;;;   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+;;;   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+;;;   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+;;;   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+;;;   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+;;;   TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+;;;   PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+;;;   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+;;;   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+;;;   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+;;;
+
+;; Similar to build-standalone, but with an SRFI 138-compliant interface.
+
+(use gauche.cgen.standalone)
+(use gauche.parseopt)
+(use gauche.process)
+(use file.util)
+
+;; Needs to return a list of .sld files relative to the supplied dir.
+(define (find-slds dir)
+  (let-values (((subdirs files) (directory-list2 dir :children? #t
+                                                 :add-path? #f)))
+    (let* ((slds (filter (lambda (path)
+                           (let ((ext (path-extension path)))
+                             (and ext (string=? "sld" ext))))
+                         files))
+           (sd-sld (apply append (map (lambda (sd)
+                                        (map (lambda (sld)
+                                               (build-path sd sld))
+                                             (find-slds (build-path dir sd))))
+                                      subdirs))))
+      (append slds sd-sld))))
+
+;; Needs to return a list of full paths to directories with sld files.
+(define (subdirs-with-slds dir)
+  (let-values (((subdirs files) (directory-list2 dir :children? #t
+                                                 :add-path? #t)))
+    (let* ((slds (filter (lambda (path)
+                           (let ((ext (path-extension path)))
+                             (and ext (string=? "sld" ext))))
+                         files))
+           (sd-sld (apply append (map subdirs-with-slds subdirs))))
+      (if (null? slds)
+          sd-sld
+          (cons dir sd-sld)))))
+
+(define (usage)
+  (display "Usage: compile-r7rs [options...] [pathname]
+
+Options:
+-o outfile  Specify output file name.  When omitted, the basename of
+            the main source file is used.
+-I dir      Specify a search path of extra files (lib/library.scm ...)
+            to prepend if they're not relative to the current directory.
+            This option can be given multiple times.
+-A dir      Specify a search path of extra files (lib/library.scm ...)
+            to append if they're not relative to the current directory.
+            This option can be given multiple times.
+-D name
+            Add name to the list of feature identifiers maintained by the
+            Scheme implementation for the purpose of executing the program
+            in the text file pathname. This option can be given multiple
+            times.\n")
+  (exit 1))
+
+(define (main args)
+  (define incdirs '())
+  (define feature-ids '())
+  (define appenddirs '())
+  (define compile-env (sys-getenv "COMPILE_R7RS"))
+  (let-args (cdr args) ([outfile "o=s" #f]
+                        [#f "I=s" #f => (^x (push! incdirs x) #f)]
+                        [#f "D=s" #f => (^x (push! feature-ids x) #f)]
+                        [#f "A=s" #f => (^x (push! appenddirs x) #f)]
+                        [else _ (usage)]
+                        . files)
+    (let* ((dirs (append (reverse incdirs) (reverse appenddirs)))
+           (extras (fold-right (lambda (dir acc)
+                                 (append acc (find-slds dir)))
+                               '() dirs))
+           (incdirs (fold-right (lambda (dir acc)
+                                  (append acc (subdirs-with-slds dir)))
+                                '() dirs))
+           (argstr (string-join (cdr args) " ")))
+      (cond (compile-env
+             (sys-unsetenv "COMPILE_R7RS")
+             (sys-system #"~compile-env ~argstr"))
+            (else
+             (when (not (= 1 (length files))) (usage))
+             (build-standalone
+              (car files)
+              :outfile outfile
+              :extra-files extras
+              :include-dirs incdirs
+              :feature-ids feature-ids)))))
+  0)
+
+;; Local variables:
+;; mode: scheme
+;; end:

--- a/src/core.c
+++ b/src/core.c
@@ -584,6 +584,7 @@ init_cond_features()
 
         /* SRFIs that are not libraries */
         { "srfi-22", NULL },    /* Scheme scripts */
+        { "srfi-138", NULL },    /* compile-r7rs script */
 
         /* Threads */
 #if   defined(GAUCHE_USE_PTHREADS)

--- a/src/srfis.scm
+++ b/src/srfis.scm
@@ -1072,6 +1072,14 @@ textは単に「変更不可でインデクスされた文字列」にすぎま�
 文字列のインデクシングについては@ref{String indexing}を参照してください。
 APIは@ref{R7RS immutable texts}で説明しています。
 
+srfi-138
+()
+
+Compiling Scheme programs to executables
+Supported.  @xref{Building standalone executables}.
+
+Scheme プログラムを実行可能ファイルにコンパイルする
+サポートされています。 @xref{Building standalone executables}。
 
 srfi-141, srfi-141
 ()


### PR DESCRIPTION
SRFI 138 provides a generic/standardized CLI interface to building standalone executables.

This PR adds and installs a script that is similar to tools/build-standalone.