### PR TITLE
Fix change-class doc example

### DIFF
--- a/doc/object.texi
+++ b/doc/object.texi
@@ -2933,9 +2933,9 @@ slot @code{y} of new class, she may write something like this:
 
 @example
 (define-method change-class ((obj <old-class>) <new-class>)
-  (let ((old-val (slot-ref obj 'x)))
-    (next-method)               ;; calls default change-class
-    (slot-set! obj 'y old-val)  ;; here, obj's class is already <new-class>.
+  (let ((old-val (slot-ref-using-class <old-class> obj 'x)))
+    (next-method)                                       ;; calls default change-class
+    (slot-set-using-class! <new-class> obj 'y old-val)  ;; here, obj's class is already <new-class>.
     obj))
 @end example
 


### PR DESCRIPTION
`change-class` の例が無限ループを引き起こすものになっていました。`slot-set!` の方はそのままでも動きましたが、直前に別スレッドが再びクラス再定義していたらややこしそうなので、そちらもusing class版にしておきました。