### PR TITLE
Fix array literal input

### DIFF
--- a/ext/uvector/array.scm
+++ b/ext/uvector/array.scm
@@ -321,7 +321,7 @@
   (define line (port-current-line port))
   (define chars `(,type-char))          ; for error message
   (define (save-char!)
-    (let1 ch (read-char)
+    (let1 ch (read-char port)
       (unless (eof-object? ch) (push! chars ch))))
   (define (prefix) (list->string (reverse chars)))
   (define (err msg content)
@@ -331,9 +331,9 @@
   (define (bad-prefix)
     ;; We read up to the delimiter so that the subsequent read won't be
     ;; tripped.
-    (let loop ((ch (peek-char)))
+    (let loop ((ch (peek-char port)))
       (unless (or (eof-object? ch) (#[\s\(\[\{#\"'`,] ch))
-        (save-char!) (loop (peek-char))))
+        (save-char!) (loop (peek-char port))))
     (err "Invalid array literal prefix" #f))
   (define (make-type-tag nbits)
     (string->symbol (format "~c~d" (char-down-case type-char) nbits)))


### PR DESCRIPTION
- read edit モードで、uniform array のリテラルを入力すると固まっていたので修正しました。
  ( #1s8(1 2 3 4 5) 等 )

- あと、同じ array.scm の define-class ですが、気になった点がいくつかあります。
  ```
  (define-class <c128array> (<array-base>)
    ()
    :metaclass <array-meta>
    :backing-storage-class <c128vector>
    :tag 'c64
    :element-size 64)
  ```
  - tag は c128 が正しいでしょうか?
  - element-size は 128 が正しいでしょうか?
  - 将来的にシリアライズに対応した場合、tag が uvector と区別がつかないのでは?
