### PR TITLE
Typo fix

### DIFF
--- a/doc/corelib.texi
+++ b/doc/corelib.texi
@@ -7579,7 +7579,7 @@ pointed by @var{keys} is replaced with the return value of @var{proc}.
 @c COMMON
 
 @example
-(assoc-update-in '((a (b . 1) (c . 2))) '(a c) (cut + <> 1))
+(alist-update-in '((a (b . 1) (c . 2))) '(a c) (cut + <> 1))
   @result{} ((a (b . 1) (c . 3))
 @end example
 

--- a/doc/coresyn.texi
+++ b/doc/coresyn.texi
@@ -210,7 +210,7 @@ GaucheはR7RSのオプショナルな数値構文と、Gauche特有の拡張を�
 次の二つの異なる意味を持ちます。
 @enumerate
 @item
-数値の小数ががひと続きの@code{#}で終わっている場合、それは「重要でない
+数値の小数部がひと続きの@code{#}で終わっている場合、それは「重要でない
 (有効数字外の)桁」を意味します(この構文はR5RSに含まれていました)。
 Gaucheはそれらの桁を0で置き換えます。
 @code{#}の連続は整数部から始まって小数点を
@@ -3739,15 +3739,15 @@ definitions work just like assignments.
 (define x 3)
 (define (value-of-x) x)
 
-(value-of-x x) @result{} 3
+(value-of-x) @result{} 3
 
 (define x 4)
 
-(value-of-x x) @result{} 4
+(value-of-x) @result{} 4
 @end example
 
 @c EN
-If @var{variable} is not bound in the current module, but has an
+If @var{variable} is not bound in the current module, but has
 imported bindings, things get interesting but complicated.
 @xref{Into the Scheme-Verse}, for the details.
 @c JP

--- a/doc/macro.texi
+++ b/doc/macro.texi
@@ -2509,7 +2509,7 @@ These procedures can be used to expand globally defined macros.
 展開されたフォームを返します。そうでなければ、@var{form} をそのまま
 返します。
 
-@code{macroexpand} は、@var{form}の一番外側の式がが展開できなくなるまで
+@code{macroexpand} は、@var{form}の一番外側の式が展開できなくなるまで
 @code{macroexpand-1} を繰り返します。
 (@code{macroexpand}は@var{form}の一番外側以外のマクロは展開しません。
 @var{form}内の全てのマクロを展開するには@code{macroexpand-all}を使ってください。)

--- a/doc/modgauche.texi
+++ b/doc/modgauche.texi
@@ -24116,7 +24116,7 @@ test record fileが既に存在していると、@code{test-start}は
 @c COMMON
 
 @c EN
-If you writes the @code{check} target in your makefile as follows,
+If you write the @code{check} target in your makefile as follows,
 you will get the final one-line summary every time you run
 @code{make check}, assuming that @file{test1.scm}, @file{test2.scm},
 and @file{test3.scm} all has @code{(test-record-file "test.record")}

--- a/doc/modintro.texi
+++ b/doc/modintro.texi
@@ -367,7 +367,7 @@ For generic RDBMS interface, see @ref{Database independent access layer}.
 非常に大きなハッシュテーブル(数百万エントリ)の場合、
 @ref{Sparse tables}の方がメモリ効率が良い可能性もあります。
 @item
-@emph{平衡木} - 辞書のキーに順序づけが必要な場合はツリーマップがが利用できます。
+@emph{平衡木} - 辞書のキーに順序づけが必要な場合はツリーマップが利用できます。
 @ref{Treemaps}参照。
 @item
 @emph{不変なマップ} - しばしは、変更不可能な辞書が便利な場面があります。

--- a/doc/program.texi
+++ b/doc/program.texi
@@ -2152,7 +2152,7 @@ Simple debug stubs may produce too many output, and you may
 want to limit them when certain conditions are met.  A reader syntax
 @code{#??=@var{test} @var{expr}} and
 @code{#??,@var{test} @var{procedure-call}} works much like
-@code{#??=@var{expr}} and @code{#?,@var{procedure-call}}, but
+@code{#?=@var{expr}} and @code{#?,@var{procedure-call}}, but
 only when @var{test} yields true:
 @c JP
 単純なデバッグスタブではしばしば大量にデバッグ出力が出てしまうので、
@@ -2160,7 +2160,7 @@ only when @var{test} yields true:
 リーダー構文@code{#??=@var{test} @var{expr}}と
 @code{#??,@var{test} @var{procedure-call}}は、
 @var{test}が真に評価される時だけそれぞれ
-@code{#??=@var{expr}}および@code{#?,@var{procedure-call}}のように
+@code{#?=@var{expr}}および@code{#?,@var{procedure-call}}のように
 動作します。
 @c COMMON
 


### PR DESCRIPTION
Minor typo fixes.

Description of changes:
- example of `alist-update-in` (doc/corelib.texi L7582): replace deprecated `assoc-update-in` with `alist-update-in`
- example of `define` (doc/coresyn.texi L3742,3746): `value-of-x` takes no arguments
- description of `#??=` (doc/program.texi L2155): `#??=` is like `#?=` (with a single "?") but takes two arguments
- others are grammar
