### PR TITLE
Revise make-rtd to pass additional initargs to make

### DIFF
--- a/libsrc/gauche/record.scm
+++ b/libsrc/gauche/record.scm
@@ -257,7 +257,7 @@
 ;; NB: If record is created procedurally, we don't know what to set
 ;; in :defined-module.
 (define (make-rtd name fieldspecs :optional (parent #f)
-                  :key (mixins '()) (metaclass #f) (module #f))
+                  :key (mixins '()) (metaclass #f) (initargs '()) (module #f))
   ;; We only allow to inherit either other record class, or classes that
   ;; don't add slots.  The metaclass be alwayas <record-meta>
   (when parent
@@ -272,16 +272,17 @@
     (unless (subtype? metaclass <record-meta>)
       (error "Cannot use a metaclass that isn't a subtype of <record-meta>:"
              metaclass)))
-  (make (or metaclass
-            (and parent (class-of parent))
-            <record-meta>)
-    :name name :field-specs fieldspecs
-    :supers (append mixins
-                    (cond [(is-a? parent <record-meta>) (list parent)]
-                          [else (list <record>)]))
-    :slots ($ fieldspecs->slotspecs fieldspecs
-              $ if parent (length (class-slots parent)) 0)
-    :defined-modules (if module (list module) '())))
+  (apply make (or metaclass
+                  (and parent (class-of parent))
+                  <record-meta>)
+         :name name :field-specs fieldspecs
+         :supers (append mixins
+                         (cond [(is-a? parent <record-meta>) (list parent)]
+                               [else (list <record>)]))
+         :slots ($ fieldspecs->slotspecs fieldspecs
+                   $ if parent (length (class-slots parent)) 0)
+         :defined-modules (if module (list module) '())
+         initargs))
 
 (define (rtd? obj) (is-a? obj <record-meta>))
 
@@ -453,12 +454,15 @@
          [((? identifier? name) parent) (values name parent '())]
          [((? identifier? name) parent . opts)
           (let-keywords opts ([mixins #f]
-                              [metaclass #f])
+                              [metaclass #f]
+                              [initargs '()])
             (values name parent
                     (cond-list [mixins @ (quasirename r
                                            `(:mixins (list ,@mixins)))]
                                [metaclass @ (quasirename r
-                                              `(:metaclass ,metaclass))])))]
+                                              `(:metaclass ,metaclass))]
+                               [initargs @ (quasirename r
+                                             `(:initargs (list ,@initargs)))])))]
          [_ (error "invalid type-spec" type-spec)]))
      (define (build-field-spec field-specs)
        (map-to <vector> (match-lambda


### PR DESCRIPTION
`make-rtd` を、 `make` に渡す初期化引数を受け取れるようにしようという提案です。

レコードのメタクラスが初期化引数を必要としても、今の `make-rtd` (及び `define-record-type`) では渡せません。そこで、キーワード引数 `:initargs`(`define-record-type` にはtype-specのoption)を追加して渡せるようにしてみました。既存のテストと小さな例では動いています。

`:allow-other-keys` 方式も考えましたが、 `make-rtd` には既に `make` とは異なるキーワード引数(`:mixins` と `:module`)があるため、独立した一つのキーワード引数にしました。

使用例を用意しました。ADT的なクラスを生成する仕組みを作りたいとして、Eitherみたいなクラスを作ったらLeftとRightに(定義順に応じた)順序関係も自動で定義されるようにしたいとします。そこで、それぞれのコンストラクタに対応するクラス `<left>` と `<right>` (ヴァリアントクラスと呼ぶことにします)に自分のordinalを覚えておいてもらうようにします。

```scheme
(use gauche.record)
(use util.match)

;; 同クラスで比較できるレコードクラスを用意しておく
(define-class <record-comparable> (<record>)
  ()
  :metaclass <record-meta>)

(define (record-class-slots class)
  (sort-by (class-slots class)
           (cut slot-definition-option <> :index)))

;; レコード比較
;; 同じレコードならフィールドを順に比較
;; 異なるレコードなら(継承関係によらず)適当に比較
(define-method object-compare ((a <record-comparable>) (b <record-comparable>))
  (let ((a-class (class-of a))
        (b-class (class-of b)))
    (if (eq? a-class b-class)
      (let loop ((slots (record-class-slots a-class)))
        (match slots
          (() 0)
          ((slot . rest)
           (let1 name (slot-definition-name slot)
             (match (compare (slot-ref a name)
                             (slot-ref b name))
               (0
                (loop rest))
               (ord ord))))))
      (eq-compare a-class b-class))))

(define-class <variant-meta> (<class>)
  ((ordinal :init-keyword :ordinal)))

(define-class <variant-record-meta> (<variant-meta> <record-meta>)
  ())

;; ヴァリアント比較
;; 同じクラスなら compare で比較
;; 異なるクラスならクラスの ordinal で比較
;; 簡単のために、ヴァリアントの互換性は気にしない
(define (variant-compare a b)
  (let ((a-class (class-of a))
        (b-class (class-of b)))
    (if (eq? a-class b-class)
      (compare a b)
      (compare (slot-ref a-class 'ordinal)
               (slot-ref b-class 'ordinal)))))

;; こんな感じで書くと下のように展開されるようなマクロを書きたい
;; (define-variant-class either
;;   ((left (value from-left))
;;    (right (value from-right))))

(define-class <either> ()
  ())

(define-record-type (<left> <record-comparable>
                            :mixins (<either>)
                            :metaclass <variant-record-meta>
                            :initargs (:ordinal 0))
    left left?
  (value from-left))

(define-record-type (<right> <record-comparable>
                             :mixins (<either>)
                             :metaclass <variant-record-meta>
                             :initargs (:ordinal 1))
    right right?
  (value from-right))

#?=(variant-compare (left 42) (left 999))  ; -1
#?=(variant-compare (left 42) (left 1))    ; 1
#?=(variant-compare (left 42) (right 1))   ; -1
#?=(variant-compare (left 42) (right 999)) ; -1
#?=(variant-compare (right 42) (left 999)) ; 1
#?=(variant-compare (right 42) (left 1))   ; 1
```
ヴァリアントクラスの実装がレコードでないクラスも混ざっている場合を考えると、`:initargs` があれば統一的に扱えるようになって良さげに見えます。
```scheme
(use gauche.mop.singleton)
(define-class <variant-singleton-meta> (<variant-meta> <singleton-meta>)
  ())

(define-class <maybe> ()
  ())

(define-class <nothing> (<maybe>)
  ()
  :metaclass <variant-singleton-meta>
  :ordinal 0)

(define (nothing)
  (instance-of <nothing>))

(define-record-type (<just> <record-comparable>
                            :mixins (<maybe>)
                            :metaclass <variant-record-meta>
                            :initargs (:ordinal 1))
    just just?
  (value from-just))

(define-method object-compare ((_ <nothing>) (_ <nothing>))
  0)

#?=(variant-compare (just 42) (just 999)) ; -1
#?=(variant-compare (just 42) (just 0))   ; 1
#?=(variant-compare (just 42) (nothing))  ; 1
#?=(variant-compare (nothing) (just 42))  ; -1
```

まあ今回の例だと別に後で `set!` したり他のひとが順序関係を覚えておいても `variant-compare` はできるんですが、ともあれ `:initargs` が必要な機能のように思えてきます。