### PR TITLE
Make subtype fn of <?> behaves like (</> (<Assortment> #f) ...)

### DIFF
--- a/src/libtype.scm
+++ b/src/libtype.scm
@@ -619,7 +619,8 @@
   :subtype? (^[type super]
               (if (is-a? super <?>)
                 (subtype? (~ type'primary-type) (~ super'primary-type))
-                'super))
+                (and (of-type? #f super)
+                     (subtype? (~ type'primary-type) super))))
   :supertype? (^[type sub] (subtype? sub (~ type'primary-type))))
 
 ;;;

--- a/test/type.scm
+++ b/test/type.scm
@@ -87,7 +87,10 @@
 (t-subtype <real>    (<?> <integer>) #f)
 (t-subtype (<?> <integer>) (<?> <real>) #t)
 (t-subtype (<?> <integer>) <integer> #f)
+(t-subtype (<?> <boolean>) <boolean> #t)
 (t-subtype (<?> <integer>) (</> (<?> <number>) (<?> <string>)) #t)
+(t-subtype (<?> <char>) (</> <boolean> <char>) #t)
+(t-subtype (<?> <char>) (</> <integer> <char>) #f)
 
 (t-subtype (<Tuple> <integer> <string>) <list> #t)
 (t-subtype (<Tuple> <integer> <string>) (<Tuple> <integer> <string>) #t)
@@ -139,6 +142,8 @@
 (t-subtype (<Assortment> 1 3) <integer> #t)
 (t-subtype (<Assortment> 1 'a) (</> <integer> <symbol>) #t)
 (t-subtype (<Assortment> 1 'a) (</> <integer> <string>) #f)
+(t-subtype (</> (<Assortment> #f) <char>) (<?> <char>) #t)
+(t-subtype (<?> <char>) (</> (<Assortment> #f) <char>) #t)
 
 (test-section "built-in type constructors")
 


### PR DESCRIPTION
`(<?> <boolean>)` は `<boolean>` のsubtypeになってくれませんが、 `(</> (<Assortment> #f) <boolean>)` は `<boolean>` のsubtypeになってくれます。 `(subtype? (<?> <char>) (</> <boolean> <char>))` でも同じことが起きます。

```scheme
gosh$ (subtype? (<?> <boolean>) <boolean>)
#f
gosh$ (subtype? (<?> <char>) (</> <boolean> <char>))
#f
gosh$ (subtype? (</> (<Assortment> #f) <boolean>) <boolean>)
#t
gosh$ (subtype? (</> (<Assortment> #f) <char>) (</> <boolean> <char>))
#t
```

そこで、 `<?>` の挙動を `(</> (Assortment> #f) ...)` に合わせてみました。いかがでしょう。