### PR TITLE
Change vm error handling

### DIFF
--- a/src/gauche/vm.h
+++ b/src/gauche/vm.h
@@ -527,13 +527,7 @@ struct ScmVMRec {
 #endif
 
     /* Escape handling */
-    ScmObj floatingEscapePoints; /* List of escapePoints that point to
-                                    in-stack continuation frames.  We only need
-                                    it so that we can adjust pointers to cont
-                                    frames when they are moved to the heap.
-                                    The list is cleared once cont frames
-                                    are moved to the heap.
-                                 */
+    ScmObj floatingEscapePoints; /* not used */
     int escapeReason;            /* temporary storage to pass data across
                                     longjmp(). */
     void *escapeData[2];         /* ditto. */

--- a/src/vm.c
+++ b/src/vm.c
@@ -317,7 +317,6 @@ ScmVM *Scm_NewVM(ScmVM *proto, ScmObj name)
 
     v->dynamicHandlers = SCM_NIL;
 
-    v->floatingEscapePoints = SCM_NIL;
     v->escapeReason = SCM_VM_ESCAPE_NONE;
     v->escapeData[0] = NULL;
     v->escapeData[1] = NULL;
@@ -438,7 +437,6 @@ ScmVM *Scm_VMTakeSnapshot(ScmVM *vm)
     v->denv = vm->denv;
     v->dynamicHandlers = vm->dynamicHandlers;
 
-    v->floatingEscapePoints = vm->floatingEscapePoints;
     v->escapeReason = vm->escapeReason;
     v->escapeData[0] = vm->escapeData[0];
     v->escapeData[1] = vm->escapeData[1];
@@ -1301,18 +1299,6 @@ static void save_cont(ScmVM *vm)
         if (FORWARDED_CONT_P(cstk->cont)) {
             cstk->cont = FORWARDED_CONT(cstk->cont);
         }
-    }
-    {
-        ScmObj eps;
-        SCM_FOR_EACH(eps, vm->floatingEscapePoints) {
-            ScmObj ep = SCM_CAR(eps);
-            SCM_ASSERT(SCM_ESCAPE_POINT_P(ep));
-            ScmEscapePoint *e = SCM_ESCAPE_POINT(ep);
-            if (FORWARDED_CONT_P(e->cont)) {
-                e->cont = FORWARDED_CONT(e->cont);
-            }
-        }
-        vm->floatingEscapePoints = SCM_NIL;
     }
 }
 
@@ -2541,7 +2527,9 @@ static void call_after_thunk(ScmVM *vm, ScmObj handler_entry)
     SCM_ASSERT(SCM_DYNAMIC_HANDLER_P(handler_entry));
     ScmDynamicHandler *dh = SCM_DYNAMIC_HANDLER(handler_entry);
     vm->denv = dh->denv;
-    Scm_ApplyRec(dh->after, dh->args);
+    if (!SCM_FALSEP(dh->after)) {
+        Scm_ApplyRec(dh->after, dh->args);
+    }
 }
 
 static ScmObj vm_call_before_thunk(ScmVM *vm, ScmObj handler_entry)
@@ -2561,7 +2549,11 @@ static ScmObj vm_call_after_thunk(ScmVM *vm, ScmObj handler_entry)
     SCM_ASSERT(SCM_DYNAMIC_HANDLER_P(handler_entry));
     ScmDynamicHandler *dh = SCM_DYNAMIC_HANDLER(handler_entry);
     vm->denv = dh->denv;
-    return Scm_VMApply(dh->after, dh->args);
+    if (!SCM_FALSEP(dh->after)) {
+        return Scm_VMApply(dh->after, dh->args);
+    } else {
+        return SCM_UNDEFINED;
+    }
 }
 /* End of handler-chain internal API */
 
@@ -2644,20 +2636,37 @@ static ScmObj dynwind_body_cc(ScmVM *vm, ScmObj result, ScmObj *data)
        actually gets slightly slower.  More branches may have a negative
        effect.  So we keep it simple here.
      */
