### PR TITLE
Drop unused library linkage from test tool

### DIFF
--- a/ext/dbm/Makefile.in
+++ b/ext/dbm/Makefile.in
@@ -49,7 +49,7 @@ odbm.sci dbm--odbm.c : odbm.scm
 # auxiliary stuff to find out the extension of ndbm file(s).
 ndbm-makedb : ndbm-makedb.c
 	$(CC) $(DEFS) $(INCLUDES) $(CPPFLAGS) $(CFLAGS) -o ndbm-makedb \
-	  $(srcdir)/ndbm-makedb.c $(LOCAL_LFLAGS) $(XLDFLAGS) @NDBMLIB@ $(LIBS)
+	  $(srcdir)/ndbm-makedb.c $(LOCAL_LFLAGS) $(XLDFLAGS) @NDBMLIB@
 
 ndbm-suffixes.h : ndbm-makedb ndbm-suffixes.scm
 	$(GOSH) $(srcdir)/ndbm-suffixes.scm ndbm-suffixes.h


### PR DESCRIPTION
Build from distribution source tarball will fail to build `ndbm-makedb` because `libgauche-0.98` is not found in system library path.
This error will happen when previous version of Gauche is not installed yet.

> ld: cannot find -lgauche-0.98: No such file or directory
