### PR TITLE
Disable COMPILE_R7RS in gauche-compile-r7rs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -252,11 +252,23 @@ dnl   enable-shared-commands
 dnl
 AC_ARG_ENABLE(shared-commands,
   AS_HELP_STRING([--enable-shared-commands],
-                 [Install commands with SRFI-defined common names such as compile-r7rs.  Note that other Scheme implementations may also install commands with the same name.  This option overwrites them if there's any.]),
+                 [Install commands with SRFI-defined common names such as scheme-r7rs.  Note that other Scheme implementations may also install commands with the same name.  This option overwrites them if there's any.]),
   [
     AS_CASE([$enableval],
             [no], [],
                   [install_common_commands=yes])
+  ], [])
+
+dnl ----------------------------------------------------------
+dnl   enable-compile-r7rs
+dnl
+AC_ARG_ENABLE(compile-r7rs,
+  AS_HELP_STRING([--enable-compile-r7rs],
+                 [Install compile-r7rs command defined in SRFI-138.  Note that other Scheme implementations may also install the command with the same name.  This option overwrites them if there's any.]),
+  [
+    AS_CASE([$enableval],
+            [no], [],
+                  [install_compile_r7rs=yes])
   ], [])
 
 dnl ----------------------------------------------------------
@@ -806,6 +818,13 @@ AS_IF([test "$libgauche_version_link" = yes -a "$SHLIB_OK" = ok],
 AS_IF([test "$install_common_commands" = yes],
       [INSTALL_COMMON_COMMANDS='$(SHELL) $(top_srcdir)/tools/install-shared-commands.sh'],
       [INSTALL_COMMON_COMMANDS=:])
+AS_IF([test "$install_compile_r7rs" = yes], [
+        INSTALL_COMPILE_R7RS_ON=""
+        INSTALL_COMPILE_R7RS_OFF="#"
+      ],[
+        INSTALL_COMPILE_R7RS_ON="#"
+        INSTALL_COMPILE_R7RS_OFF=""
+      ])
 
 AC_SUBST(xhost)
 AC_SUBST(SHLIB_SO_CFLAGS)
@@ -823,6 +842,8 @@ AC_DEFINE_UNQUOTED(SHLIB_SO_SUFFIX, "$SHLIB_SO_SUFFIX", [Shared library file suf
 AC_SUBST(LINK_HELPER)
 AC_SUBST(MAKEVERSLINK)
 AC_SUBST(INSTALL_COMMON_COMMANDS)
+AC_SUBST(INSTALL_COMPILE_R7RS_ON)
+AC_SUBST(INSTALL_COMPILE_R7RS_OFF)
 AC_SUBST(CYGWIN_FIXDLL)
 AC_MSG_RESULT($SHLIB_OK)
 

--- a/doc/program.texi
+++ b/doc/program.texi
@@ -2780,9 +2780,14 @@ the following programs are also installed.
 @itemx scheme-srfi-7
 Those are the names of Scheme interpreter suggeted by SRFI-22.
 They are symlinked to @code{gosh}.
+@end table
+
+Additionally, if you configure Gauche with @code{--enable-compile-r7rs},
+the following program is also installed.
+
+@table @b
 @item compile-r7rs
 This is the name of Scheme compiler recommended by SRFI-138.
-It is symlinked to @code{gauche-compile-r7rs}.
 @end table
 
 @c ----------------------------------------------------------------------
@@ -2944,27 +2949,28 @@ script (@pxref{Building standalone executables}).  We recommend
 that script, for it is more featureful.
 
 The @code{gauche-compile-r7rs} and @code{compile-r7rs} script is provided
-so that you can invoke a 'Scheme compiler' with a stanardized manner.
+so that you can invoke a 'Scheme compiler' with a standardized manner.
 It may be handy if other tools (e.g. IDE) need to invoke a Scheme
 compiler as a subprocess.
 
 This interface is defined in SRFI-138, which also suggests the name
 @code{compile-r7rs}.  We only install @code{gauche-compile-r7rs} by
 default so that we won't accidentally clobber other implementation's
-program, but if you give @code{--enable-shared-commands} option to
-@code{configure} script, a symbolic link @code{compile-r7rs} is created.
+program, but if you give @code{--enable-compile-r7rs} option to
+@code{configure} script, @code{compile-r7rs} is created.
 
 @deftp {Program} gauche-compile-r7rs [options] script.scm
 @deftpx {Program} compile-r7rs [options] script.scm
 Compile a Scheme source file @code{script.scm} and produce an
 executable binary.  The @code{compile-r7rs} is only installed
-if Gauche is configured with @code{--enable-shared-commands}.
+if Gauche is configured with @code{--enable-compile-r7rs}.
 
-If the enviornment variable @code{COMPILE_R7RS} is defined
+If the environment variable @code{COMPILE_R7RS} is defined
 to a non-empty string, it is assumed to a pathname of another
 program, which is invoked with the same arguments to
-@code{gauche-compile-r7rs} instead.  This allows the user to choose
+@code{compile-r7rs} instead.  This allows the user to choose
 alternative implementation's compiler.
+This function is only enabled for compile-r7rs, not gauche-compile-r7rs.
 
 The following command-line arguments are recognized.
 

--- a/lib/gauche/cgen/standalone.scm
+++ b/lib/gauche/cgen/standalone.scm
@@ -137,7 +137,7 @@
   (define (existing-dir? flag)
     (if-let1 m (#/^-[IL]/ flag)
       (cond-expand
-       [gauche.os.windows (shell-escape-string flag 'windows)]
+       [gauche.os.windows (shell-escape-string (string-trim-right flag) 'windows)]
        [else (let1 path (string-trim-both (rxmatch-after m) #\")
                (and (file-exists? path)
                     (if (string-index flag #\")

--- a/lib/tools/compile-r7rs
+++ b/lib/tools/compile-r7rs
@@ -69,24 +69,14 @@
           (cons dir sd-sld)))))
 
 (define (usage)
-  (print "Usage: compile-r7rs [options...] [pathname]")
+  (print "Usage: gauche-compile-r7rs [options...] [pathname]")
   (print)
   (print "Options:")
   (print (option-parser-help-string))
   (exit 1))
 
 (define (main args)
-  (let1 alt-compiler (sys-getenv "COMPILE_R7RS")
-    (if (and alt-compiler (> (string-length alt-compiler) 0))
-      (if (file-is-executable? alt-compiler)
-        (begin
-          (sys-unsetenv "COMPILE_R7RS")
-          (warn "compile-r7rs: Invoking alternative compiler specified \
-                 by COMPILE_R7RS: ~s\n" alt-compiler)
-          (do-process `(,alt-compiler ,@(cdr args)) :fork #f))
-        (exit 1 "Value of COMPILE_R7RS isn't an executable program: ~a"
-              alt-compiler))
-      (do-compile (cdr args)))))
+  (do-compile (cdr args)))
 
 (define (do-compile args)
   (let-args args

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -179,6 +179,9 @@ INSTALL_SUBHEADERS = \
 	gauche/weak.h gauche/win-compat.h gauche/writer.h \
 	gauche/wthread.h
 
+@INSTALL_COMPILE_R7RS_ON@COMPILE_R7RS_COMMAND_EXE = compile-r7rs$(EXEEXT)
+@INSTALL_COMPILE_R7RS_OFF@COMPILE_R7RS_COMMAND_EXE =
+
 INSTALL_LIBS = $(LIBGAUCHE).$(SOEXT) $(LIBGAUCHE_STATIC).a
 INSTALL_BINS = gosh$(EXEEXT)           \
 	       @ALTERNATIVE_GOSH@      \
@@ -186,7 +189,8 @@ INSTALL_BINS = gosh$(EXEEXT)           \
 	       gauche-install$(EXEEXT) \
 	       gauche-package$(EXEEXT) \
 	       gauche-cesconv$(EXEEXT) \
-	       gauche-compile-r7rs$(EXEEXT)
+	       gauche-compile-r7rs$(EXEEXT) \
+	       $(COMPILE_R7RS_COMMAND_EXE)
 INSTALL_SCMS = genstub precomp cesconv build-standalone
 
 PRIVATE_HEADERS = gauche/priv/arith.h gauche/priv/arith_i386.h \
@@ -434,6 +438,9 @@ gauche-cesconv : gauche-cesconv.in
 gauche-compile-r7rs : gauche-compile-r7rs.in
 	$(top_srcdir)/tools/make-tool.sh $(BIN_INSTALL_DIR) $@ $<
 
+@INSTALL_COMPILE_R7RS_ON@compile-r7rs : compile-r7rs.in
+@INSTALL_COMPILE_R7RS_ON@	$(top_srcdir)/tools/make-tool.sh $(BIN_INSTALL_DIR) $@ $<
+
 # static link -----------------------------------------
 # can be called after everything was built
 
@@ -621,6 +628,7 @@ gauche-install.exe : $(LIBGAUCHE).$(SOEXT) gauche-install-rsrc.o
 gauche-package.exe : $(LIBGAUCHE).$(SOEXT)
 gauche-cesconv.exe : $(LIBGAUCHE).$(SOEXT)
 gauche-compile-r7rs.exe : $(LIBGAUCHE).$(SOEXT)
+@INSTALL_COMPILE_R7RS_ON@compile-r7rs.exe : $(LIBGAUCHE).$(SOEXT)
 
 install-mingw:
 	$(INSTALL_DATA) $(INSTALL_MINGWHEADERS) "$(DESTDIR)$(HEADER_INSTALL_DIR)/gauche"

--- a/src/compile-r7rs.in
+++ b/src/compile-r7rs.in
@@ -1,0 +1,37 @@
+;;;
+;;; compile-r7rs - SRFI-138 compatible compile script
+;;;
+
+(load "tools/compile-r7rs")
+
+(define (usage)
+  (print "Usage: compile-r7rs [options...] [pathname]")
+  (print)
+  (print "Options:")
+  (print (option-parser-help-string))
+  (print "NOTE: If the environment variable COMPILE_R7RS is defined to")
+  (print "a non-empty string, it is assumed to a pathname of another program,")
+  (print "which is invoked with the same arguments to compile-r7rs instead.")
+  (print "This allows the user to choose alternative implementation's compiler.")
+  (exit 1))
+
+(define (main args)
+  (when (<= (length args) 1)
+    (do-compile '())) ; for display usage
+  (let1 alt-compiler (sys-getenv "COMPILE_R7RS")
+    (if (and alt-compiler (> (string-length alt-compiler) 0))
+      (if (file-is-executable? alt-compiler)
+        (begin
+          (cond-expand
+           [gauche.sys.unsetenv (sys-unsetenv "COMPILE_R7RS")]
+           [else                (sys-setenv   "COMPILE_R7RS" "" #t)])
+          (warn "compile-r7rs: Invoking alternative compiler specified \
+                 by COMPILE_R7RS: ~s\n" alt-compiler)
+          (do-process `(,alt-compiler ,@(cdr args)) :fork #f))
+        (exit 1 "Value of COMPILE_R7RS isn't an executable program: ~a"
+              alt-compiler))
+      (do-compile (cdr args)))))
+
+;; Local variables:
+;; mode: scheme
+;; end:

--- a/tools/install-shared-commands.sh
+++ b/tools/install-shared-commands.sh
@@ -31,6 +31,3 @@ makelink() {
 makelink gosh scheme-r7rs
 makelink gosh scheme-srfi-0
 makelink gosh scheme-srfi-7
-
-# SRFI-138
-makelink gauche-compile-r7rs compile-r7rs


### PR DESCRIPTION
- gauche-compile-r7rs で、環境変数 COMPILE_R7RS を無効にしました。

- compile-r7rs の方の 環境変数 COMPILE_R7RS の仕様はそのままです。
  一応、Usage に仕様を追記しました。
  また、引数なしで起動した場合には、(環境変数を実行しないで) Usage を表示するようにしました。

- また、compile-r7rs を作成する configure のオプションを、
  `--enable-shared-commands` から分離して `--enable-compile-r7rs` にしました。
  リファレンスの記載も変更しました。

- また、lib/cgen/standalone.scm を1箇所修正しました。
  (Windows の shell-escape-string によってダブルクォートが付加されるケースで、
   flagの末尾に空白があるとエラーになっていた)

＜関連 issue＞
- #1043
