### PR TITLE
Fix module-exports?

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -342,43 +342,45 @@ static ScmGloc *search_binding(ScmModule *module, ScmSymbol *symbol,
         module_add_visited(&searched, module);
     }
 
-    ScmObj p, mp;
-    /* Next, search from imported modules
-       If the import is prefixed, we avoid caching the result. */
-    SCM_FOR_EACH(p, module->imported) {
-        ScmObj elt = SCM_CAR(p);
-        ScmObj sym = SCM_OBJ(symbol);
-        int prefixed = FALSE;
+    ScmObj mp;
+    if (!external_only || module->exportAll) {
+        ScmObj p;
+        /* Next, search from imported modules
+           If the import is prefixed, we avoid caching the result. */
+        SCM_FOR_EACH(p, module->imported) {
+            ScmObj elt = SCM_CAR(p);
+            ScmObj sym = SCM_OBJ(symbol);
+            int prefixed = FALSE;
 
-        SCM_ASSERT(SCM_MODULEP(elt));
-        SCM_FOR_EACH(mp, SCM_MODULE(elt)->mpl) {
-            ScmGloc *g;
+            SCM_ASSERT(SCM_MODULEP(elt));
+            SCM_FOR_EACH(mp, SCM_MODULE(elt)->mpl) {
+                ScmGloc *g;
 
-            SCM_ASSERT(SCM_MODULEP(SCM_CAR(mp)));
-            ScmModule *m = SCM_MODULE(SCM_CAR(mp));
-            if (!prefixed && module_visited_p(&searched, m)) continue;
-            if (SCM_SYMBOLP(m->prefix)) {
-                sym = Scm_SymbolSansPrefix(SCM_SYMBOL(sym),
-                                           SCM_SYMBOL(m->prefix));
-                if (!SCM_SYMBOLP(sym)) break;
-                prefixed = TRUE;
-            }
-
-            ScmObj v = Scm_HashTableRef(m->external, SCM_OBJ(sym), SCM_FALSE);
-            if (SCM_GLOCP(v)) {
-                g = SCM_GLOC(v);
-                if (g->hidden) break;
-                if (SCM_GLOC_PHANTOM_BINDING_P(g)) {
-                    g = search_binding(m, g->name, FALSE, FALSE, TRUE);
-                    if (g) return g;
-                } else {
-                    return g;
+                SCM_ASSERT(SCM_MODULEP(SCM_CAR(mp)));
+                ScmModule *m = SCM_MODULE(SCM_CAR(mp));
+                if (!prefixed && module_visited_p(&searched, m)) continue;
+                if (SCM_SYMBOLP(m->prefix)) {
+                    sym = Scm_SymbolSansPrefix(SCM_SYMBOL(sym),
+                                               SCM_SYMBOL(m->prefix));
+                    if (!SCM_SYMBOLP(sym)) break;
+                    prefixed = TRUE;
                 }
+
+                ScmObj v = Scm_HashTableRef(m->external, SCM_OBJ(sym), SCM_FALSE);
+                if (SCM_GLOCP(v)) {
+                    g = SCM_GLOC(v);
+                    if (g->hidden) break;
+                    if (SCM_GLOC_PHANTOM_BINDING_P(g)) {
+                        g = search_binding(m, g->name, FALSE, FALSE, TRUE);
+                        if (g) return g;
+                    } else {
+                        return g;
+                    }
+                }
+                if (!prefixed) module_add_visited(&searched, m);
             }
-            if (!prefixed) module_add_visited(&searched, m);
         }
     }
-
     /* Then, search from parent modules */
     SCM_ASSERT(SCM_PAIRP(module->mpl));
     SCM_FOR_EACH(mp, SCM_CDR(module->mpl)) {

--- a/tests/module.scm
+++ b/tests/module.scm
@@ -278,7 +278,13 @@
   (define kyu (+ shi go))
   (export (rename kyu ku)))
 (define-module Oc-1
-  (import Oc))
+  (import Oc)
+  (export-all))
+(define-module Oc-2
+  (import Oc)
+  (export ichi))
+(define-module Oc-3
+  (extend Oc))
 
 (test "export-time renaming" '(1 4 5 9 #f #f)
       (lambda ()
@@ -303,6 +309,24 @@
       '((ichi #t #t) (ni #f #f) (shi #f #f) (yon #t #t) (go #t #t) (kyu #f #f) (ku #t #t))
       (lambda ()
         (let [(m (find-module 'Oc-1))]
+          (map (lambda (n)
+                 (list n
+                       (module-binds? m n)
+                       (module-exports? m n)))
+               '(ichi ni shi yon go kyu ku)))))
+(test "export-time renaming and defines?/exports? (0c-2)"
+      '((ichi #t #t) (ni #f #f) (shi #f #f) (yon #t #f) (go #t #f) (kyu #f #f) (ku #t #f))
+      (lambda ()
+        (let ([m (find-module 'Oc-2)])
+          (map (lambda (n)
+                 (list n
+                       (module-binds? m n)
+                       (module-exports? m n)))
+               '(ichi ni shi yon go kyu ku)))))
+(test "export-time renaming and defines?/exports? (0c-3)"
+      '((ichi #t #t) (ni #t #f) (shi #t #f) (yon #f #t) (go #t #t) (kyu #t #f) (ku #f #t))
+      (lambda ()
+        (let ([m (find-module 'Oc-3)])
           (map (lambda (n)
                  (list n
                        (module-binds? m n)


### PR DESCRIPTION
`module-exports?` が `import` しているだけの束縛に対して `#t` を返しています。
```scheme
(define-module m1 (export foo) (define foo 42))
(define-module m2 (import m1))
(print (module-exports? 'm2 'foo)) ; #t
```
この影響でunbound variable errorが嘘の報告をします。
```
gosh> mt-random-get-seed
*** UNBOUND-VARIABLE-ERROR: unbound variable: mt-random-get-seed
    NOTE: `mt-random-get-seed' is exported from the following modules:
     - srfi.27
     - math.mt-random
```

まず、`module-exports?` のテスト(0c-1)が間違っていそうなのでそれを修正しました。`export-all` を想定していたのかなと思って `Oc-1` に `export-all` を追加する形にしました。ついでに必要そうなテストを追加しました。

それで `search_binding` を修正したのですが、いい方法が分からなくてやや場当たり的な修正になってしまったかもしれません。最初は単に `external_only` の時はimport関係は検索しないとすればいいかと思ったのですが、`export-all` はそのモジュールで直接束縛していない場合はphantom bindingを作らないようなので、`module->exportALL` の場合はここで `external_only` を無視するようにしました。