### PR TITLE
Fix standalone compile on Windows

### DIFF
--- a/lib/gauche/cgen/standalone.scm
+++ b/lib/gauche/cgen/standalone.scm
@@ -137,7 +137,8 @@
   (define (existing-dir? flag)
     (if-let1 m (#/^-[IL]/ flag)
       (cond-expand
-       [gauche.os.windows (shell-escape-string flag 'windows)]
+       [gauche.os.windows (shell-escape-string (string-trim-right flag)
+                                               'windows)]
        [else (let1 path (string-trim-both (rxmatch-after m) #\")
                (and (file-exists? path)
                     (if (string-index flag #\")


### PR DESCRIPTION
- Windows で、コンパイルエラーが出ることがあったため、
  lib/cgen/standalone.scm を1箇所修正しました。
  (Windows の shell-escape-string によってダブルクォートが付加されるケースで、
   flag の末尾に空白があるとエラーになっていました)
