### PR TITLE
Remove dangling autoload print-exact-decimal-point-number

### DIFF
--- a/src/autoloads.scm
+++ b/src/autoloads.scm
@@ -79,7 +79,6 @@
 (autoload gauche.numutil
           exact-integer-sqrt
           continued-fraction real->rational
-          print-exact-decimal-point-number
           expt-mod inverse-mod gamma lgamma
           real-valued? rational-valued? integer-valued?
           div-and-mod div mod div0-and-mod0 div0 mod0


### PR DESCRIPTION
`apropos` で引っかかりました。`apropos` や `module-binds?` はautoloadを解決しちゃうんですね。
```
gosh$ ,a .*
*** ERROR: Autoloaded symbol print-exact-decimal-point-number is not defined in the module gauche.numutil
Stack Trace:
_______________________________________
  0  (report-error e)
  1  (module-binds? module sym)
...
```