### PR TITLE
Change for MSYS2 UCRT64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       TESTLOG_PATH: testlog-linux
     steps:
     - uses: actions/checkout@v4
-    - uses: shirok/setup-gauche@v5
+    - uses: shirok/setup-gauche@v6
     - name: Run release version of Gauche
       run: |
         gosh -V
@@ -59,7 +59,7 @@ jobs:
       TESTLOG_PATH: testlog-osx-${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
-    - uses: shirok/setup-gauche@v5
+    - uses: shirok/setup-gauche@v6
     - name: Run release version of Gauche
       run: |
         gosh -V
@@ -95,30 +95,39 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [x86_64, i686]
+        sys: [ucrt64, mingw64, mingw32]
         include:
-        - arch: x86_64
+        - sys: ucrt64
+          env: ucrt-x86_64
+          arch: x86_64
           bit: 64
           devtool_path: D:\devtool64
-        - arch: i686
+        - sys: mingw64
+          env: x86_64
+          arch: x86_64
+          bit: 64
+          devtool_path: D:\devtool64
+        - sys: mingw32
+          env: i686
+          arch: i686
           bit: 32
           devtool_path: D:\devtool32
     env:
       GAUCHE_VERSION_URL: https://practical-scheme.net/gauche/releases/latest.txt
       GAUCHE_INSTALLER_URL: https://practical-scheme.net/gauche/releases/latest.${{ matrix.bit }}bit.msi
       GAUCHE_PATH: ${{ matrix.devtool_path }}\Gauche\bin
-      TESTLOG_NAME: testlog-windows-${{ matrix.arch }}
-      TESTLOG_PATH: testlog-windows-${{ matrix.arch }}
+      TESTLOG_NAME: testlog-windows-${{ matrix.sys }}
+      TESTLOG_PATH: testlog-windows-${{ matrix.sys }}
     steps:
     - run: git config --global core.autocrlf false
     - uses: actions/checkout@v4
     - uses: msys2/setup-msys2@v2
       with:
-        msystem: MINGW${{ matrix.bit }}
+        msystem: ${{ matrix.sys }}
         path-type: inherit
         release: true
         update: true
-        install: 'base-devel mingw-w64-${{ matrix.arch }}-toolchain mingw-w64-${{ matrix.arch }}-autotools'
+        install: 'base-devel mingw-w64-${{ matrix.env }}-toolchain mingw-w64-${{ matrix.env }}-autotools'
     - name: Run MSYS2 once
       shell: msys2 {0}
       run: |
@@ -144,14 +153,6 @@ jobs:
       run: |
         where gosh
         gosh -V
-    - name: Install tools
-      shell: msys2 {0}
-      run: |
-        where openssl
-        echo 'Rename unavailable openssl.exe'
-        mv /mingw${{ matrix.bit }}/bin/openssl.exe /mingw${{ matrix.bit }}/bin/openssl_NG.exe
-        where openssl
-        /usr/bin/openssl version
     - name: Build
       shell: msys2 {0}
       run: |
@@ -179,5 +180,5 @@ jobs:
     #  if: always()
     #  uses: actions/upload-artifact@v4
     #  with:
-    #    name: Gauche-${{ matrix.arch }}
-    #    path: ../Gauche-mingw-dist/Gauche-${{ matrix.arch }}
+    #    name: Gauche-${{ matrix.env }}
+    #    path: ../Gauche-mingw-dist/Gauche-${{ matrix.env }}

--- a/src/gauche/win-compat.h
+++ b/src/gauche/win-compat.h
@@ -184,10 +184,11 @@ extern __declspec(dllimport) const char *Scm_WCS2MBS(const WCHAR *s);
    NB: Windows' mkdir() and _wmkdir() takes one argument.
    NB: Substituing stat with _wstat64 must be in sync with
        the usage of struct __stat64 in ScmSysStatRec (see system.h)
+   NB: UCRT's _waccess() causes error when X_OK is passed.
  */
 #if defined(UNICODE)
 #define open(path, ...)    _wopen(Scm_MBS2WCS(path), __VA_ARGS__)
-#define access(path, mode) _waccess(Scm_MBS2WCS(path), mode)
+#define access(path, mode) _waccess(Scm_MBS2WCS(path), (mode) & ~X_OK)
 #define chdir(dir)         _wchdir(Scm_MBS2WCS(dir))
 #define chmod(path, mode)  _wchmod(Scm_MBS2WCS(path), mode)
 #define mkdir(dir)         _wmkdir(Scm_MBS2WCS(dir))

--- a/src/mingw-dist.sh
+++ b/src/mingw-dist.sh
@@ -16,6 +16,10 @@ DISABLE_BUILD_GOSH_FLAGS="BUILD_GOSH_FLAGS="
 # NB: We no longer officially support 32bit build.  We just keep the variable
 # for those who want to build it by themselves.
 case "$MSYSTEM" in
+  UCRT64)
+    mingwdir=${MINGWDIR:-/ucrt64}
+    mingwarch="ucrt-x86_64"
+    ;;
   MINGW32)
     mingwdir=${MINGWDIR:-/mingw32}
     mingwarch="i686"
@@ -37,6 +41,8 @@ export PATH=$mingwdir/bin:$PATH
 #  building i686 binary on x86_64 shell, for example), so this setting
 #  makes things easier.
 case "$MSYSTEM" in
+  UCRT64)
+    buildopt=--build=x86_64-w64-mingw32;;
   MINGW32)
     buildopt=--build=i686-w64-mingw32;;
   *)


### PR DESCRIPTION
- MSYS2 の UCRT64 対応を行いました。
  (といっても、ほとんどそのままで動くようでした)

- UCRT の _waccess() に X_OK を渡すと、エラーになる件に対応しました。
  (src/gauche/win-compat.h)

- GitHub Actions の build-windows に ucrt64 を追加しました。

- 詳細な互換性の確認は未実施です。
  (#1116 に関連)
