### PR TITLE
Fix missing :mapper keyword when calling pmap in parallel-execute

### DIFF
--- a/lib/srfi/216.scm
+++ b/lib/srfi/216.scm
@@ -31,7 +31,7 @@
     (inexact (random-integer (ceiling->exact n)))))
 
 (define (parallel-execute thunk1 . thunks)
-  (pmap (^p (p)) (cons thunk1 thunks) (make-fully-concurrent-mapper))
+  (pmap (^p (p)) (cons thunk1 thunks) :mapper (make-fully-concurrent-mapper))
   (undefined))
 
 (define *global-lock* (make-mutex))     ;for test-and-set!


### PR DESCRIPTION
This is a fix for #1196 