### PR TITLE
Avoid label for end of block

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -1798,7 +1798,7 @@ const char *Scm_StringCursorPointer(const ScmStringBody *sb, ScmObj sc,
         case STRING_CURSOR_FALLBACK_TO_END:
             return SCM_STRING_BODY_END(sb);
         default:
-            /* FALLTHROUGH */
+            /* FALLTHROUGH */;
         }
     }
 


### PR DESCRIPTION
手元のGCC(9.2.0)でコンパイルエラーになりました。GCCでのブロック末尾へのラベルのサポートは11から、C23がデフォルトになるのは15からだそうです( https://gcc.gnu.org/projects/c-status.html )。