### PR TITLE
Confirming non existence of sys/event.h for Linux (inotify) code

### DIFF
--- a/ext/file/event-core.scm
+++ b/ext/file/event-core.scm
@@ -38,7 +38,7 @@
  ;;
  ;; Linux (inotify)
  ;;
- (.when (defined HAVE_SYS_INOTIFY_H)
+ (.when (and (defined HAVE_SYS_INOTIFY_H) (not HAVE_SYS_EVENT_H))
    (.include <sys/inotify.h>)
 
    (define-ctype ScmSysInotifyEvent::(.struct


### PR DESCRIPTION
On BSD system with libinotify installed, code for Linux (inotify) is executed. This commit prevents it by confirming the non existence of sys/event.h for execution of code for Linux (inotify).

This pull request fixes the issue #1112 