### PR TITLE
Avoid display causing instance update of class

### DIFF
--- a/src/libio.scm
+++ b/src/libio.scm
@@ -885,7 +885,7 @@
            [(box? obj)
             (dotimes [i (box-arity obj)]
               (walk (unbox-value obj i) 0))]
-           [(is-a? obj <dictionary>)
+           [(subclass? (current-class-of obj) <dictionary>)
             (%dict-walk! obj (^[k v] (walk k 0) (walk v 0)))]
            [else ; generic objects.  we go walk pass via write-object
             (write-object obj port)])

--- a/tests/io2.scm
+++ b/tests/io2.scm
@@ -7,6 +7,7 @@
 (use scheme.list)
 (use file.util)
 (use util.isomorph)
+(use util.match)
 
 (test-start "advanced read/write features")
 
@@ -937,6 +938,25 @@
        "#<opaque-dict 42>\n"
        (call-with-output-string
          (cut pprint (make <opaque-dict> :value 42) :port <>)))
+
+;; avoid instance updating of class objects
+(define-class <hoge-meta> (<class>) ())
+(define-class <hoge> () () :metaclass <hoge-meta>)
+(define <old-hoge-meta> <hoge-meta>)
+
+(define-class <hoge-meta> (<class>) ())
+
+(for-each (match-lambda
+            ((name writer)
+             (test* #"avoid instance updating (~name)"
+                    #t
+                    (begin
+                      (write-to-string <hoge> writer)
+                      (eq? <old-hoge-meta>
+                           (current-class-of <hoge>))))))
+          `(("display" ,display)
+            ("write" ,write)
+            ("pprint" ,pprint)))
 
 ;;===============================================================
 ;; utf-8 with BOM


### PR DESCRIPTION
`<class>` にはinstance updateを避ける `write-object` が折角定義されているのに、`%write-walk-rec` の中で `is-a?` を使っているために、 `display` しただけでinstance updateされていました。この変更だけで `pprint` もinstance updateしなくなったので、テストに含めておきました( `SCM_ISA` はinstance updateしないんですね)。