### PR TITLE
Docs: fix sample code in make-trie documentation

### DIFF
--- a/doc/modutil.texi
+++ b/doc/modutil.texi
@@ -8759,15 +8759,12 @@ string keys with case-insensitive way:
 @example
 (make-trie list
            (cut alist-ref <> <> char-ci=? #f)
-           (lambda (t k v)
+           (^[t k v]
              (if v
                (alist-set! t k v char-ci=?)
                (alist-delete! k t char-ci=?)))
-           (lambda (t f s)
-             (let loop ((t t) (s s))
-               (if (null? t)
-                 s
-                 (loop (cdr t) (f (caar t) (cdar t) s)))))
+           (^[t f s]
+             (fold (^[e s] (f (car e) (cdr e) s)) s t))
            null?)
 @end example
 


### PR DESCRIPTION
In the [documentation's sample code](https://practical-scheme.net/gauche/man/gauche-refe/Trie.html#index-make_002dtrie) for the `make-trie` procedure, the optional `tab-fold` argument was causing an error when calling `fold`.

I have verified the behavior with the following code.

```scheme
(define t (make-trie list
                     (cut alist-ref <> <> char-ci=? #f)
                     (lambda (t k v)
                       (if v
                         (alist-set! t k v char-ci=?)
                         (alist-delete! k t char-ci=?)))
                     (lambda (t f s)
                       (let loop ((t t) (s s))
                         (if (null? t)
                           s
                           (loop (cdr t) (f (caar t) (cdar t) s)))))
                     null?))

(let ()
  (trie-put! t "car" 'a)
  (trie-put! t "cat" 'b)
  (trie-put! t "cup" 'c)

  (print (trie-map t cons))                    ;=> ((car . a) (cat . b) (cup . c))
  (print (trie-common-prefix t "ca"))          ;=> ((car . a) (cat . b))
  (print (trie-common-prefix-map t "cu" cons)) ;=> ((cup . c))
  (print (trie-fold t (^(k v s) (+ s 1)) 0))   ;=> 3
  )
```