### PR TITLE
Update MbedTLS to 3.6.4

### DIFF
--- a/tools/tls/Makefile.in
+++ b/tools/tls/Makefile.in
@@ -5,12 +5,18 @@
 .PHONY: mbedtls
 
 # update these for new MbedTLS version / repo
-MBEDTLS_VERSION = 3.6.0
+# for 3.6.4
+MBEDTLS_VERSION = 3.6.4
+MBEDTLS_SOURCE_URL = https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-$(MBEDTLS_VERSION)/mbedtls-$(MBEDTLS_VERSION).tar.bz2
+## for 3.6.0
+#MBEDTLS_VERSION = 3.6.0
+#MBEDTLS_SOURCE_URL = https://github.com/Mbed-TLS/mbedtls/releases/download/v$(MBEDTLS_VERSION)/mbedtls-$(MBEDTLS_VERSION).tar.bz2
+## for 3.5.2
 #MBEDTLS_VERSION = 3.5.2
-MBEDTLS_SOURCE_BZ  = https://github.com/Mbed-TLS/mbedtls/releases/download/v$(MBEDTLS_VERSION)/mbedtls-$(MBEDTLS_VERSION).tar.bz2
-MBEDTLS_SOURCE_GZ  = https://github.com/Mbed-TLS/mbedtls/archive/refs/tags/v$(MBEDTLS_VERSION).tar.gz
-FETCHED_BZ = mbedtls-$(MBEDTLS_VERSION).tar.bz2
-FETCHED_GZ = mbedtls-$(MBEDTLS_VERSION).tar.gz
+#MBEDTLS_SOURCE_URL = https://github.com/Mbed-TLS/mbedtls/archive/refs/tags/v$(MBEDTLS_VERSION).tar.gz
+
+MBEDTLS_SOURCE_TYPE = $(suffix $(MBEDTLS_SOURCE_URL))
+MBEDTLS_SOURCE_FILE = mbedtls-$(MBEDTLS_VERSION).tar$(MBEDTLS_SOURCE_TYPE)
 
 LN_S = @LN_S@
 OBJEXT = @OBJEXT@
@@ -42,13 +48,14 @@ libmbedtls.a: mbedtls-$(MBEDTLS_VERSION)
 	 && cp $(MBEDTLS_LIBS) ../..
 
 mbedtls-$(MBEDTLS_VERSION):
-	if curl -f -L -o $(FETCHED_BZ) $(MBEDTLS_SOURCE_BZ); then \
-	  tar xjvf $(FETCHED_BZ); \
-	elif curl -f -L -o $(FETCHED_GZ) $(MBEDTLS_SOURCE_GZ); then \
-	  tar xzvf $(FETCHED_GZ); \
-	else \
-	  echo "Couldn't fetch MbedTLS $(MBEDTLS_VERSION)"; \
-	  exit 1; \
+	if ! curl -f -L -o $(MBEDTLS_SOURCE_FILE) $(MBEDTLS_SOURCE_URL); then \
+	  echo "Couldn't fetch MbedTLS $(MBEDTLS_VERSION)";                   \
+	  exit 1;                                                             \
+	fi
+	if [ $(MBEDTLS_SOURCE_TYPE) = ".bz2" ]; then \
+	  tar xjvf $(MBEDTLS_SOURCE_FILE);           \
+	else                                         \
+	  tar xzvf $(MBEDTLS_SOURCE_FILE);           \
 	fi
 	echo 'set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")' >> mbedtls-$(MBEDTLS_VERSION)/library/CMakeLists.txt
 
@@ -72,4 +79,4 @@ distclean: clean
 	rm -rf mbedtls-$(MBEDTLS_VERSION)
 
 maintainer-clean: clean
-	rm -rf mbedtls-$(MBEDTLS_VERSION) $(FETCHED_BZ) $(FETCHED_GZ) $(CONFIG_GENERATED)
+	rm -rf mbedtls-$(MBEDTLS_VERSION) $(MBEDTLS_SOURCE_FILE) $(CONFIG_GENERATED)


### PR DESCRIPTION
- MbedTLS を 3.6.4 にしました。

- 3.6.0 は、MSYS2 UCRT64 の gcc 15 でビルドすると正常に動作しないようでした。
  (test で、エラー -27648 (-0x6c00) になる。
   #1018 に似ているが、固まって終了しない。
   MbedTLS の issue 9884 あたりかと思うが、よく分からない)

- 3.6.4 は、URL のパス名が違うのと、
  mbedtls-$(MBEDTLS_VERSION).tar.bz2 の方をダウンロードしないとビルドに失敗するようでした。
  ( mbedtls-$(MBEDTLS_VERSION).tar.gz の方は、サブモジュールのフォルダ (framework 等) が空のため )

- また、別件になりますが、しばらく curl のダウンロードが成功しなくて困っていました。
  (エラー「curl: (60) SSL certificate problem: unable to get local issuer certificate」)
  (curl に -k オプションを付ければ成功する。しかしセキュリティ上は良くないとのこと)
  これは、セキュリティソフトの HTTPS スキャン という機能が原因でした。
  一時的に OFF にすると成功しました。
  (CA証明書の関係かと思って、いろいろ試していたが、関係なかった…)