-    int nvals = vm->numVals;
-    if (nvals > 1) {
-        ScmObj *vals = SCM_NEW_ARRAY(ScmObj, nvals-1);
-        memcpy(vals, vm->vals, sizeof(ScmObj)*(nvals-1));
-        ScmObj *d = Scm_pc_PushCC(vm, dynwind_after_cc, 3);
-        d[0] = result;
-        d[1] = SCM_OBJ((intptr_t)nvals);
-        d[2] = SCM_OBJ(vals);
+    if (SCM_FALSEP(after)) {
+        /* we can skip application of 'after' */
+        ScmObj d[3];
+        int nvals = vm->numVals;
+        if (nvals > 1) {
+            ScmObj *vals = SCM_NEW_ARRAY(ScmObj, nvals-1);
+            memcpy(vals, vm->vals, sizeof(ScmObj)*(nvals-1));
+            d[0] = result;
+            d[1] = SCM_OBJ((intptr_t)nvals);
+            d[2] = SCM_OBJ(vals);
+        } else {
+            d[0] = result;
+            d[1] = SCM_OBJ((intptr_t)nvals);
+        }
+        return dynwind_after_cc(vm, SCM_UNDEFINED, d);
     } else {
-        ScmObj *d = Scm_pc_PushCC(vm, dynwind_after_cc, 2);
-        d[0] = result;
-        d[1] = SCM_OBJ((intptr_t)nvals);
+        int nvals = vm->numVals;
+        if (nvals > 1) {
+            ScmObj *vals = SCM_NEW_ARRAY(ScmObj, nvals-1);
+            memcpy(vals, vm->vals, sizeof(ScmObj)*(nvals-1));
+            ScmObj *d = Scm_pc_PushCC(vm, dynwind_after_cc, 3);
+            d[0] = result;
+            d[1] = SCM_OBJ((intptr_t)nvals);
+            d[2] = SCM_OBJ(vals);
+        } else {
+            ScmObj *d = Scm_pc_PushCC(vm, dynwind_after_cc, 2);
+            d[0] = result;
+            d[1] = SCM_OBJ((intptr_t)nvals);
+        }
+        return Scm_VMApply0(after);
     }
-    return Scm_VMApply0(after);
 }
 
 static ScmObj dynwind_after_cc(ScmVM *vm, ScmObj result SCM_UNUSED,
@@ -2984,37 +2993,17 @@ ScmObj Scm_VMThrowException(ScmVM *vm, ScmObj exception, u_long raise_flags)
 /*
  * with-error-handler
  */
-static ScmObj discard_ehandler(ScmObj *args SCM_UNUSED,
-                               int nargs SCM_UNUSED,
-                               void *data)
-{
-    /* restore floatingEscapePoints when necessary */
-    ScmObj eps = SCM_OBJ(data);
-    if (SCM_PAIRP(eps)) {
-        ScmVM *vm = theVM;
-        ScmContFrame *c = SCM_ESCAPE_POINT(SCM_CAR(eps))->cont;
-        if (IN_STACK_P((ScmObj*)c)) {
-            /* Those cont frames are not saved yet, so keep them
-               in the chain. */
-            theVM->floatingEscapePoints = eps;
-        }
-    }
-    return SCM_UNDEFINED;
-}
-
 static ScmObj with_error_handler(ScmVM *vm, ScmObj handler,
                                  ScmObj thunk, int rewindBefore)
 {
+    save_cont(vm);
     ScmEscapePoint *ep = new_ep(vm, handler, rewindBefore,
                                 SCM_FALSE, SCM_FALSE);
 
     ScmObj ehandler = make_escape_handler(ep);
     Scm_VMPushExceptionHandler(ehandler);
     SCM_VM_RUNTIME_FLAG_CLEAR(theVM, SCM_ERROR_BEING_REPORTED);
-    ScmObj prev_fep = vm->floatingEscapePoints;
-    vm->floatingEscapePoints = Scm_Cons(SCM_OBJ(ep), prev_fep);
-    ScmObj after  = Scm_MakeSubr(discard_ehandler, prev_fep, 0, 0, SCM_FALSE);
-    return Scm_VMDynamicWind(SCM_FALSE, thunk, after);
+    return Scm_VMDynamicWind(SCM_FALSE, thunk, SCM_FALSE);
 }
 
 ScmObj Scm_VMWithErrorHandler(ScmObj handler, ScmObj thunk)

--- a/tests/with-err-handler-performance.scm
+++ b/tests/with-err-handler-performance.scm
@@ -1,0 +1,59 @@
+;;
+;; benchmarking with-error-handler optimization
+;;
+
+(use gauche.time)
+
+(define (f n p)
+  (if (zero? n)
+    (if p
+      (raise 'f)
+      n)
+    (with-error-handler
+     (lambda (e) (raise e))
+     (lambda () (f (- n 1) p)))))
+
+(define (f-exc n)
+  (with-error-handler values (cut f n #t)))
+
+(define (f-no-exc n)
+  (with-error-handler values (cut f n #f)))
+
+(define (main args)
+  (time-these/report 30000
+                     `((f-exc . ,(cut f-exc 1000))
+                       (f-no-exc . ,(cut f-no-exc 1000))))
+  0)
+
+#|
+OS  : Windows 11 25H2
+CPU : AMD Ryzen 7 7735U (2.70 GHz)
+RAM : 16.0 GB
+
+;; 0.9.16_pre2 (change vm error handling (2026-03-17))
+Benchmark: ran f-exc, f-no-exc, each for 30000 times.
+     f-exc: 190.959 real, 190.188 cpu (157.250 user + 32.938 sys)@ 157.74/s n=30000
+  f-no-exc:  12.808 real,  12.734 cpu ( 11.578 user +  1.156 sys)@2355.90/s n=30000
+
+             Rate  f-exc f-no-exc
+     f-exc  158/s     --    0.067
+  f-no-exc 2356/s 14.935       --
+
+;; 0.9.16_pre2 (commit f37f980 (2026-03-16))
+Benchmark: ran f-exc, f-no-exc, each for 30000 times.
+     f-exc: 213.385 real, 212.766 cpu (178.844 user + 33.922 sys)@141.00/s n=30000
+  f-no-exc:  31.590 real,  31.500 cpu ( 30.000 user +  1.500 sys)@952.38/s n=30000
+
+            Rate f-exc f-no-exc
+     f-exc 141/s    --    0.148
+  f-no-exc 952/s 6.754       --
+
+;; 0.9.15
+Benchmark: ran f-exc, f-no-exc, each for 30000 times.
+     f-exc: 151.355 real, 151.953 cpu (127.500 user + 24.453 sys)@197.43/s n=30000
+  f-no-exc:  45.784 real,  46.328 cpu ( 38.609 user +  7.719 sys)@647.56/s n=30000
+
+            Rate f-exc f-no-exc
+     f-exc 197/s    --    0.305
+  f-no-exc 648/s 3.280       --
+|#


### PR DESCRIPTION
**＜＜本件は、急いでマージする必用はありません。＞＞**

- 現状、vm->floatingEscapePoints が残っているのは、
  vm.c の with_error_handler() で 
  save_cont() を実行しないようにしているためだと思うのですが、
  これを実行するようにしたら、
  (vm->floatingEscapePoints と discard_ehandler() が不要になるので)
  パフォーマンスはどうなるのかと思って、作成してみたものです。

- 実行時間の測定は、
  tests/with-exc-handler-performance.scm の
  with-exception-handler を with-error-handler に置換した
  tests/with-err-handler-performance.scm を作成して行いました。

- 結果は、tests/with-err-handler-performance.scm の下の方に記載しました。
  0.9.15 との比較では、
  例外が発生するケースでは、 0.9.15 より遅くなりました (0.8倍) 。
  例外が発生しないケースでは 0.9.15 より速くなりました (3.6倍) 。
  また、
  0.9.16_pre2 (commit f37f980 (2026-03-16)) との比較では、
  例外が発生するケースでは、 0.9.16_pre2 より速くなりました (1.1倍) 。
  例外が発生しないケースでは 0.9.16_pre2 より速くなりました (2.5倍) 。

- 何か問題等あるかもしれませんが、まずは情報としてあげておきます。
