### PR TITLE
Fix vm-dump segmentation fault

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -4168,7 +4168,10 @@ void Scm_VMDump(ScmVM *vm_to_dump)
 {
     /* We first take a snapshot of the given VM, so that the act of
        dumping won't interfere with the state of the target.
-     */
+
+       NB: save_cont is required to preserve vm->cont->prev.
+    */
+    save_cont(vm_to_dump);
     ScmVM *vm = Scm_VMTakeSnapshot(vm_to_dump);
     ScmPort *out = SCM_CURERR;
     ScmEnvFrame *env = vm->env;


### PR DESCRIPTION
- 起動後すぐに (vm-dump) を実行すると SEGV が発生します。
  ```
  gosh$ (vm-dump)
  VM 00000000bd155960 -----------------------------------------------------------
     pc: 00000000f41a5ca8   (RET)
     sp: 00000000bdd75000  [00000000bdd75000-00000000bdd75000-00000000bdd88880]
   argp: 00000000bd1579b0
   val0: #<subr #0=(vm-dump :optional vm)>
   envs:
  conts:
     00000000bd157978
                env = 000000000000000b
               size = 20
               base = 0000000000000014
  ;; ==> SEGV
  ```

- 何かエラーを起こした後だと成功します。
  ```
  gosh$ x
  *** UNBOUND-VARIABLE-ERROR: unbound variable: x
  Stack Trace:
  _______________________________________
    0  (report-error e)
    1  (eval expr env)
          at "C:\\Program Files\\Gauche\\share\\gauche-0.98\\0.9.16_pre2\\lib/gauche/interactive.scm":407
    2  (evaluator exp (vm-current-module))
    3  (with-error-handler (^e (report-error e) #t) (^ () (let loop2 ...
  gosh$ (vm-dump)
  VM 0000000056295960 -----------------------------------------------------------
     pc: 00000000f41a5ca8   (RET)
     sp: 0000000056f8e000  [0000000056f8e000-0000000056f8e000-0000000056fa1880]
   argp: 00000000562971a0
   val0: #<subr #0=(vm-dump :optional vm)>
   envs:
  conts:
     0000000056297168
                env = 00000000f41a5c90
               size = 1
               base = 0000000056a70cc0  #f
                 pc = {cproc 00000000f3f259f0}
     0000000056297110
                env = 0000000056f85b20
               size = 0
               base = 0000000056a70cc0  #f
                 pc = 0000000056984540[    6(0000000056984510)] (TAIL-RECEIVE(0,1))
     :
  ;; ==> OK
  ```

- Gauche 0.9.15 と 0.9.14 でも同じでした。

- SEGV が起きるときは、
  Scm_VMDump() 内の Scm_Printf() を実行するたびに
  vm->cont->prev の値が変わっていくようでした (gdb で確認) 。

- Scm_VMDump() の先頭に save_cont(vm_to_dump); を追加すると直るようでした。
  ( Scm_VMTakeSnapshot() の後に save_cont(vm); を追加するのはだめでした )
