### PR TITLE
Fix scripts test error on Windows

### DIFF
--- a/test/scripts.scm
+++ b/test/scripts.scm
@@ -960,8 +960,20 @@
 
   (dynload-and-eval
    "macros"
-   (begin
-     (load (build-path *top-srcdir* "test" "test-precomp" "macros-user"))
+   (let ()
+     (cond-expand
+      [gauche.os.windows
+       (use gauche.test)
+       (use file.util)
+       (define *top-srcdir*
+         (sys-normalize-pathname (or (sys-getenv "top_srcdir") "..")
+                                 :absolute #t :canonicalize #t))
+       (define macros-user-path
+         (build-path *top-srcdir* ".." "test" "test-precomp" "macros-user"))]
+      [else
+       (define macros-user-path
+         (build-path *top-srcdir* "test" "test-precomp" "macros-user"))])
+     (load macros-user-path)
      (test* "compiled macro (er)" '((apple) (banana) bonk)
             (map er-aif-test '(apple banana dragonfruit)))
      (test* "compiled macro (id-macro)" '(#f 1 2)


### PR DESCRIPTION
- Windows で、scripts のテストで以下のエラーが出ていたため、修正しました。
  (ただ、テスト結果としては passed になっていました)

```
Testing utility scripts ...                                      *** UNBOUND-VARIABLE-ERROR: unbound variable: *top-srcdir*
    While loading "././t.scm" at line 1
Stack Trace:
_______________________________________
  0  (build-path *top-srcdir* "test" "test-precomp" "macros-user")
        at "././t.scm":1
  1  (load (build-path *top-srcdir* "test" "test-precomp" "macros-"...
        at "././t.scm":1
  2  (eval s #f)
  3  (with-error-handler (lambda (e) (cond (else (let1 e2 (if (con ...
  4  (load-from-port (if ignore-coding port (open-coding-aware-por ...
passed.
```

- `*top-srcdir*`, `build-path`, `test*` が unbound variable になっていたのと、
  パスの指定は、1階層上が正しいようでした。
