### PR TITLE
Avoid r7rs-benchmarks timeout

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -182,10 +182,12 @@ void Scm_Init(const char *signature)
     GC_set_finalize_on_demand(TRUE);
     GC_set_finalizer_notifier(finalizable);
 
+    /* NB: Following setting causes r7rs-benchmarks timeout (cpstak and
+           parsing), so it is commented out. */
     /* Newer bdwgc delays spawning marker threads until the client creates
        first thread.  We can take advantage of parallel markers even with
        single-threaded program, so we ask them to go parallel now.  */
-    GC_start_mark_threads();
+    /* GC_start_mark_threads(); */
 
     (void)SCM_INTERNAL_MUTEX_INIT(cond_features.mutex);
 


### PR DESCRIPTION
- 最近更新された r7rs-benchmarks の結果で、
  cpstak と parsing のタイムアウト(5分以上)が発生していたため調べました。

- 情報元：
  https://ecraven.github.io/r7rs-benchmarks/

- 前回の結果：
  https://web.archive.org/web/20221104225919/https://ecraven.github.io/r7rs-benchmarks/

- 自分の環境 (Windows) で確認したところ、
  Gauche 0.9.14 と 0.9.15 では、以下のように増加していました。
  ```
  ./bench gauche cpstak
      178s → 237s (133%)
  ./bench gauche parsing
      296s → 370s (125%)
  ```

- このため、git bisect で、0.9.15 と 0.9.14 の間を確認したところ、
  以下のコミットが見つかりました。
  https://github.com/shirok/Gauche/commit/89d270c
  ( Explicitly start marker threads )

- 変更箇所をコメントアウトしたところ、以下のように改善しました。
  ```
  ./bench gauche cpstak
      162s
  ./bench gauche parsing
      263s
  ```

＜補足情報＞
- https://practical-scheme.net/wiliki/wiliki.cgi?Gauche%3AGC
  の下の方に、過去のGCの設定の情報があります。(古いですが…)

- また、事前に
  ```
  export GC_INITIAL_HEAP_SIZE=100M
  ```
  を実行すると、変更箇所のコメントアウト前は、
  ```
  ./bench gauche cpstak
      160s
  ./bench gauche parsing
      117s
  ```
  に減りました。また、変更箇所のコメントアウト後は、
  ```
  ./bench gauche cpstak
      134s
  ./bench gauche parsing
      105s
  ```
  に減りました。
  これは以前、
  [Gauche-r7rs-bench-GM](https://docs.google.com/spreadsheets/d/1S1N5g2XCqQu8yrf_6SV-fJBOF1HO1l9CVQ4PNKR_I14/edit?usp=drive_link)
  で調べた結果に近くなっています。
  ただ、メモリを消費するし、効果があるプログラムは一部だけのようでした。
