### PR TITLE
Fix PDF/DVI document index generation for non-ASCII words

### DIFF
--- a/doc/Makefile.in
+++ b/doc/Makefile.in
@@ -135,7 +135,7 @@ texi : gauche-refe.texi gauche-refj.texi
 html : gauche-refe.html gauche-refj.html
 htmls : gauche-refe/index.html gauche-refj/index.html
 htmls-draft : gauche-refe-draft/index.html gauche-refj-draft/index.html
-dvi : gauche-refe.dvi gauche-refj.dvi
+dvi : gauche-refe.dvi
 pdf : gauche-refe.pdf gauche-refj.pdf
 info : gauche-refe.info.gz gauche-refj.info.gz
 epub : gauche-refe.epub gauche-refj.epub

--- a/doc/makedoc.scm
+++ b/doc/makedoc.scm
@@ -13,7 +13,7 @@
 (define (main args)
   (cond-expand
    ;; do not let LANG setting affect makeinfo
-   [gauche.sys.setenv (sys-putenv "LANG=C")]
+   [gauche.sys.setenv (sys-putenv "LANG=C.UTF-8")]
    [else])
   (if (match (cdr args)
         [("info" input makeinfo gzip)     (do-info input makeinfo gzip)]

--- a/doc/makedoc.scm
+++ b/doc/makedoc.scm
@@ -11,10 +11,6 @@
 ;;;
 
 (define (main args)
-  (cond-expand
-   ;; do not let LANG setting affect makeinfo
-   [gauche.sys.setenv (sys-putenv "LANG=C.UTF-8")]
-   [else])
   (if (match (cdr args)
         [("info" input makeinfo gzip)     (do-info input makeinfo gzip)]
         [("html" input makeinfo)          (do-html input makeinfo)]

--- a/doc/makedoc.scm
+++ b/doc/makedoc.scm
@@ -155,11 +155,6 @@
   (do-process (make-cmd `(,makeinfo "--pdf" "--Xopt" "--tidy" ,input))))
 
 (define (do-dvi input makeinfo)
-  (cond-expand
-   [gauche.sys.setenv
-    (when (#/j\.texi$/ input)
-      (sys-putenv "TEX=dviluatex"))]
-   [else])
   (do-process (make-cmd `(,makeinfo "--dvi" "--Xopt" "--tidy" ,input))))
 
 (define (do-epub input makeinfo)


### PR DESCRIPTION
Current variable index in PDF/DVI document drops the words like `π`.
This is because Texinfo PDF/DVI index generator wants UTF-8 locale support for non-ASCII (UTF-8) words.

Drop `LANG=C` to restore UTF-8 locale.

This PR also drops japanese DVI document because current LuaTeX-ja drops DVI support.