### PR TITLE
Add call-with-composable-continuation experimentally v2

### DIFF
--- a/doc/modgauche.texi
+++ b/doc/modgauche.texi
@@ -19503,7 +19503,7 @@ continuations you can't get away from those names.  If these names
 conflict to other names in your program, you can use @code{:prefix}
 import specifier (@pxref{Using modules}), for example as follows:
 @c JP
-註: 部分継続はふたつのオペレータ、@code{reset}と@code{shift}を使います。
+注意: 部分継続はふたつのオペレータ、@code{reset}と@code{shift}を使います。
 これらは元の論文で導入された名前ですが、既に用語として定着した感があります。
 ライブラリ関数名としては一般的に過ぎる名前なので、よりわかりやすい名前を
 つけようかとも考えたのですが、部分継続を話題にする際にはこれらの用語が
@@ -19519,6 +19519,16 @@ import specifier (@pxref{Using modules}), for example as follows:
 
 (pc:reset ... (pc:shift k ....) )
 @end example
+
+@c EN
+Note: This module replaces @code{call/cc} and @code{guard}
+with their partial continuation versions.
+For now, this might causes low performance of them.
+@c JP
+注意: 本モジュールは、@code{call/cc}と@code{guard}を、
+部分継続バージョンに差し替えます。
+現状では、これらのパフォーマンスが低下する可能性があります。
+@c COMMON
 
 @defmac reset expr @dots{}
 @c MOD gauche.partcont
@@ -19633,6 +19643,49 @@ Sometimes this similarity of @code{call/cc} comes handy.
 用意しました。
 @c COMMON
 @end defun
+
+@defmac reset-at prompt-tag expr @dots{}
+@c MOD gauche.partcont
+@end defmac
+
+@defmac shift-at prompt-tag var expr @dots{}
+@c MOD gauche.partcont
+@end defmac
+
+@defmac prompt expr @dots{}
+@c MOD gauche.partcont
+@end defmac
+
+@defmac control var expr @dots{}
+@c MOD gauche.partcont
+@end defmac
+
+@defmac prompt-at prompt-tag expr @dots{}
+@c MOD gauche.partcont
+@end defmac
+
+@defmac control-at prompt-tag var expr @dots{}
+@c MOD gauche.partcont
+@end defmac
+
+@defun call-with-current-continuation proc
+@defunx call/cc proc
+@c MOD gauche.partcont
+@c EN
+This is a partial continuation version of call/cc.
+@c JP
+部分継続バージョンのcall/ccです。
+@c COMMON
+@end defun
+
+@defmac guard (var clause @dots{}) body @dots{}
+@c MOD gauche.partcont
+@c EN
+This is a partial continuation version of guard.
+@c JP
+部分継続バージョンのguardです。
+@c COMMON
+@end defmac
 
 @c EN
 Well, @dots{} I bet you feel like your brain is twisted hard

--- a/doc/modsrfi.texi
+++ b/doc/modsrfi.texi
@@ -16608,7 +16608,9 @@ Here's a list of SRFI-226 APIs and how Gauche supports them.
 Implemented experimentally.
 @item call-with-current-continuation
 @itemx call/cc
-@xref{Continuations}.
+@xref{Continuations}.  However, current implementation
+of @code{call/cc} and @code{guard} haven't integrated to SRFI-226 model yet.
+(i.e. these aren't partial continuation versions.)
 @item call-in-continuation
 @itemx call-in
 Not implemented yet.
@@ -16624,14 +16626,11 @@ Not implemented yet.
 
 @item Shift and reset
 @table @code
-@item shift-at
-@itemx reset-at
-Not implemented yet.
 @item shift
 @itemx reset
-@xref{Partial continuations}.  However, current implementation
-of @code{shift}/@code{reset} hasn't integrated to SRFI-226 model
-yet.
+@itemx shift-at
+@itemx reset-at
+@xref{Partial continuations}.
 @end table
 
 @item Inspection

--- a/doc/modsrfi.texi
+++ b/doc/modsrfi.texi
@@ -16637,7 +16637,7 @@ Not implemented yet.
 @table @code
 @item continuation?
 @itemx non-composable-continuation?
-Not implemented yet.
+Implemented experimentally.
 @end table
 
 @item Continuation marks

--- a/doc/modsrfi.texi
+++ b/doc/modsrfi.texi
@@ -16618,7 +16618,7 @@ Implemented experimentally.
 @item call-with-continuation-barrier
 Not implemented yet.
 @item continuation-prompt-available?
-Not implemented yet.
+Implemented experimentally.
 @item dynamic-wind
 @xref{Continuations}.
 @item unwind-protect

--- a/doc/modsrfi.texi
+++ b/doc/modsrfi.texi
@@ -16605,7 +16605,7 @@ Here's a list of SRFI-226 APIs and how Gauche supports them.
 @table @code
 @item call-with-non-comosable-continuation
 @itemx call-with-composable-continuation
-Not implemented yet.
+Implemented experimentally.
 @item call-with-current-continuation
 @itemx call/cc
 @xref{Continuations}.

--- a/doc/modsrfi.texi
+++ b/doc/modsrfi.texi
@@ -16613,7 +16613,8 @@ of @code{call/cc} and @code{guard} haven't integrated to SRFI-226 model yet.
 (i.e. these aren't partial continuation versions.)
 @item call-in-continuation
 @itemx call-in
-Not implemented yet.
+@itemx return-to
+Implemented experimentally.
 @item call-with-continuation-barrier
 Not implemented yet.
 @item continuation-prompt-available?

--- a/lib/gauche/partcont.scm
+++ b/lib/gauche/partcont.scm
@@ -1,19 +1,144 @@
 (define-module gauche.partcont
-  (export reset shift call/pc))
+  (export reset shift call/pc reset-at shift-at
+          prompt control prompt-at control-at
+          call-with-current-continuation call/cc
+          guard))
 (select-module gauche.partcont)
 
 (define %reset (with-module gauche.internal %reset))
 (define %call/pc (with-module gauche.internal %call/pc))
 
+;; reset / shift
+
 (define-syntax reset
   (syntax-rules ()
     [(reset expr ...)
-     (%reset (^[] expr ...))]))
+     (call-with-continuation-prompt (^[] expr ...))]))
 
-(define (call/pc proc)
-  (%call/pc (^k (proc (^ args (reset (apply k args)))))))
+(define-syntax reset-at
+  (syntax-rules ()
+    [(reset-at prompt-tag expr ...)
+     (call-with-continuation-prompt (^[] expr ...) prompt-tag)]))
+
+(define (call/pc proc :optional (prompt-tag #f))
+  (%call/pc
+   (^k
+    (abort-current-continuation
+     (or prompt-tag (default-continuation-prompt-tag))
+     (^[] (proc (^ args
+                   (call-with-continuation-prompt
+                    (^[] (apply k args))
+                    prompt-tag))))))
+   prompt-tag))
 
 (define-syntax shift
   (syntax-rules ()
     [(shift var expr ...)
      (call/pc (^[var] expr ...))]))
+
+(define-syntax shift-at
+  (syntax-rules ()
+    [(shift-at prompt-tag var expr ...)
+     (call/pc (^[var] expr ...) prompt-tag)]))
+
+;; prompt / control
+
+(define-syntax prompt
+  (syntax-rules ()
+    [(prompt expr ...)
+     (call-with-continuation-prompt
+      (^[] expr ...)
+      (default-continuation-prompt-tag)
+      (lambda (thunk) (thunk)))]))
+
+(define-syntax prompt-at
+  (syntax-rules ()
+    [(prompt-at prompt-tag expr ...)
+     (call-with-continuation-prompt
+      (^[] expr ...)
+      prompt-tag
+      (lambda (thunk) (thunk)))]))
+
+(define (call/control proc :optional (prompt-tag #f))
+  (%call/pc
+   (^k
+    (abort-current-continuation
+     (or prompt-tag (default-continuation-prompt-tag))
+     (^[] (proc (^ args (apply k args))))))
+   prompt-tag))
+
+(define-syntax control
+  (syntax-rules ()
+    [(control var expr ...)
+     (call/control (^[var] expr ...))]))
+
+(define-syntax control-at
+  (syntax-rules ()
+    [(control-at prompt-tag var expr ...)
+     (call/control (^[var] expr ...) prompt-tag)]))
+
+;; call/cc
+
+(define call-with-current-continuation call-with-non-composable-continuation)
+(define call/cc call-with-non-composable-continuation)
+
+;; guard
+
+(define-syntax guard
+  (syntax-rules ()
+    ((guard (var clause ...) e1 e2 ...)
+     ((call/cc
+       (lambda (guard-k)
+         (with-exception-handler
+          (lambda (condition)
+            ((call/cc
+              (lambda (handler-k)
+                (guard-k
+                 (lambda ()
+                   (let ((var condition))
+                     (guard-aux
+                      (handler-k
+                       (lambda ()
+                         (raise-continuable condition)))
+                      clause ...))))))))
+          (lambda ()
+            (call-with-values
+                (lambda () e1 e2 ...)
+              (lambda args
+                (guard-k
+                 (lambda ()
+                   (apply values args)))))))))))))
+
+(define-syntax guard-aux
+  (syntax-rules (else =>)
+    ((guard-aux reraise (else result1 result2 ...))
+     (begin result1 result2 ...))
+    ((guard-aux reraise (test => result))
+     (let ((temp test))
+       (if temp
+         (result temp)
+         reraise)))
+    ((guard-aux reraise (test => result)
+                clause1 clause2 ...)
+     (let ((temp test))
+       (if temp
+         (result temp)
+         (guard-aux reraise clause1 clause2 ...))))
+    ((guard-aux reraise (test))
+     (or test reraise))
+    ((guard-aux reraise (test) clause1 clause2 ...)
+     (let ((temp test))
+       (if temp
+         temp
+         (guard-aux reraise clause1 clause2 ...))))
+    ((guard-aux reraise (test result1 result2 ...))
+     (if test
+       (begin result1 result2 ...)
+       reraise))
+    ((guard-aux reraise
+                (test result1 result2 ...)
+                clause1 clause2 ...)
+     (if test
+       (begin result1 result2 ...)
+       (guard-aux reraise clause1 clause2 ...)))))
+

--- a/lib/gauche/partcont.scm
+++ b/lib/gauche/partcont.scm
@@ -77,12 +77,12 @@
     [(control-at prompt-tag var expr ...)
      (call/control (^[var] expr ...) prompt-tag)]))
 
-;; call/cc
+;; call/cc (= non-composable partial continuation)
 
 (define call-with-current-continuation call-with-non-composable-continuation)
 (define call/cc call-with-non-composable-continuation)
 
-;; guard
+;; guard (from R7RS)
 
 (define-syntax guard
   (syntax-rules ()
@@ -141,4 +141,3 @@
      (if test
        (begin result1 result2 ...)
        (guard-aux reraise clause1 clause2 ...)))))
-

--- a/lib/srfi/226/continuation.scm
+++ b/lib/srfi/226/continuation.scm
@@ -15,6 +15,6 @@
           call-in
           return-to
           ;;call-with-continuation-barrier
-          ;;continuation-prompt-available?
+          continuation-prompt-available?
           dynamic-wind
           unwind-protect))

--- a/lib/srfi/226/continuation.scm
+++ b/lib/srfi/226/continuation.scm
@@ -11,9 +11,9 @@
           call-with-current-continuation
           call/cc
           call-with-composable-continuation
-          ;;call-in-continuation
-          ;;call-in
-          ;;return-to
+          call-in-continuation
+          call-in
+          return-to
           ;;call-with-continuation-barrier
           ;;continuation-prompt-available?
           dynamic-wind

--- a/lib/srfi/226/continuation.scm
+++ b/lib/srfi/226/continuation.scm
@@ -7,10 +7,10 @@
           make-continuation-violation
           continuation-violation?
           continuation-violation-prompt-tag
-          ;;call-with-non-composable-continuation
+          call-with-non-composable-continuation
           call-with-current-continuation
           call/cc
-          ;;call-with-composable-continuation
+          call-with-composable-continuation
           ;;call-in-continuation
           ;;call-in
           ;;return-to

--- a/lib/srfi/226/inspection.scm
+++ b/lib/srfi/226/inspection.scm
@@ -4,5 +4,5 @@
 
 (define-module srfi.226.inspection
   (export continuation?
-          ;; non-composable-continuation?
+          non-composable-continuation?
           ))

--- a/lib/srfi/226/shift-reset.scm
+++ b/lib/srfi/226/shift-reset.scm
@@ -5,5 +5,5 @@
 (define-module srfi.226.shift-reset
   (use gauche.partcont)
   (export shift reset
-          ;; shift-at reset-at
+          shift-at reset-at
           ))

--- a/src/gauche.h
+++ b/src/gauche.h
@@ -670,6 +670,8 @@ SCM_EXTERN ScmObj Scm_VMCallWithNonComposableContinuation(ScmObj proc,
                                                           ScmObj promptTag);
 SCM_EXTERN ScmObj Scm_VMCallInContinuation(ScmObj cont, ScmObj proc,
                                            ScmObj args);
+SCM_EXTERN int    Scm_ContinuationPromptAvailableP(ScmObj promptTag,
+                                                   ScmObj cont);
 
 SCM_EXTERN ScmObj Scm_VMWithErrorHandler(ScmObj handler, ScmObj thunk);
 SCM_EXTERN ScmObj Scm_VMWithGuardHandler(ScmObj handler, ScmObj thunk);

--- a/src/gauche.h
+++ b/src/gauche.h
@@ -660,6 +660,7 @@ SCM_EXTERN ScmObj Scm_VMReset(ScmObj proc);
 SCM_EXTERN void   Scm_VMPushDynamicHandlers(ScmObj, ScmObj, ScmObj);
 SCM_EXTERN ScmObj Scm_VMDynamicWind(ScmObj pre, ScmObj body, ScmObj post);
 SCM_EXTERN int    Scm_ContinuationP(ScmObj proc);
+SCM_EXTERN int    Scm_NonComposableContinuationP(ScmObj proc);
 
 SCM_EXTERN ScmObj Scm_VMCallWithContinuationPrompt(ScmObj, ScmObj, ScmObj);
 SCM_EXTERN ScmObj Scm_VMAbortCurrentContinuation(ScmObj, ScmObj);

--- a/src/gauche.h
+++ b/src/gauche.h
@@ -668,6 +668,8 @@ SCM_EXTERN ScmObj Scm_VMCallWithComposableContinuation(ScmObj proc,
                                                        ScmObj promptTag);
 SCM_EXTERN ScmObj Scm_VMCallWithNonComposableContinuation(ScmObj proc,
                                                           ScmObj promptTag);
+SCM_EXTERN ScmObj Scm_VMCallInContinuation(ScmObj cont, ScmObj proc,
+                                           ScmObj args);
 
 SCM_EXTERN ScmObj Scm_VMWithErrorHandler(ScmObj handler, ScmObj thunk);
 SCM_EXTERN ScmObj Scm_VMWithGuardHandler(ScmObj handler, ScmObj thunk);

--- a/src/gauche.h
+++ b/src/gauche.h
@@ -654,6 +654,7 @@ SCM_EXTERN ScmObj Scm_VMEval(ScmObj expr, ScmObj env);
 SCM_EXTERN ScmObj Scm_VMCall(ScmObj *args, int argcnt, void *data);
 
 SCM_EXTERN ScmObj Scm_VMCallCC(ScmObj proc);
+SCM_EXTERN ScmObj Scm_VMCallCCWithTag(ScmObj proc, ScmObj promptTag);
 SCM_EXTERN ScmObj Scm_VMCallPC(ScmObj proc);
 SCM_EXTERN ScmObj Scm_VMReset(ScmObj proc);
 SCM_EXTERN void   Scm_VMPushDynamicHandlers(ScmObj, ScmObj, ScmObj);
@@ -662,6 +663,10 @@ SCM_EXTERN int    Scm_ContinuationP(ScmObj proc);
 
 SCM_EXTERN ScmObj Scm_VMCallWithContinuationPrompt(ScmObj, ScmObj, ScmObj);
 SCM_EXTERN ScmObj Scm_VMAbortCurrentContinuation(ScmObj, ScmObj);
+SCM_EXTERN ScmObj Scm_VMCallWithComposableContinuation(ScmObj proc,
+                                                       ScmObj promptTag);
+SCM_EXTERN ScmObj Scm_VMCallWithNonComposableContinuation(ScmObj proc,
+                                                          ScmObj promptTag);
 
 SCM_EXTERN ScmObj Scm_VMWithErrorHandler(ScmObj handler, ScmObj thunk);
 SCM_EXTERN ScmObj Scm_VMWithGuardHandler(ScmObj handler, ScmObj thunk);

--- a/src/gauche/priv/vmP.h
+++ b/src/gauche/priv/vmP.h
@@ -174,6 +174,9 @@ typedef struct ScmEscapePointRec {
                                      CONT_TYPE_NON_COMPOSABLE
                                        - non-composable partial continuation
                                 */
+    int contTypeReq;            /* requested continuation type
+                                   (used for 'non-composable-continuation?')
+                                */
 
     /* The following fields are used for new implementation of partial cont. */
     ScmObj promptTag;           /* (not used now) */

--- a/src/gauche/priv/vmP.h
+++ b/src/gauche/priv/vmP.h
@@ -153,6 +153,7 @@ typedef struct ScmEscapePointRec {
     ScmObj xhandler;            /* saved exception handler */
     ScmObj partialChain;        /* for partial continuation */
     ScmObj partialHandlers;     /* for partial continuation */
+    ScmContFrame *partialCont;  /* for partial continuation */
     int errorReporting;         /* state of SCM_VM_ERROR_REPORTING flag
                                    when this ep is captured.  The flag status
                                    should be restored when the control
@@ -182,6 +183,7 @@ typedef struct ScmEscapePointRec {
     ScmObj promptTag;           /* (not used now) */
     ScmObj abortHandler;        /* abort handler */
     ScmObj abortArgs;           /* abort handler's arguments */
+    ScmObj noCompHandler;       /* for non-composable partial continuation */
     struct ScmEscapePointRec *bottom; /* (not used now) */
 } ScmEscapePoint;
 

--- a/src/gauche/priv/vmP.h
+++ b/src/gauche/priv/vmP.h
@@ -73,8 +73,8 @@ struct ScmPromptTagRec {
    multiple of ScmWord. */
 typedef struct ScmPromptDataRec {
     ScmWord dummy;              /* RET insn */
-    ScmObj abortHandler;        /* abort handler */
-    ScmObj dynamicHandlers;     /* dynamic-wind handler chain */
+    ScmObj abortHandler;        /* abort handler              (not used now)*/
+    ScmObj dynamicHandlers;     /* dynamic-wind handler chain (not used now)*/
 } ScmPromptData;
 
 #define PROMPT_DATA_SIZE       sizeof(ScmPromptData)/sizeof(ScmWord)
@@ -132,6 +132,13 @@ SCM_CLASS_DECL(Scm_DynamicHandlerClass);
  *  EscapePoint (EP) structure is a saved continuation.  It grabs
  *  a head of continuation chain with some auxiliary data.
  */
+
+enum {
+    CONT_TYPE_FULL = 0,
+    CONT_TYPE_COMPOSABLE = 1,
+    CONT_TYPE_NON_COMPOSABLE = 2
+};
+
 typedef struct ScmEscapePointRec {
     SCM_HEADER;
     ScmObj ehandler;            /* handler closure */
@@ -144,8 +151,8 @@ typedef struct ScmEscapePointRec {
                                    for they can be executed on anywhere
                                    w.r.t. cstack. */
     ScmObj xhandler;            /* saved exception handler */
-    ScmObj resetChain;          /* for reset/shift */
-    ScmObj partHandlers;        /* for reset/shift */
+    ScmObj partialChain;        /* for partial continuation */
+    ScmObj partialHandlers;     /* for partial continuation */
     int errorReporting;         /* state of SCM_VM_ERROR_REPORTING flag
                                    when this ep is captured.  The flag status
                                    should be restored when the control
@@ -159,11 +166,20 @@ typedef struct ScmEscapePointRec {
                                    with-error-handler uses the latter model,
                                    but SRFI-34's guard needs the former model.
                                 */
+    int contType;               /* continuation type
+                                     CONT_TYPE_FULL
+                                       - full continuation (legacy)
+                                     CONT_TYPE_COMPOSABLE
+                                       - composable partial continuation
+                                     CONT_TYPE_NON_COMPOSABLE
+                                       - non-composable partial continuation
+                                */
 
     /* The following fields are used for new implementation of partial cont. */
-    ScmObj promptTag;
-    ScmObj abortHandler;
-    struct ScmEscapePointRec *bottom;
+    ScmObj promptTag;           /* (not used now) */
+    ScmObj abortHandler;        /* abort handler */
+    ScmObj abortArgs;           /* abort handler's arguments */
+    struct ScmEscapePointRec *bottom; /* (not used now) */
 } ScmEscapePoint;
 
 SCM_CLASS_DECL(Scm_EscapePointClass);

--- a/src/gauche/priv/vmP.h
+++ b/src/gauche/priv/vmP.h
@@ -180,7 +180,7 @@ typedef struct ScmEscapePointRec {
                                 */
 
     /* The following fields are used for new implementation of partial cont. */
-    ScmObj promptTag;           /* (not used now) */
+    ScmObj promptTag;           /* prompt tag */
     ScmObj abortHandler;        /* abort handler */
     ScmObj abortArgs;           /* abort handler's arguments */
     ScmObj noCompHandler;       /* for non-composable partial continuation */

--- a/src/gauche/vm.h
+++ b/src/gauche/vm.h
@@ -527,16 +527,9 @@ struct ScmVMRec {
 #endif
 
     /* Escape handling */
-    ScmObj floatingEscapePoints; /* List of escapePoints that point to
-                                    in-stack continuation frames.  We only need
-                                    it so that we can adjust pointers to cont
-                                    frames when they are moved to the heap.
-                                    The list is cleared once cont frames
-                                    are moved to the heap.
-                                 */
     int escapeReason;            /* temporary storage to pass data across
                                     longjmp(). */
-    void *escapeData[2];         /* ditto. */
+    void *escapeData[3];         /* ditto. */
     int errorHandlerContinuable; /* A transient flag, set by the error handler
                                     as a result of 'guard' expansion to tell
                                     that the control should return to 'raise'
@@ -576,15 +569,11 @@ struct ScmVMRec {
     ScmCallTrace *callTrace;
     ScmCodeCache *codeCache;
 
-    /* for reset/shift */
-    ScmContinuationPrompt *currentPrompt;
-    ScmObj resetChain;          /* list of reset information,
-                                   where reset information is
-                                   (delimited . <dynamic handlers chain>).
-                                   the delimited flag is set when 'shift'
-                                   appears in 'reset' and the end marker of
-                                   partial continuation is set. */
-
+    /* for partial continuation */
+    ScmObj partialChain;        /* list of partial continuation information,
+                                   where partial continuation information is
+                                   (promptTag . escapePoint).
+                                */
 };
 
 SCM_EXTERN ScmVM *Scm_NewVM(ScmVM *proto, ScmObj name);

--- a/src/libproc.scm
+++ b/src/libproc.scm
@@ -91,6 +91,10 @@
                                               :optional (prompt-tag #f)
                                                         (abort-handler #f))
   Scm_VMCallWithContinuationPrompt)
+(define-cproc %continuation-prompt-available? (prompt-tag
+                                               :optional (cont #f))
+                                              ::<boolean>
+  Scm_ContinuationPromptAvailableP)
 
 ;; Continuaton prompts
 (select-module gauche)
@@ -136,6 +140,10 @@
   (unless (non-composable-continuation? cont)
     (errorf "cont must be a non-composable continuation, but got: ~S" cont))
   (apply call-in-continuation cont values args))
+(define (continuation-prompt-available? prompt-tag :optional (cont #f))
+  ((with-module gauche.internal %continuation-prompt-available?)
+   prompt-tag
+   (or cont (call-with-non-composable-continuation values))))
 
 ;; Continuation marks
 (select-module gauche)

--- a/src/libproc.scm
+++ b/src/libproc.scm
@@ -126,6 +126,16 @@
 (define-cproc call-with-non-composable-continuation (proc
                                                      :optional (prompt-tag #f))
   Scm_VMCallWithNonComposableContinuation)
+(define-cproc call-in-continuation (cont proc :rest objs)
+  Scm_VMCallInContinuation)
+(define (call-in cont proc :rest args)
+  (unless (non-composable-continuation? cont)
+    (errorf "cont must be a non-composable continuation, but got: ~S" cont))
+  (apply call-in-continuation cont proc args))
+(define (return-to cont :rest args)
+  (unless (non-composable-continuation? cont)
+    (errorf "cont must be a non-composable continuation, but got: ~S" cont))
+  (apply call-in-continuation cont values args))
 
 ;; Continuation marks
 (select-module gauche)

--- a/src/libproc.scm
+++ b/src/libproc.scm
@@ -77,6 +77,8 @@
 
 ;; SRFI-226
 (define-cproc continuation? (obj) ::<boolean> Scm_ContinuationP)
+(define-cproc non-composable-continuation? (obj) ::<boolean>
+  Scm_NonComposableContinuationP)
 
 (select-module gauche.internal)
 ;; for partial continuation.  See lib/gauche/partcont.scm

--- a/src/libproc.scm
+++ b/src/libproc.scm
@@ -64,7 +64,9 @@
                   (SCM_APPEND1 head tail (SCM_CAR cp)))
                 (return (Scm_VMApply proc head))])))
 
-(define-cproc call-with-current-continuation (proc) Scm_VMCallCC)
+(define-cproc call-with-current-continuation (proc
+                                              :optional (prompt-tag #f))
+  Scm_VMCallCCWithTag)
 (define-cproc values (:rest args) :constant (inliner VALUES) Scm_Values)
 (define-cproc dynamic-wind (pre body post) Scm_VMDynamicWind)
 
@@ -78,8 +80,15 @@
 
 (select-module gauche.internal)
 ;; for partial continuation.  See lib/gauche/partcont.scm
-(define-cproc %call/pc (proc) (return (Scm_VMCallPC proc)))
-(define-cproc %reset (proc) (return (Scm_VMReset proc)))
+(define-cproc %call/pc (proc :optional (prompt-tag #f))
+  Scm_VMCallWithComposableContinuation)
+(define-cproc %reset (thunk) Scm_VMReset)
+
+(select-module gauche.internal)
+(define-cproc %call-with-continuation-prompt (thunk
+                                              :optional (prompt-tag #f)
+                                                        (abort-handler #f))
+  Scm_VMCallWithContinuationPrompt)
 
 ;; Continuaton prompts
 (select-module gauche)
@@ -90,12 +99,35 @@
 (define-cproc continuation-prompt-tag? (obj) ::<boolean>
   SCM_PROMPT_TAG_P)
 
-(define-cproc call-with-continuation-prompt (thunk
-                                             :optional (prompt-tag #f)
+(define (call-with-continuation-prompt thunk :optional (prompt-tag #f)
                                                        (abort-handler #f))
-  Scm_VMCallWithContinuationPrompt)
+  (if abort-handler
+    ((with-module gauche.internal %call-with-continuation-prompt)
+     thunk
+     prompt-tag
+     abort-handler)
+    ((with-module gauche.internal %call-with-continuation-prompt)
+     thunk
+     prompt-tag
+     (lambda (continuation-thunk)
+       (unless (and (procedure? continuation-thunk)
+                    (eqv? (arity continuation-thunk) 0))
+         (errorf "default abort-handler requires exactly one argument, \
+                  which must be a thunk, but got: ~S"
+                 continuation-thunk))
+       (call-with-continuation-prompt continuation-thunk prompt-tag #f)))))
 (define-cproc abort-current-continuation (prompt-tag :rest objs)
   Scm_VMAbortCurrentContinuation)
+(define (call-with-composable-continuation proc :optional (prompt-tag #f))
+  ((with-module gauche.internal %call/pc)
+   (^k (proc (^ args
+                (call-with-continuation-prompt
+                 (^[] (apply k args))
+                 prompt-tag))))
+   prompt-tag))
+(define-cproc call-with-non-composable-continuation (proc
+                                                     :optional (prompt-tag #f))
+  Scm_VMCallWithNonComposableContinuation)
 
 ;; Continuation marks
 (select-module gauche)

--- a/src/libproc.scm
+++ b/src/libproc.scm
@@ -118,13 +118,9 @@
        (call-with-continuation-prompt continuation-thunk prompt-tag #f)))))
 (define-cproc abort-current-continuation (prompt-tag :rest objs)
   Scm_VMAbortCurrentContinuation)
-(define (call-with-composable-continuation proc :optional (prompt-tag #f))
-  ((with-module gauche.internal %call/pc)
-   (^k (proc (^ args
-                (call-with-continuation-prompt
-                 (^[] (apply k args))
-                 prompt-tag))))
-   prompt-tag))
+(define-cproc call-with-composable-continuation (proc
+                                                 :optional (prompt-tag #f))
+  Scm_VMCallWithComposableContinuation)
 (define-cproc call-with-non-composable-continuation (proc
                                                      :optional (prompt-tag #f))
   Scm_VMCallWithNonComposableContinuation)

--- a/src/vm.c
+++ b/src/vm.c
@@ -1594,9 +1594,8 @@ static ScmContFrame *copy_cont_frames(ScmContFrame *c,
 {
     ScmVM *vm = theVM;
 
-    if (c == NULL) { return NULL; }
-
     /* copy cont frame c */
+    if (c == NULL) { return NULL; }
     ScmContFrame *cc = copy_cont_1(vm, c, FALSE);
     if (c == c_last) {
         /* cut on c_last */
@@ -2005,6 +2004,7 @@ static ScmEscapePoint *new_ep(ScmVM *vm,
     ep->xhandler = Scm_VMCurrentExceptionHandler();
     ep->partialChain = vm->partialChain;
     ep->partialHandlers = SCM_NIL;
+    ep->partialCont = NULL;
     ep->errorReporting =
         SCM_VM_RUNTIME_FLAG_IS_SET(vm, SCM_ERROR_BEING_REPORTED);
     ep->rewindBefore = rewindBefore;
@@ -2013,6 +2013,7 @@ static ScmEscapePoint *new_ep(ScmVM *vm,
     ep->promptTag = promptTag;
     ep->abortHandler = abortHandler;
     ep->abortArgs = SCM_NIL;
+    ep->noCompHandler = SCM_FALSE;
     ep->bottom = NULL;
     return ep;
 }
@@ -2029,6 +2030,7 @@ static ScmEscapePoint *copy_ep(ScmEscapePoint *ep)
     ep2->xhandler = ep->xhandler;
     ep2->partialChain = ep->partialChain;
     ep2->partialHandlers = ep->partialHandlers;
+    ep2->partialCont = ep->partialCont;
     ep2->errorReporting = ep->errorReporting;
     ep2->rewindBefore = ep->rewindBefore;
     ep2->contType = ep->contType;
@@ -2036,6 +2038,7 @@ static ScmEscapePoint *copy_ep(ScmEscapePoint *ep)
     ep2->promptTag = ep->promptTag;
     ep2->abortHandler = ep->abortHandler;
     ep2->abortArgs = ep->abortArgs;
+    ep2->noCompHandler = ep->noCompHandler;
     ep2->bottom = ep->bottom;
     return ep2;
 }
@@ -3244,7 +3247,7 @@ static ScmObj find_partial_information(ScmVM *vm, ScmObj promptTag,
         }
     }
     if (outerMost) {
-        *outerMost = 0;
+        *outerMost = FALSE;
     }
     return SCM_NIL;
 }
@@ -3518,6 +3521,7 @@ void Scm_VMFlushDynamicHandlers()
 static ScmObj throw_cont_cc(ScmObj result, void **data);
 static ScmObj vm_abort_to_cc(ScmObj result, void **data);
 static ScmObj vm_partial_end_cc(ScmObj result, void **data);
+static ScmObj vm_no_comp_cc(ScmObj result, void **data);
 
 static ScmObj throw_cont_body(ScmObj hdlist,      /*((flag . handler-chain)...)*/
                               ScmEscapePoint *ep, /* target continuation */
@@ -3560,36 +3564,6 @@ static ScmObj throw_cont_body(ScmObj hdlist,      /*((flag . handler-chain)...)*
     } else {
         /* for partial continuation */
 
-        /* for non-composable partial continuation */
-        /* we drop continuation from current to prompt before merge. */
-        if (ep->contType == CONT_TYPE_NON_COMPOSABLE) {
-            /* find partial continuation information of nearest prompt */
-            ScmObj partialInfo = find_partial_information(vm, ep->promptTag,
-                                                          NULL);
-            if (!SCM_PAIRP(partialInfo)) {
-                Scm_RaiseCondition(SCM_OBJ(SCM_CLASS_CONTINUATION_ERROR),
-                                   "prompt-tag", ep->promptTag,
-                                   SCM_RAISE_CONDITION_MESSAGE,
-                                   "Prompt tag (%S) not found (E1)",
-                                   ep->promptTag);
-            }
-
-            /* get escape point on prompt */
-            ScmEscapePoint *ep2 = (ScmEscapePoint *)SCM_CDR(partialInfo);
-
-            /* get prompt continuation */
-            /* (outer of prompt continuation is ep2->cont->prev->prev) */
-            SCM_ASSERT(ep2 && ep2->cont && ep2->cont->prev);
-            ScmContFrame *cprompt = ep2->cont->prev->prev;
-
-            /* drop continuation from current to prompt */
-            vm->cont = cprompt;
-
-            /* set partial continuation information */
-            /* (cdr means outer of prompt) */
-            vm->partialChain = SCM_CDR(ep2->partialChain);
-        }
-
         /* push partial end continuation */
         void *data[1];
         data[0] = (void*)vm->partialChain;
@@ -3600,7 +3574,7 @@ static ScmObj throw_cont_body(ScmObj hdlist,      /*((flag . handler-chain)...)*
                problems of continuation sharing.
         */
         save_cont(vm);
-        ScmContFrame *epcont_copy = copy_cont_frames(ep->cont, NULL);
+        ScmContFrame *epcont_copy = copy_cont_frames(ep->partialCont, NULL);
         vm->cont = merge_cont_frames(vm->cont, epcont_copy);
     }
     vm->denv = ep->denv;
@@ -3616,6 +3590,13 @@ static ScmObj throw_cont_body(ScmObj hdlist,      /*((flag . handler-chain)...)*
         data[0] = (void*)ep->abortHandler;
         data[1] = (void*)ep->abortArgs;
         Scm_VMPushCC(vm_abort_to_cc, data, 2);
+    }
+
+    /* for non-composable partial continuation */
+    if (ep->contType == CONT_TYPE_FULL && !SCM_FALSEP(ep->noCompHandler)) {
+        void *data[1];
+        data[0] = (void*)ep->noCompHandler;
+        Scm_VMPushCC(vm_no_comp_cc, data, 1);
     }
 
     int nargs = Scm_Length(args);
@@ -3673,6 +3654,15 @@ static ScmObj vm_partial_end_cc(ScmObj result, void **data)
     return result;
 }
 
+static ScmObj vm_no_comp_cc(ScmObj result SCM_UNUSED, void **data)
+{
+    ScmVM *vm = theVM;
+    ScmObj noCompHandler = SCM_OBJ(data[0]);
+    ScmObj args = Scm_VMGetResult(vm);
+
+    return Scm_VMApply(noCompHandler, args);
+}
+
 /* Body of the continuation SUBR */
 static ScmObj throw_continuation(ScmObj *argframe,
                                  int nargs SCM_UNUSED, void *data)
@@ -3680,6 +3670,38 @@ static ScmObj throw_continuation(ScmObj *argframe,
     ScmEscapePoint *ep = (ScmEscapePoint*)data;
     ScmObj args = argframe[0];
     ScmVM *vm = theVM;
+
+    /* for non-composable partial continuation */
+    /* we drop continuation from current to prompt. */
+    if (ep->contType == CONT_TYPE_NON_COMPOSABLE) {
+        /* find partial continuation information of nearest prompt */
+        ScmObj partialInfo = find_partial_information(vm, ep->promptTag,
+                                                      NULL);
+        if (!SCM_PAIRP(partialInfo)) {
+            Scm_RaiseCondition(SCM_OBJ(SCM_CLASS_CONTINUATION_ERROR),
+                               "prompt-tag", ep->promptTag,
+                               SCM_RAISE_CONDITION_MESSAGE,
+                               "Prompt tag (%S) not found (E1)",
+                               ep->promptTag);
+        }
+
+        /* get escape point on prompt */
+        ScmEscapePoint *ep2 = (ScmEscapePoint *)SCM_CDR(partialInfo);
+
+        /* remake contproc */
+        ScmEscapePoint *ep3 = copy_ep(ep);
+        ep3->contType = CONT_TYPE_COMPOSABLE;
+        ScmObj contproc = Scm_MakeSubr(throw_continuation, ep3, 0, 1,
+                                       continuation_symbol);
+
+        /* jump to prompt */
+        ScmEscapePoint *ep4 = copy_ep(ep2);
+        ep4->abortHandler = SCM_FALSE;
+        ep4->noCompHandler = contproc;
+        ScmObj contproc2 = Scm_MakeSubr(throw_continuation, ep4, 0, 1,
+                                        continuation_symbol);
+        return Scm_VMApply(contproc2, args);
+    }
 
     /* calculate dynamic handlers to call */
     ScmObj hdlist = SCM_NIL;
@@ -3696,37 +3718,13 @@ static ScmObj throw_continuation(ScmObj *argframe,
                                           currentHandlers);
     }
 
-    /* for non-composable partial continuation */
-    /* we must rewind cstack from current to prompt to avoid memory leak.
-       so we move ep->cstack before rewinding cstack.
-    */
-    ScmCStack *epcstack = ep->cstack;
-    if (ep->contType == CONT_TYPE_NON_COMPOSABLE) {
-        /* find partial continuation information of nearest prompt */
-        ScmObj partialInfo = find_partial_information(vm, ep->promptTag,
-                                                      NULL);
-        if (!SCM_PAIRP(partialInfo)) {
-            Scm_RaiseCondition(SCM_OBJ(SCM_CLASS_CONTINUATION_ERROR),
-                               "prompt-tag", ep->promptTag,
-                               SCM_RAISE_CONDITION_MESSAGE,
-                               "Prompt tag (%S) not found (E2)",
-                               ep->promptTag);
-        }
-
-        /* get escape point on prompt */
-        ScmEscapePoint *ep2 = (ScmEscapePoint *)SCM_CDR(partialInfo);
-
-        /* move ep->cstack to prompt location */
-        epcstack = ep2->cstack;
-    }
-
     /* First, check to see if we need to rewind C stack.
        NB: If we are invoking a composable partial continuation,
        we execute it on the current cstack. */
-    if (ep->contType != CONT_TYPE_COMPOSABLE && vm->cstack != epcstack) {
+    if (ep->contType != CONT_TYPE_COMPOSABLE && vm->cstack != ep->cstack) {
         ScmCStack *cs;
         for (cs = vm->cstack; cs; cs = cs->prev) {
-            if (epcstack == cs) break;
+            if (ep->cstack == cs) break;
         }
 
         /* If the continuation captured below the current C stack, we rewind
@@ -3831,7 +3829,7 @@ ScmObj vm_call_pc_with_tag_and_type(ScmObj proc, ScmObj promptTag, int contType)
         Scm_RaiseCondition(SCM_OBJ(SCM_CLASS_CONTINUATION_ERROR),
                            "prompt-tag", promptTag,
                            SCM_RAISE_CONDITION_MESSAGE,
-                           "Prompt tag (%S) not found (E3)",
+                           "Prompt tag (%S) not found (E2)",
                            promptTag);
     }
 #endif
@@ -3847,12 +3845,13 @@ ScmObj vm_call_pc_with_tag_and_type(ScmObj proc, ScmObj promptTag, int contType)
        handling. */
     ScmEscapePoint *ep = new_ep(vm, SCM_FALSE, FALSE, contType,
                                 promptTag, SCM_FALSE);
-    /* Set delimited cont frames instead of full cont frames (vm->cont).
+    /* Save partial cont frames instead of full cont frames (vm->cont).
        This is important to avoid memory leak of partial continuation.
        See:
        https://okmij.org/ftp/continuations/against-callcc.html#memory-leak
     */
-    ep->cont = copy_cont_frames(vm->cont, cprompt);
+    ep->partialCont = copy_cont_frames(vm->cont, cprompt);
+    ep->cont = NULL;               /* don't use for partial continuation */
     ep->denv = cprompt ? cprompt->denv : SCM_NIL;
     ep->dynamicHandlers = SCM_NIL; /* don't use for partial continuation */
     ep->partialChain = SCM_NIL;    /* don't use for partial continuation */

--- a/src/vm.c
+++ b/src/vm.c
@@ -86,20 +86,27 @@ struct ScmContinuationPromptRec {
     struct ScmContinuationPromptRec *prev;
 };
 
-/* bitflags for ScmContFrame->marker */
+/* bitflags for ScmContFrame->marker
+ *
+ *  BOUNDARY - this is a user_eval_inner boundary; when RETURN_OP encounters
+ *             this frame, run_loop returns control to the surrounding C
+ *             stack.  Boundary frames are also PROMPT frames.
+ *  PROMPT   - this is a prompt cont frame.  Both boundary frames and frames
+ *             pushed by call-with-continuation-prompt carry this.
+ */
 enum {
-    SCM_CONT_PROMPT_MARKER = (1L<<0),
-    SCM_CONT_BOUNDARY_MARKER = (1L<<1)
+    SCM_CONT_BOUNDARY_MARKER = (1L<<0),
+    SCM_CONT_PROMPT_MARKER   = (1L<<1),
 };
 
 static void push_prompt_cont(ScmVM*, ScmObj, ScmObj);
 static void push_boundary_cont(ScmVM*, ScmObj, ScmObj);
 
-/* return true if cont is a boundary continuation frame */
+/* return true if cont is a boundary continuation frame (C-stack boundary) */
 #define BOUNDARY_FRAME_P(cont) ((cont)->marker & SCM_CONT_BOUNDARY_MARKER)
 
-/* return true if cont is a prompt continuation frame */
-#define PROMPT_FRAME_P(cont) ((cont)->marker & SCM_CONT_PROMPT_MARKER)
+/* return true if cont is a prompt cont frame */
+#define PROMPT_FRAME_P(cont)   ((cont)->marker & SCM_CONT_PROMPT_MARKER)
 
 /* A stub VM code to make VM return immediately */
 static ScmWord return_code[] = { SCM_VM_INSN(SCM_VM_RET) };
@@ -794,13 +801,13 @@ static void vm_unregister(ScmVM *vm)
     } while (0)
 
 /* return operation. */
-#define RETURN_OP()                                   \
-    do {                                              \
-        if (CONT == NULL || BOUNDARY_FRAME_P(CONT)) { \
-            return; /* no more continuations */       \
-        } else {                                      \
-            POP_CONT();                               \
-        }                                             \
+#define RETURN_OP()                                     \
+    do {                                                \
+        if (CONT == NULL || BOUNDARY_FRAME_P(CONT)) {   \
+            return; /* no more continuations */         \
+        } else {                                        \
+            POP_CONT();                                 \
+        }                                               \
     } while (0)
 
 /* push environment header to finish the environment frame.
@@ -1992,6 +1999,10 @@ static ScmEscapePoint *new_ep(ScmVM *vm,
                               ScmObj abortHandler)
 {
     /* save continuation to heap before capturing escape point */
+    /*
+       NB: This avoids ep->cont remains pointing to the stack
+           after vm->cont has moved to heap.
+    */
     save_cont(vm);
 
     ScmEscapePoint *ep = SCM_NEW(ScmEscapePoint);
@@ -3724,7 +3735,7 @@ static ScmObj throw_continuation(ScmObj *argframe,
                                                currentHandlers);
     } else if (ep->contType == CONT_TYPE_COMPOSABLE) {
         /* for composable partial continuation */
-        /* this avoids redundant calls of dynamic handlers. */
+        /* NB: this avoids redundant calls of dynamic handlers */
         hdlist =
             throw_cont_calculate_handlers(Scm_Append2(ep->partialHandlers,
                                                       currentHandlers),
@@ -3733,7 +3744,7 @@ static ScmObj throw_continuation(ScmObj *argframe,
         /* for non-composable partial continuation */
         /* get escape point from continuation */
         ScmEscapePoint *ep2 = (ScmEscapePoint*)((ScmSubr*)ep->noCompHandler)->data;
-        /* this avoids redundant calls of dynamic handlers. */
+        /* NB: this avoids redundant calls of dynamic handlers */
         hdlist =
             throw_cont_calculate_handlers(Scm_Append2(ep2->partialHandlers,
                                                       ep->dynamicHandlers),
@@ -3911,7 +3922,7 @@ ScmObj vm_call_pc_with_tag_and_type(ScmObj proc, ScmObj promptTag,
         }
     }
 
-    /* Cut partial continuation information from current to prompt */
+    /* cut partial continuation information from current to prompt */
     {
         ScmObj h = SCM_NIL, t = SCM_NIL, p;
         SCM_FOR_EACH(p, vm->partialChain) {
@@ -3924,9 +3935,8 @@ ScmObj vm_call_pc_with_tag_and_type(ScmObj proc, ScmObj promptTag,
     /* get dynamic handlers chain on prompt */
     ScmObj targetHandlers = ep2->dynamicHandlers;
 
-    /* Cut dynamic handlers chain from current to prompt.
-       This is important to avoid redundant calls of dynamic handlers.
-    */
+    /* cut dynamic handlers chain from current to prompt */
+    /* NB: this avoids redundant calls of dynamic handlers */
     {
         ScmObj h = SCM_NIL, t = SCM_NIL, p;
         SCM_FOR_EACH(p, get_dynamic_handlers(vm)) {

--- a/src/vm.c
+++ b/src/vm.c
@@ -1195,7 +1195,7 @@ static inline ScmEnvFrame *save_env(ScmVM *vm, ScmEnvFrame *env_begin)
 }
 
 static ScmContFrame *copy_cont_1(ScmVM *vm, ScmContFrame *c,
-                                  int promptDataCopy)
+                                 int promptDataCopy)
 {
     int size = (CONT_FRAME_SIZE + c->size) * sizeof(ScmObj);
     ScmObj *heap = SCM_NEW2(ScmObj*, size);
@@ -1582,7 +1582,8 @@ static ScmObj find_dynamic_env(ScmVM *vm, ScmObj key, ScmObj fallback)
     else return fallback;
 }
 
-static ScmObj find_dynamic_env_specified(ScmObj denv, ScmObj key, ScmObj fallback)
+static ScmObj find_dynamic_env_specified(ScmObj denv, ScmObj key,
+                                         ScmObj fallback)
 {
     ScmObj p = Scm_Assq(key, denv);
     if (SCM_PAIRP(p)) return SCM_CDR(p);
@@ -1596,8 +1597,7 @@ ScmObj Scm_VMFindDynamicEnv(ScmObj key, ScmObj fallback)
 }
 
 /* Copy cont frames from c to c_last */
-static ScmContFrame *copy_cont_frames(ScmContFrame *c,
-                                      ScmContFrame *c_last)
+static ScmContFrame *copy_cont_frames(ScmContFrame *c, ScmContFrame *c_last)
 {
     ScmVM *vm = theVM;
 
@@ -1632,13 +1632,8 @@ static ScmContFrame *merge_cont_frames(ScmContFrame *c1, ScmContFrame *c2)
 {
     if (c1 == NULL) { return c2; }
     ScmContFrame *c_cur = c1;
-    while (1) {
-        if (c_cur->prev == NULL) {
-            c_cur->prev = c2;
-            break;
-        }
-        c_cur = c_cur->prev;
-    }
+    while (c_cur->prev) { c_cur = c_cur->prev; }
+    c_cur->prev = c2;
     return c1;
 }
 
@@ -3844,7 +3839,8 @@ int Scm_NonComposableContinuationP(ScmObj proc)
    in shift/reset controls (Gasbichler&Sperber, "Final Shift for Call/cc",
    ICFP02.)   Note that we treat the boundary frame as the bottom of
    partial continuation. */
-ScmObj vm_call_pc_with_tag_and_type(ScmObj proc, ScmObj promptTag, int contType)
+ScmObj vm_call_pc_with_tag_and_type(ScmObj proc, ScmObj promptTag,
+                                    int contType)
 {
     ScmVM *vm = theVM;
 
@@ -3896,16 +3892,22 @@ ScmObj vm_call_pc_with_tag_and_type(ScmObj proc, ScmObj promptTag, int contType)
            NB: We leave at least one informations each for exception handlers
                and parameters in denv.
         */
-        ScmObj ehandlers = Scm_VMFindDynamicEnv(denv_key_exception_handler, SCM_NIL);
-        ScmObj parameters = Scm_VMFindDynamicEnv(denv_key_parameterization, SCM_NIL);
+        ScmObj ehandlers = Scm_VMFindDynamicEnv(denv_key_exception_handler,
+                                                SCM_NIL);
+        ScmObj parameters = Scm_VMFindDynamicEnv(denv_key_parameterization,
+                                                 SCM_NIL);
         for (ScmContFrame *c = ep->partialCont; c; c = c->prev) {
             ScmObj h = SCM_NIL, t = SCM_NIL, p;
             SCM_FOR_EACH(p, c->denv) {
                 if (p == ep->denv) { break; }
                 SCM_APPEND1(h, t, SCM_CAR(p));
             }
-            ScmObj eh = find_dynamic_env_specified(h, denv_key_exception_handler, SCM_NIL);
-            ScmObj pr = find_dynamic_env_specified(h, denv_key_parameterization, SCM_NIL);
+            ScmObj eh =
+                find_dynamic_env_specified(h, denv_key_exception_handler,
+                                           SCM_NIL);
+            ScmObj pr =
+                find_dynamic_env_specified(h, denv_key_parameterization,
+                                           SCM_NIL);
             if (!SCM_PAIRP(eh) && SCM_PAIRP(ehandlers)) {
                 h = Scm_Acons(denv_key_exception_handler, ehandlers, h);
             }
@@ -3949,17 +3951,20 @@ ScmObj vm_call_pc_with_tag_and_type(ScmObj proc, ScmObj promptTag, int contType)
 
 ScmObj Scm_VMCallPC(ScmObj proc)
 {
-    return vm_call_pc_with_tag_and_type(proc, SCM_FALSE, CONT_TYPE_COMPOSABLE);
+    return vm_call_pc_with_tag_and_type(proc, SCM_FALSE,
+                                        CONT_TYPE_COMPOSABLE);
 }
 
 ScmObj Scm_VMCallWithComposableContinuation(ScmObj proc, ScmObj promptTag)
 {
-    return vm_call_pc_with_tag_and_type(proc, promptTag, CONT_TYPE_COMPOSABLE);
+    return vm_call_pc_with_tag_and_type(proc, promptTag,
+                                        CONT_TYPE_COMPOSABLE);
 }
 
 ScmObj Scm_VMCallWithNonComposableContinuation(ScmObj proc, ScmObj promptTag)
 {
-    return vm_call_pc_with_tag_and_type(proc, promptTag, CONT_TYPE_NON_COMPOSABLE);
+    return vm_call_pc_with_tag_and_type(proc, promptTag,
+                                        CONT_TYPE_NON_COMPOSABLE);
 }
 
 ScmObj Scm_VMCallInContinuation(ScmObj cont, ScmObj proc, ScmObj args)
@@ -4599,7 +4604,8 @@ void Scm_VMDump(ScmVM *vm_to_dump)
         }
     }
 
-    Scm_Printf(out, "partial-chain-length: %d\n", (int)Scm_Length(vm->partialChain));
+    Scm_Printf(out, "partial-chain-length: %d\n",
+               (int)Scm_Length(vm->partialChain));
 
     if (vm->base) {
         Scm_Printf(out, "Code:\n");

--- a/src/vm.c
+++ b/src/vm.c
@@ -3578,7 +3578,7 @@ static ScmObj throw_cont_body(ScmObj hdlist,      /*((flag . handler-chain)...)*
             ScmEscapePoint *ep2 = (ScmEscapePoint *)SCM_CDR(partialInfo);
 
             /* get prompt continuation */
-            /* (outer prompt continuation is ep2->cont->prev->prev) */
+            /* (outer of prompt continuation is ep2->cont->prev->prev) */
             SCM_ASSERT(ep2 && ep2->cont && ep2->cont->prev);
             ScmContFrame *cprompt = ep2->cont->prev->prev;
 
@@ -3586,7 +3586,7 @@ static ScmObj throw_cont_body(ScmObj hdlist,      /*((flag . handler-chain)...)*
             vm->cont = cprompt;
 
             /* set partial continuation information */
-            /* (cdr means outer prompt) */
+            /* (cdr means outer of prompt) */
             vm->partialChain = SCM_CDR(ep2->partialChain);
         }
 

--- a/src/vm.c
+++ b/src/vm.c
@@ -3593,7 +3593,7 @@ static ScmObj throw_cont_body(ScmObj hdlist,      /*((flag . handler-chain)...)*
     }
 
     /* for non-composable partial continuation */
-    if (ep->contType == CONT_TYPE_FULL && !SCM_FALSEP(ep->noCompHandler)) {
+    if (!SCM_FALSEP(ep->noCompHandler)) {
         void *data[1];
         data[0] = (void*)ep->noCompHandler;
         Scm_VMPushCC(vm_no_comp_cc, data, 1);
@@ -3706,16 +3706,27 @@ static ScmObj throw_continuation(ScmObj *argframe,
     /* calculate dynamic handlers to call */
     ScmObj hdlist = SCM_NIL;
     ScmObj currentHandlers = get_dynamic_handlers(vm);
-    if (ep->contType == CONT_TYPE_FULL) {
+    if (ep->contType == CONT_TYPE_FULL && SCM_FALSEP(ep->noCompHandler)) {
         /* for full continuation */
         hdlist = throw_cont_calculate_handlers(ep->dynamicHandlers,
                                                currentHandlers);
-    } else {
-        /* for partial continuation */
+    } else if (ep->contType == CONT_TYPE_COMPOSABLE) {
+        /* for composable partial continuation */
+        /* this avoids redundant calls of dynamic handlers. */
         hdlist =
             throw_cont_calculate_handlers(Scm_Append2(ep->partialHandlers,
                                                       currentHandlers),
                                           currentHandlers);
+    } else {
+        /* for non-composable partial continuation */
+        /* get escape point from continuation */
+        ScmEscapePoint *ep2 = (ScmEscapePoint*)((ScmSubr*)ep->noCompHandler)->data;
+        /* this avoids redundant calls of dynamic handlers. */
+        hdlist =
+            throw_cont_calculate_handlers(Scm_Append2(ep2->partialHandlers,
+                                                      ep->dynamicHandlers),
+                                          currentHandlers);
+        ep2->partialHandlers = SCM_NIL;
     }
 
     /* First, check to see if we need to rewind C stack.

--- a/src/vm.c
+++ b/src/vm.c
@@ -1582,6 +1582,13 @@ static ScmObj find_dynamic_env(ScmVM *vm, ScmObj key, ScmObj fallback)
     else return fallback;
 }
 
+static ScmObj find_dynamic_env_specified(ScmObj denv, ScmObj key, ScmObj fallback)
+{
+    ScmObj p = Scm_Assq(key, denv);
+    if (SCM_PAIRP(p)) return SCM_CDR(p);
+    else return fallback;
+}
+
 /* Public API */
 ScmObj Scm_VMFindDynamicEnv(ScmObj key, ScmObj fallback)
 {
@@ -1621,20 +1628,18 @@ static ScmContFrame *copy_cont_frames(ScmContFrame *c,
 }
 
 /* Merge cont frames */
-static ScmContFrame *merge_cont_frames(ScmContFrame *c,
-                                       ScmContFrame *c_add)
+static ScmContFrame *merge_cont_frames(ScmContFrame *c1, ScmContFrame *c2)
 {
-    if (c_add == NULL) { return c; }
-    ScmContFrame *c_add_2 = c_add;
+    if (c1 == NULL) { return c2; }
+    ScmContFrame *c_cur = c1;
     while (1) {
-        if (c_add_2->prev == NULL) {
-            /* merge cont frames */
-            c_add_2->prev = c;
+        if (c_cur->prev == NULL) {
+            c_cur->prev = c2;
             break;
         }
-        c_add_2 = c_add_2->prev;
+        c_cur = c_cur->prev;
     }
-    return c_add;
+    return c1;
 }
 
 
@@ -3219,6 +3224,8 @@ ScmObj Scm_VMCallWithContinuationPrompt(ScmObj thunk,
     return Scm_VMApply0(thunk);
 }
 
+/* not used now */
+#if 0
 static ScmContFrame *find_prompt_frame(ScmVM *vm, ScmObj promptTag)
 {
     if (!SCM_PROMPT_TAG(promptTag)) promptTag = SCM_OBJ(&defaultPromptTag);
@@ -3230,6 +3237,7 @@ static ScmContFrame *find_prompt_frame(ScmVM *vm, ScmObj promptTag)
     }
     return NULL;
 }
+#endif
 
 /* find partial continuation informatin of nearest prompt.
    outerMost returns if the found information is on the outer most.
@@ -3237,13 +3245,13 @@ static ScmContFrame *find_prompt_frame(ScmVM *vm, ScmObj promptTag)
 static ScmObj find_partial_information(ScmVM *vm, ScmObj promptTag,
                                        int *outerMost)
 {
-    ScmObj p1;
-    SCM_FOR_EACH(p1, vm->partialChain) {
-        if (SCM_CAR(SCM_CAR(p1)) == promptTag) {
+    ScmObj p;
+    SCM_FOR_EACH(p, vm->partialChain) {
+        if (SCM_CAAR(p) == promptTag) {
             if (outerMost) {
-                *outerMost = !SCM_PAIRP(SCM_CDR(p1));
+                *outerMost = !SCM_PAIRP(SCM_CDR(p));
             }
-            return SCM_CAR(p1);
+            return SCM_CAR(p);
         }
     }
     if (outerMost) {
@@ -3259,7 +3267,7 @@ ScmObj Scm_VMAbortCurrentContinuation(ScmObj promptTag, ScmObj args)
 {
     ScmVM *vm = theVM;
 
-    if (!(SCM_PROMPT_TAG_P(promptTag) || SCM_FALSEP(promptTag))) {
+    if (!SCM_PROMPT_TAG_P(promptTag)) {
         SCM_TYPE_ERROR(promptTag, "prompt tag");
     }
 
@@ -3339,8 +3347,10 @@ static ScmObj make_continuation_mark_set(ScmVM *vm,
 {
     if (!SCM_PROMPT_TAG_P(promptTag)) promptTag = SCM_OBJ(&defaultPromptTag);
 
-    ScmContFrame *bottom = find_prompt_frame(vm, promptTag);
-    if (bottom == NULL) {
+    /* find partial continuation information of nearest prompt */
+    ScmObj partialInfo = find_partial_information(vm, promptTag, NULL);
+    /* (workaround for default prompt missing error) */
+    if (!SCM_PAIRP(partialInfo) && promptTag != SCM_OBJ(&defaultPromptTag)) {
         Scm_RaiseCondition(SCM_OBJ(SCM_CLASS_CONTINUATION_ERROR),
                            "prompt-tag", promptTag,
                            SCM_RAISE_CONDITION_MESSAGE,
@@ -3348,11 +3358,19 @@ static ScmObj make_continuation_mark_set(ScmVM *vm,
                            promptTag);
     }
 
+    /* get escape point on prompt */
+    ScmEscapePoint *ep =
+        (SCM_PAIRP(partialInfo)?
+         (ScmEscapePoint *)SCM_CDR(partialInfo) : NULL);
+
+    /* get prompt continuation */
+    ScmContFrame *bottom = ep ? ep->cont : NULL;
+
     ScmContinuationMarkSet *cm = SCM_NEW(ScmContinuationMarkSet);
     SCM_SET_CLASS(cm, SCM_CLASS_CONTINUATION_MARK_SET);
     cm->cont = cont;
     cm->denv = denv;
-    cm->bottomDenv = bottom->denv;
+    cm->bottomDenv = bottom ? bottom->denv : SCM_NIL;
     return SCM_OBJ(cm);
 }
 
@@ -3575,7 +3593,13 @@ static ScmObj throw_cont_body(ScmObj hdlist,      /*((flag . handler-chain)...)*
         */
         save_cont(vm);
         ScmContFrame *epcont_copy = copy_cont_frames(ep->partialCont, NULL);
-        vm->cont = merge_cont_frames(vm->cont, epcont_copy);
+        {
+            /* we also merge partial denv */
+            for (ScmContFrame *c = epcont_copy; c; c = c->prev) {
+                c->denv = Scm_Append2(c->denv, vm->cont->denv);
+            }
+        }
+        vm->cont = merge_cont_frames(epcont_copy, vm->cont);
     }
     vm->denv = ep->denv;
 
@@ -3857,16 +3881,50 @@ ScmObj vm_call_pc_with_tag_and_type(ScmObj proc, ScmObj promptTag, int contType)
        handling. */
     ScmEscapePoint *ep = new_ep(vm, SCM_FALSE, FALSE, contType,
                                 promptTag, SCM_FALSE);
+    ep->cont = NULL;               /* don't use for partial continuation */
+    ep->denv = cprompt ? cprompt->denv : SCM_NIL;
+    ep->dynamicHandlers = SCM_NIL; /* don't use for partial continuation */
+
     /* Save partial cont frames instead of full cont frames (vm->cont).
        This is important to avoid memory leak of partial continuation.
        See:
        https://okmij.org/ftp/continuations/against-callcc.html#memory-leak
     */
     ep->partialCont = copy_cont_frames(vm->cont, cprompt);
-    ep->cont = NULL;               /* don't use for partial continuation */
-    ep->denv = cprompt ? cprompt->denv : SCM_NIL;
-    ep->dynamicHandlers = SCM_NIL; /* don't use for partial continuation */
-    ep->partialChain = SCM_NIL;    /* don't use for partial continuation */
+    {
+        /* We also cut denv from current to prompt.
+           NB: We leave at least one informations each for exception handlers
+               and parameters in denv.
+        */
+        ScmObj ehandlers = Scm_VMFindDynamicEnv(denv_key_exception_handler, SCM_NIL);
+        ScmObj parameters = Scm_VMFindDynamicEnv(denv_key_parameterization, SCM_NIL);
+        for (ScmContFrame *c = ep->partialCont; c; c = c->prev) {
+            ScmObj h = SCM_NIL, t = SCM_NIL, p;
+            SCM_FOR_EACH(p, c->denv) {
+                if (p == ep->denv) { break; }
+                SCM_APPEND1(h, t, SCM_CAR(p));
+            }
+            ScmObj eh = find_dynamic_env_specified(h, denv_key_exception_handler, SCM_NIL);
+            ScmObj pr = find_dynamic_env_specified(h, denv_key_parameterization, SCM_NIL);
+            if (!SCM_PAIRP(eh) && SCM_PAIRP(ehandlers)) {
+                h = Scm_Acons(denv_key_exception_handler, ehandlers, h);
+            }
+            if (!SCM_PAIRP(pr) && SCM_PAIRP(parameters)) {
+                h = Scm_Acons(denv_key_parameterization, parameters, h);
+            }
+            c->denv = h;
+        }
+    }
+
+    /* Cut partial continuation information from current to prompt */
+    {
+        ScmObj h = SCM_NIL, t = SCM_NIL, p;
+        SCM_FOR_EACH(p, vm->partialChain) {
+            if (p == ep->partialChain) { break; }
+            SCM_APPEND1(h, t, SCM_CAR(p));
+        }
+        ep->partialChain = h;
+    }
 
     /* get dynamic handlers chain on prompt */
     ScmObj targetHandlers = ep2->dynamicHandlers;
@@ -3874,12 +3932,14 @@ ScmObj vm_call_pc_with_tag_and_type(ScmObj proc, ScmObj promptTag, int contType)
     /* Cut dynamic handlers chain from current to prompt.
        This is important to avoid redundant calls of dynamic handlers.
     */
-    ScmObj h = SCM_NIL, t = SCM_NIL, p;
-    SCM_FOR_EACH(p, get_dynamic_handlers(vm)) {
-        if (p == targetHandlers) { break; }
-        SCM_APPEND1(h, t, SCM_CAR(p));
+    {
+        ScmObj h = SCM_NIL, t = SCM_NIL, p;
+        SCM_FOR_EACH(p, get_dynamic_handlers(vm)) {
+            if (p == targetHandlers) { break; }
+            SCM_APPEND1(h, t, SCM_CAR(p));
+        }
+        ep->partialHandlers = h;
     }
-    ep->partialHandlers = h;
 
     ScmObj contproc = Scm_MakeSubr(throw_continuation, ep, 0, 1,
                                    continuation_symbol);
@@ -3905,7 +3965,7 @@ ScmObj Scm_VMCallWithNonComposableContinuation(ScmObj proc, ScmObj promptTag)
 ScmObj Scm_VMCallInContinuation(ScmObj cont, ScmObj proc, ScmObj args)
 {
     if (!Scm_ContinuationP(cont)) {
-        Scm_Error("cont must be a continuation, but got: %S", cont);
+        SCM_TYPE_ERROR(cont, "continuation");
     }
 
     /* get escape point from continuation */
@@ -3918,6 +3978,34 @@ ScmObj Scm_VMCallInContinuation(ScmObj cont, ScmObj proc, ScmObj args)
     ScmObj contproc = Scm_MakeSubr(throw_continuation, ep2, 0, 1,
                                    continuation_symbol);
     return Scm_VMApply(contproc, SCM_NIL);
+}
+
+int Scm_ContinuationPromptAvailableP(ScmObj promptTag, ScmObj cont)
+{
+    if (!SCM_PROMPT_TAG_P(promptTag)) {
+        SCM_TYPE_ERROR(promptTag, "prompt tag");
+    }
+    if (!Scm_ContinuationP(cont)) {
+        SCM_TYPE_ERROR(cont, "continuation");
+    }
+
+    /* get escape point from continuation */
+    ScmEscapePoint *ep = (ScmEscapePoint*)((ScmSubr*)cont)->data;
+
+    /* for non-composable partial continuation */
+    if (ep->contTypeReq == CONT_TYPE_NON_COMPOSABLE &&
+        ep->promptTag == promptTag) {
+        return TRUE;
+    }
+
+    /* search partial continuation information */
+    ScmObj p;
+    SCM_FOR_EACH(p, ep->partialChain) {
+        if (SCM_CAAR(p) == promptTag) {
+            return TRUE;
+        }
+    }
+    return FALSE;
 }
 
 ScmObj Scm_VMReset(ScmObj proc)

--- a/src/vm.c
+++ b/src/vm.c
@@ -2016,6 +2016,28 @@ static ScmEscapePoint *new_ep(ScmVM *vm,
     return ep;
 }
 
+static ScmEscapePoint *copy_ep(ScmEscapePoint *ep)
+{
+    ScmEscapePoint *ep2 = SCM_NEW(ScmEscapePoint);
+    SCM_SET_CLASS(ep2, SCM_CLASS_ESCAPE_POINT);
+    ep2->ehandler = ep->ehandler;
+    ep2->cont = ep->cont;
+    ep2->denv = ep->denv;
+    ep2->dynamicHandlers = ep->dynamicHandlers;
+    ep2->cstack = ep->cstack;
+    ep2->xhandler = ep->xhandler;
+    ep2->partialChain = ep->partialChain;
+    ep2->partialHandlers = ep->partialHandlers;
+    ep2->errorReporting = ep->errorReporting;
+    ep2->rewindBefore = ep->rewindBefore;
+    ep2->contType = ep->contType;
+    ep2->promptTag = ep->promptTag;
+    ep2->abortHandler = ep->abortHandler;
+    ep2->abortArgs = ep->abortArgs;
+    ep2->bottom = ep->bottom;
+    return ep2;
+}
+
 /*-------------------------------------------------------------
  * User level eval and apply.
  *   When the C routine wants the Scheme code to return to it,
@@ -3255,7 +3277,9 @@ ScmObj Scm_VMAbortCurrentContinuation(ScmObj promptTag, ScmObj args)
     }
 
     /* get abort continuation */
-    ScmContFrame *abortTo = ep->cont;
+    /* (outer prompt continuation is ep->cont->prev->prev) */
+    SCM_ASSERT(ep && ep->cont && ep->cont->prev);
+    ScmContFrame *abortTo = ep->cont->prev->prev;
 
     /* Discard continuation, and reinstate abortTo frame and its
        dynamic environment. */
@@ -3263,9 +3287,13 @@ ScmObj Scm_VMAbortCurrentContinuation(ScmObj promptTag, ScmObj args)
     DENV = abortTo->denv;
 
     /* call continuation procedure to abort */
-    ep->abortHandler = abortHandler;
-    ep->abortArgs = abortArgs;
-    ScmObj contproc = Scm_MakeSubr(throw_continuation, ep, 0, 1,
+    ScmEscapePoint *ep2 = copy_ep(ep);
+    ep2->cont = abortTo;
+    /* (cdr means outer prompt) */
+    ep2->partialChain = SCM_CDR(ep->partialChain);
+    ep2->abortHandler = abortHandler;
+    ep2->abortArgs = abortArgs;
+    ScmObj contproc = Scm_MakeSubr(throw_continuation, ep2, 0, 1,
                                    continuation_symbol);
     return Scm_VMApply(contproc, SCM_NIL);
 }
@@ -3509,33 +3537,38 @@ static ScmObj throw_cont_body(ScmObj hdlist,      /*((flag . handler-chain)...)*
     } else {
         /* for partial continuation */
 
-        /* find partial continuation information of nearest prompt */
-        ScmObj partialInfo = find_partial_information(vm, ep->promptTag);
-        if (!SCM_PAIRP(partialInfo)) {
-            Scm_RaiseCondition(SCM_OBJ(SCM_CLASS_CONTINUATION_ERROR),
-                               "prompt-tag", ep->promptTag,
-                               SCM_RAISE_CONDITION_MESSAGE,
-                               "Prompt tag (%S) not found (E1)",
-                               ep->promptTag);
-        }
-
-        /* get escape point on prompt */
-        ScmEscapePoint *ep2 = (ScmEscapePoint *)SCM_CDR(partialInfo);
-
         /* for non-composable partial continuation */
         /* we drop continuation from current to prompt before merge. */
         if (ep->contType == CONT_TYPE_NON_COMPOSABLE) {
+            /* find partial continuation information of nearest prompt */
+            ScmObj partialInfo = find_partial_information(vm, ep->promptTag);
+            if (!SCM_PAIRP(partialInfo)) {
+                Scm_RaiseCondition(SCM_OBJ(SCM_CLASS_CONTINUATION_ERROR),
+                                   "prompt-tag", ep->promptTag,
+                                   SCM_RAISE_CONDITION_MESSAGE,
+                                   "Prompt tag (%S) not found (E1)",
+                                   ep->promptTag);
+            }
+
+            /* get escape point on prompt */
+            ScmEscapePoint *ep2 = (ScmEscapePoint *)SCM_CDR(partialInfo);
+
             /* get prompt continuation */
-            ScmContFrame *cprompt = ep2->cont;
+            /* (outer prompt continuation is ep2->cont->prev->prev) */
+            SCM_ASSERT(ep2 && ep2->cont && ep2->cont->prev);
+            ScmContFrame *cprompt = ep2->cont->prev->prev;
+
             /* drop continuation from current to prompt */
             vm->cont = cprompt;
+
             /* set partial continuation information */
-            vm->partialChain = ep2->partialChain;
+            /* (cdr means outer prompt) */
+            vm->partialChain = SCM_CDR(ep2->partialChain);
         }
 
         /* push partial end continuation */
         void *data[1];
-        data[0] = (void*)ep2->partialChain;
+        data[0] = (void*)vm->partialChain;
         Scm_VMPushCC(vm_partial_end_cc, data, 1);
 
         /* we merge current continuation and partial continuation.
@@ -3653,10 +3686,15 @@ static ScmObj throw_continuation(ScmObj *argframe,
                                "Prompt tag (%S) not found (E2)",
                                ep->promptTag);
         }
+
         /* get escape point on prompt */
         ScmEscapePoint *ep2 = (ScmEscapePoint *)SCM_CDR(partialInfo);
+
         /* get prompt continuation */
-        ScmContFrame *cprompt = ep2->cont;
+        /* (outer prompt continuation is ep2->cont->prev->prev) */
+        SCM_ASSERT(ep2 && ep2->cont && ep2->cont->prev);
+        ScmContFrame *cprompt = ep2->cont->prev->prev;
+
         /* move ep->cstack to prompt location */
         ScmCStack *cs;
         for (cs = vm->cstack; cs; cs = cs->prev) {

--- a/src/vm.c
+++ b/src/vm.c
@@ -1194,7 +1194,7 @@ static inline ScmEnvFrame *save_env(ScmVM *vm, ScmEnvFrame *env_begin)
     return head;
 }
 
-static ScmContFrame *copy_ccont_1(ScmVM *vm, ScmContFrame *c,
+static ScmContFrame *copy_cont_1(ScmVM *vm, ScmContFrame *c,
                                   int promptDataCopy)
 {
     int size = (CONT_FRAME_SIZE + c->size) * sizeof(ScmObj);
@@ -1249,8 +1249,8 @@ static void save_cont_1(ScmVM *vm, ScmContFrame *c)
 
     /* First pass */
     do {
-        /* copy ccont frame c */
-        ScmContFrame *csave = copy_ccont_1(vm, c, TRUE);
+        /* copy cont frame c */
+        ScmContFrame *csave = copy_cont_1(vm, c, TRUE);
 
         /* make the orig frame forwarded */
         if (prev) prev->prev = csave;
@@ -1588,6 +1588,56 @@ ScmObj Scm_VMFindDynamicEnv(ScmObj key, ScmObj fallback)
     return find_dynamic_env(theVM, key, fallback);
 }
 
+/* Copy cont frames from c to c_last */
+static ScmContFrame *copy_cont_frames(ScmContFrame *c,
+                                      ScmContFrame *c_last)
+{
+    ScmVM *vm = theVM;
+
+    if (c == NULL) { return NULL; }
+
+    /* copy cont frame c */
+    ScmContFrame *cc = copy_cont_1(vm, c, FALSE);
+    if (c == c_last) {
+        /* cut on c_last */
+        cc->prev = NULL;
+        return cc;
+    }
+
+    /* copy cont frames until c_last */
+    ScmContFrame *cc_old = cc;
+    while (1) {
+        c = c->prev;
+        if (c == NULL) { break; }
+        ScmContFrame *cc2 = copy_cont_1(vm, c, FALSE);
+        cc_old->prev = cc2;
+        if (c == c_last) {
+            /* cut on c_last */
+            cc2->prev = NULL;
+            break;
+        }
+        cc_old = cc2;
+    }
+    return cc;
+}
+
+/* Merge cont frames */
+static ScmContFrame *merge_cont_frames(ScmContFrame *c,
+                                       ScmContFrame *c_add)
+{
+    if (c_add == NULL) { return c; }
+    ScmContFrame *c_add_2 = c_add;
+    while (1) {
+        if (c_add_2->prev == NULL) {
+            /* merge cont frames */
+            c_add_2->prev = c;
+            break;
+        }
+        c_add_2 = c_add_2->prev;
+    }
+    return c_add;
+}
+
 
 /*==================================================================
  * Function application from C
@@ -1864,56 +1914,6 @@ static ScmObj *new_ccont(ScmVM *vm, ScmPContinuationProc *after,
     CONT = cc;
     ARGP = SP = s + datasize + CONT_FRAME_SIZE;
     return s;
-}
-
-/* Copy ccont frames from c to c_last */
-static ScmContFrame *copy_ccont_frames(ScmContFrame *c,
-                                       ScmContFrame *c_last)
-{
-    ScmVM *vm = theVM;
-
-    if (c == NULL) { return NULL; }
-
-    /* copy ccont frame c */
-    ScmContFrame *cc = copy_ccont_1(vm, c, FALSE);
-    if (c == c_last) {
-        /* cut on c_last */
-        cc->prev = NULL;
-        return cc;
-    }
-
-    /* copy ccont frames until c_last */
-    ScmContFrame *cc_old = cc;
-    while (1) {
-        c = c->prev;
-        if (c == NULL) { break; }
-        ScmContFrame *cc2 = copy_ccont_1(vm, c, FALSE);
-        cc_old->prev = cc2;
-        if (c == c_last) {
-            /* cut on c_last */
-            cc2->prev = NULL;
-            break;
-        }
-        cc_old = cc2;
-    }
-    return cc;
-}
-
-/* Merge ccont frames */
-static ScmContFrame *merge_ccont_frames(ScmContFrame *c,
-                                        ScmContFrame *c_add)
-{
-    if (c_add == NULL) { return c; }
-    ScmContFrame *c_add_2 = c_add;
-    while (1) {
-        if (c_add_2->prev == NULL) {
-            /* merge ccont frames */
-            c_add_2->prev = c;
-            break;
-        }
-        c_add_2 = c_add_2->prev;
-    }
-    return c_add;
 }
 
 /* This is a trick to keep the backward compatibility. */
@@ -3294,7 +3294,7 @@ ScmObj Scm_VMAbortCurrentContinuation(ScmObj promptTag, ScmObj args)
         /* (workaround for abort to toplevel error) */
         abortTo = ep->cont;
     } else {
-        /* (outer prompt continuation is ep->cont->prev->prev) */
+        /* (outer of prompt continuation is ep->cont->prev->prev) */
         SCM_ASSERT(ep && ep->cont && ep->cont->prev);
         abortTo = ep->cont->prev->prev;
     }
@@ -3311,7 +3311,7 @@ ScmObj Scm_VMAbortCurrentContinuation(ScmObj promptTag, ScmObj args)
         /* (workaround for abort to toplevel error) */
         ep2->partialChain = ep->partialChain;
     } else {
-        /* (cdr means outer prompt) */
+        /* (cdr means outer of prompt) */
         ep2->partialChain = SCM_CDR(ep->partialChain);
     }
     ep2->abortHandler = abortHandler;
@@ -3596,12 +3596,12 @@ static ScmObj throw_cont_body(ScmObj hdlist,      /*((flag . handler-chain)...)*
         Scm_VMPushCC(vm_partial_end_cc, data, 1);
 
         /* we merge current continuation and partial continuation.
-           NB: save_cont() and copy_ccont_frames() are necessary to avoid
+           NB: save_cont() and copy_cont_frames() are necessary to avoid
                problems of continuation sharing.
         */
         save_cont(vm);
-        ScmContFrame *epcont_copy = copy_ccont_frames(ep->cont, NULL);
-        vm->cont = merge_ccont_frames(vm->cont, epcont_copy);
+        ScmContFrame *epcont_copy = copy_cont_frames(ep->cont, NULL);
+        vm->cont = merge_cont_frames(vm->cont, epcont_copy);
     }
     vm->denv = ep->denv;
 
@@ -3700,6 +3700,7 @@ static ScmObj throw_continuation(ScmObj *argframe,
     /* we must rewind cstack from current to prompt to avoid memory leak.
        so we move ep->cstack before rewinding cstack.
     */
+    ScmCStack *epcstack = ep->cstack;
     if (ep->contType == CONT_TYPE_NON_COMPOSABLE) {
         /* find partial continuation information of nearest prompt */
         ScmObj partialInfo = find_partial_information(vm, ep->promptTag,
@@ -3715,28 +3716,17 @@ static ScmObj throw_continuation(ScmObj *argframe,
         /* get escape point on prompt */
         ScmEscapePoint *ep2 = (ScmEscapePoint *)SCM_CDR(partialInfo);
 
-        /* get prompt continuation */
-        /* (outer prompt continuation is ep2->cont->prev->prev) */
-        SCM_ASSERT(ep2 && ep2->cont && ep2->cont->prev);
-        ScmContFrame *cprompt = ep2->cont->prev->prev;
-
         /* move ep->cstack to prompt location */
-        ScmCStack *cs;
-        for (cs = vm->cstack; cs; cs = cs->prev) {
-            if (cs->cont == cprompt) {
-                ep->cstack = cs;
-                break;
-            }
-        }
+        epcstack = ep2->cstack;
     }
 
     /* First, check to see if we need to rewind C stack.
        NB: If we are invoking a composable partial continuation,
        we execute it on the current cstack. */
-    if (ep->contType != CONT_TYPE_COMPOSABLE && vm->cstack != ep->cstack) {
+    if (ep->contType != CONT_TYPE_COMPOSABLE && vm->cstack != epcstack) {
         ScmCStack *cs;
         for (cs = vm->cstack; cs; cs = cs->prev) {
-            if (ep->cstack == cs) break;
+            if (epcstack == cs) break;
         }
 
         /* If the continuation captured below the current C stack, we rewind
@@ -3857,12 +3847,12 @@ ScmObj vm_call_pc_with_tag_and_type(ScmObj proc, ScmObj promptTag, int contType)
        handling. */
     ScmEscapePoint *ep = new_ep(vm, SCM_FALSE, FALSE, contType,
                                 promptTag, SCM_FALSE);
-    /* Set delimited ccont frames instead of full ccont frames (vm->cont).
+    /* Set delimited cont frames instead of full cont frames (vm->cont).
        This is important to avoid memory leak of partial continuation.
        See:
        https://okmij.org/ftp/continuations/against-callcc.html#memory-leak
     */
-    ep->cont = copy_ccont_frames(vm->cont, cprompt);
+    ep->cont = copy_cont_frames(vm->cont, cprompt);
     ep->denv = cprompt ? cprompt->denv : SCM_NIL;
     ep->dynamicHandlers = SCM_NIL; /* don't use for partial continuation */
     ep->partialChain = SCM_NIL;    /* don't use for partial continuation */

--- a/src/vm.c
+++ b/src/vm.c
@@ -3226,14 +3226,23 @@ static ScmContFrame *find_prompt_frame(ScmVM *vm, ScmObj promptTag)
     return NULL;
 }
 
-/* find partial continuation informatin of nearest prompt */
-static ScmObj find_partial_information(ScmVM *vm, ScmObj promptTag)
+/* find partial continuation informatin of nearest prompt.
+   outerMost returns if the found information is on the outer most.
+   if you don't need outerMost, set it to NULL. */
+static ScmObj find_partial_information(ScmVM *vm, ScmObj promptTag,
+                                       int *outerMost)
 {
     ScmObj p1;
     SCM_FOR_EACH(p1, vm->partialChain) {
         if (SCM_CAR(SCM_CAR(p1)) == promptTag) {
+            if (outerMost) {
+                *outerMost = !SCM_PAIRP(SCM_CDR(p1));
+            }
             return SCM_CAR(p1);
         }
+    }
+    if (outerMost) {
+        *outerMost = 0;
     }
     return SCM_NIL;
 }
@@ -3250,7 +3259,8 @@ ScmObj Scm_VMAbortCurrentContinuation(ScmObj promptTag, ScmObj args)
     }
 
     /* find partial continuation information of nearest prompt */
-    ScmObj partialInfo = find_partial_information(vm, promptTag);
+    int outerMost;
+    ScmObj partialInfo = find_partial_information(vm, promptTag, &outerMost);
     if (!SCM_PAIRP(partialInfo)) {
         Scm_RaiseCondition(SCM_OBJ(SCM_CLASS_CONTINUATION_ERROR),
                            "prompt-tag", promptTag,
@@ -3277,9 +3287,15 @@ ScmObj Scm_VMAbortCurrentContinuation(ScmObj promptTag, ScmObj args)
     }
 
     /* get abort continuation */
-    /* (outer prompt continuation is ep->cont->prev->prev) */
-    SCM_ASSERT(ep && ep->cont && ep->cont->prev);
-    ScmContFrame *abortTo = ep->cont->prev->prev;
+    ScmContFrame *abortTo;
+    if (outerMost) {
+        /* (workaround for abort to toplevel error) */
+        abortTo = ep->cont;
+    } else {
+        /* (outer prompt continuation is ep->cont->prev->prev) */
+        SCM_ASSERT(ep && ep->cont && ep->cont->prev);
+        abortTo = ep->cont->prev->prev;
+    }
 
     /* Discard continuation, and reinstate abortTo frame and its
        dynamic environment. */
@@ -3289,8 +3305,13 @@ ScmObj Scm_VMAbortCurrentContinuation(ScmObj promptTag, ScmObj args)
     /* call continuation procedure to abort */
     ScmEscapePoint *ep2 = copy_ep(ep);
     ep2->cont = abortTo;
-    /* (cdr means outer prompt) */
-    ep2->partialChain = SCM_CDR(ep->partialChain);
+    if (outerMost) {
+        /* (workaround for abort to toplevel error) */
+        ep2->partialChain = ep->partialChain;
+    } else {
+        /* (cdr means outer prompt) */
+        ep2->partialChain = SCM_CDR(ep->partialChain);
+    }
     ep2->abortHandler = abortHandler;
     ep2->abortArgs = abortArgs;
     ScmObj contproc = Scm_MakeSubr(throw_continuation, ep2, 0, 1,
@@ -3541,7 +3562,8 @@ static ScmObj throw_cont_body(ScmObj hdlist,      /*((flag . handler-chain)...)*
         /* we drop continuation from current to prompt before merge. */
         if (ep->contType == CONT_TYPE_NON_COMPOSABLE) {
             /* find partial continuation information of nearest prompt */
-            ScmObj partialInfo = find_partial_information(vm, ep->promptTag);
+            ScmObj partialInfo = find_partial_information(vm, ep->promptTag,
+                                                          NULL);
             if (!SCM_PAIRP(partialInfo)) {
                 Scm_RaiseCondition(SCM_OBJ(SCM_CLASS_CONTINUATION_ERROR),
                                    "prompt-tag", ep->promptTag,
@@ -3678,7 +3700,8 @@ static ScmObj throw_continuation(ScmObj *argframe,
     */
     if (ep->contType == CONT_TYPE_NON_COMPOSABLE) {
         /* find partial continuation information of nearest prompt */
-        ScmObj partialInfo = find_partial_information(vm, ep->promptTag);
+        ScmObj partialInfo = find_partial_information(vm, ep->promptTag,
+                                                      NULL);
         if (!SCM_PAIRP(partialInfo)) {
             Scm_RaiseCondition(SCM_OBJ(SCM_CLASS_CONTINUATION_ERROR),
                                "prompt-tag", ep->promptTag,
@@ -3785,8 +3808,8 @@ ScmObj vm_call_pc_with_tag_and_type(ScmObj proc, ScmObj promptTag, int contType)
     }
 
     /* find partial continuation information of nearest prompt */
-    ScmObj partialInfo = find_partial_information(vm, promptTag);
-    /* workaround for toplevel call/cc error */
+    ScmObj partialInfo = find_partial_information(vm, promptTag, NULL);
+    /* (workaround for toplevel call/cc error) */
     if (contType == CONT_TYPE_NON_COMPOSABLE && !SCM_PAIRP(partialInfo)) {
         return Scm_VMCallCCWithTag(proc, promptTag);
     }

--- a/src/vm.c
+++ b/src/vm.c
@@ -3748,6 +3748,10 @@ ScmObj vm_call_pc_with_tag_and_type(ScmObj proc, ScmObj promptTag, int contType)
 
     /* find partial continuation information of nearest prompt */
     ScmObj partialInfo = find_partial_information(vm, promptTag);
+    /* workaround for toplevel call/cc error */
+    if (contType == CONT_TYPE_NON_COMPOSABLE && !SCM_PAIRP(partialInfo)) {
+        return Scm_VMCallCCWithTag(proc, promptTag);
+    }
     if (!SCM_PAIRP(partialInfo)) {
         Scm_RaiseCondition(SCM_OBJ(SCM_CLASS_CONTINUATION_ERROR),
                            "prompt-tag", promptTag,

--- a/src/vm.c
+++ b/src/vm.c
@@ -1250,7 +1250,7 @@ static void save_cont_1(ScmVM *vm, ScmContFrame *c)
     /* First pass */
     do {
         /* copy ccont frame c */
-        ScmContFrame *csave = copy_ccont_1(vm, c, 1);
+        ScmContFrame *csave = copy_ccont_1(vm, c, TRUE);
 
         /* make the orig frame forwarded */
         if (prev) prev->prev = csave;
@@ -1875,7 +1875,7 @@ static ScmContFrame *copy_ccont_frames(ScmContFrame *c,
     if (c == NULL) { return NULL; }
 
     /* copy ccont frame c */
-    ScmContFrame *cc = copy_ccont_1(vm, c, 0);
+    ScmContFrame *cc = copy_ccont_1(vm, c, FALSE);
     if (c == c_last) {
         /* cut on c_last */
         cc->prev = NULL;
@@ -1887,7 +1887,7 @@ static ScmContFrame *copy_ccont_frames(ScmContFrame *c,
     while (1) {
         c = c->prev;
         if (c == NULL) { break; }
-        ScmContFrame *cc2 = copy_ccont_1(vm, c, 0);
+        ScmContFrame *cc2 = copy_ccont_1(vm, c, FALSE);
         cc_old->prev = cc2;
         if (c == c_last) {
             /* cut on c_last */
@@ -2009,6 +2009,7 @@ static ScmEscapePoint *new_ep(ScmVM *vm,
         SCM_VM_RUNTIME_FLAG_IS_SET(vm, SCM_ERROR_BEING_REPORTED);
     ep->rewindBefore = rewindBefore;
     ep->contType = contType;
+    ep->contTypeReq = contType;
     ep->promptTag = promptTag;
     ep->abortHandler = abortHandler;
     ep->abortArgs = SCM_NIL;
@@ -2031,6 +2032,7 @@ static ScmEscapePoint *copy_ep(ScmEscapePoint *ep)
     ep2->errorReporting = ep->errorReporting;
     ep2->rewindBefore = ep->rewindBefore;
     ep2->contType = ep->contType;
+    ep2->contTypeReq = ep->contTypeReq;
     ep2->promptTag = ep->promptTag;
     ep2->abortHandler = ep->abortHandler;
     ep2->abortArgs = ep->abortArgs;
@@ -3766,7 +3768,8 @@ static ScmObj throw_continuation(ScmObj *argframe,
     return throw_cont_body(hdlist, ep, args);
 }
 
-ScmObj Scm_VMCallCCWithTag(ScmObj proc, ScmObj promptTag)
+ScmObj vm_call_cc_with_tag_and_type(ScmObj proc, ScmObj promptTag,
+                                    int contTypeReq)
 {
     ScmVM *vm = theVM;
 
@@ -3778,6 +3781,10 @@ ScmObj Scm_VMCallCCWithTag(ScmObj proc, ScmObj promptTag)
 
     ScmEscapePoint *ep = new_ep(vm, SCM_FALSE, FALSE, CONT_TYPE_FULL,
                                 promptTag, SCM_FALSE);
+
+    /* (ep->contTypeReq is used for 'non-composable-continuation?') */
+    ep->contTypeReq = contTypeReq;
+
     ScmObj contproc = Scm_MakeSubr(throw_continuation, ep, 0, 1,
                                    continuation_symbol);
     return Scm_VMApply1(proc, contproc);
@@ -3785,12 +3792,28 @@ ScmObj Scm_VMCallCCWithTag(ScmObj proc, ScmObj promptTag)
 
 ScmObj Scm_VMCallCC(ScmObj proc)
 {
-    return Scm_VMCallCCWithTag(proc, SCM_FALSE);
+    return vm_call_cc_with_tag_and_type(proc, SCM_FALSE, CONT_TYPE_FULL);
+}
+
+ScmObj Scm_VMCallCCWithTag(ScmObj proc, ScmObj promptTag)
+{
+    return vm_call_cc_with_tag_and_type(proc, promptTag, CONT_TYPE_FULL);
 }
 
 int Scm_ContinuationP(ScmObj proc)
 {
     return (SCM_SUBRP(proc) && SCM_PROCEDURE_INFO(proc) == continuation_symbol);
+}
+
+int Scm_NonComposableContinuationP(ScmObj proc)
+{
+    if (SCM_SUBRP(proc) && SCM_PROCEDURE_INFO(proc) == continuation_symbol) {
+        ScmEscapePoint *ep = (ScmEscapePoint*)((ScmSubr*)proc)->data;
+
+        /* (ep->contTypeReq is used instead of ep->contType) */
+        return (ep->contTypeReq != CONT_TYPE_COMPOSABLE);
+    }
+    return FALSE;
 }
 
 /* call with partial continuation.  this corresponds to the 'shift' operator
@@ -3809,10 +3832,11 @@ ScmObj vm_call_pc_with_tag_and_type(ScmObj proc, ScmObj promptTag, int contType)
 
     /* find partial continuation information of nearest prompt */
     ScmObj partialInfo = find_partial_information(vm, promptTag, NULL);
-    /* (workaround for toplevel call/cc error) */
-    if (contType == CONT_TYPE_NON_COMPOSABLE && !SCM_PAIRP(partialInfo)) {
-        return Scm_VMCallCCWithTag(proc, promptTag);
+    /* (workaround for toplevel call/cc (and call/pc) error) */
+    if (!SCM_PAIRP(partialInfo)) {
+        return vm_call_cc_with_tag_and_type(proc, promptTag, contType);
     }
+#if 0
     if (!SCM_PAIRP(partialInfo)) {
         Scm_RaiseCondition(SCM_OBJ(SCM_CLASS_CONTINUATION_ERROR),
                            "prompt-tag", promptTag,
@@ -3820,6 +3844,7 @@ ScmObj vm_call_pc_with_tag_and_type(ScmObj proc, ScmObj promptTag, int contType)
                            "Prompt tag (%S) not found (E3)",
                            promptTag);
     }
+#endif
 
     /* get escape point on prompt */
     ScmEscapePoint *ep2 = (ScmEscapePoint *)SCM_CDR(partialInfo);

--- a/src/vm.c
+++ b/src/vm.c
@@ -88,18 +88,18 @@ struct ScmContinuationPromptRec {
 
 /* bitflags for ScmContFrame->marker */
 enum {
-      SCM_CONT_SHIFT_MARKER = (1L<<0),
-      SCM_CONT_RESET_MARKER = (1L<<1)
+    SCM_CONT_PROMPT_MARKER = (1L<<0),
+    SCM_CONT_BOUNDARY_MARKER = (1L<<1)
 };
 
 static void push_prompt_cont(ScmVM*, ScmObj, ScmObj);
 static void push_boundary_cont(ScmVM*, ScmObj, ScmObj);
 
 /* return true if cont is a boundary continuation frame */
-#define BOUNDARY_FRAME_P(cont) ((cont)->marker & SCM_CONT_RESET_MARKER)
+#define BOUNDARY_FRAME_P(cont) ((cont)->marker & SCM_CONT_BOUNDARY_MARKER)
 
-/* return true if cont has the end marker of partial continuation */
-#define MARKER_FRAME_P(cont)   ((cont)->marker & SCM_CONT_SHIFT_MARKER)
+/* return true if cont is a prompt continuation frame */
+#define PROMPT_FRAME_P(cont) ((cont)->marker & SCM_CONT_PROMPT_MARKER)
 
 /* A stub VM code to make VM return immediately */
 static ScmWord return_code[] = { SCM_VM_INSN(SCM_VM_RET) };
@@ -113,17 +113,6 @@ static ScmEnvFrame ccEnvMark = {
 };
 
 #define C_CONTINUATION_P(cont)  ((cont)->env == &ccEnvMark)
-
-/* If you have ScmContFrame *cont and you'll do something that can trigger
-   saving frames, you have to call this first to ensure that your
-   cont frame keeps pointing a valid frame. */
-#define ENSURE_SAVE_CONT(cont)                  \
-    do {                                        \
-        save_cont(vm);                          \
-        if (FORWARDED_CONT_P(cont)) {           \
-            cont = FORWARDED_CONT(cont);        \
-        }                                       \
-    } while (0)
 
 /* IN_STACK_P(ptr) returns true if ptr points into the active stack area.
    IN_FULL_STACK_P(ptr) returns true if ptr points into any part of the stack.
@@ -317,10 +306,10 @@ ScmVM *Scm_NewVM(ScmVM *proto, ScmObj name)
 
     v->dynamicHandlers = SCM_NIL;
 
-    v->floatingEscapePoints = SCM_NIL;
     v->escapeReason = SCM_VM_ESCAPE_NONE;
     v->escapeData[0] = NULL;
     v->escapeData[1] = NULL;
+    v->escapeData[2] = NULL;
     v->errorHandlerContinuable = FALSE;
     v->customErrorReporter = (proto? proto->customErrorReporter : SCM_FALSE);
 #if GAUCHE_SPLIT_STACK
@@ -354,8 +343,7 @@ ScmVM *Scm_NewVM(ScmVM *proto, ScmObj name)
                     : NULL);
     v->codeCache = NULL;
 
-    v->currentPrompt = NULL;
-    v->resetChain = SCM_NIL;
+    v->partialChain = SCM_NIL;
 
     Scm_RegisterFinalizer(SCM_OBJ(v), vm_finalize, NULL);
     return v;
@@ -438,10 +426,10 @@ ScmVM *Scm_VMTakeSnapshot(ScmVM *vm)
     v->denv = vm->denv;
     v->dynamicHandlers = vm->dynamicHandlers;
 
-    v->floatingEscapePoints = vm->floatingEscapePoints;
     v->escapeReason = vm->escapeReason;
     v->escapeData[0] = vm->escapeData[0];
     v->escapeData[1] = vm->escapeData[1];
+    v->escapeData[2] = vm->escapeData[2];
     v->errorHandlerContinuable = vm->errorHandlerContinuable;
     v->customErrorReporter = vm->customErrorReporter;
 #if GAUCHE_SPLIT_STACK
@@ -473,8 +461,8 @@ ScmVM *Scm_VMTakeSnapshot(ScmVM *vm)
     v->codeCache = NULL;        /* We might need to copy this as well
                                    if we want to debug JIT code cache */
 
-    v->currentPrompt = vm->currentPrompt;
-    v->resetChain = vm->resetChain;
+    v->partialChain = vm->partialChain;
+
     /* NB: We don't register the finalizer vm_finalize to the snapshot,
        for we do not want the associated system resources to be cleaned
        up when the snapshot is GCed. */
@@ -806,17 +794,13 @@ static void vm_unregister(ScmVM *vm)
     } while (0)
 
 /* return operation. */
-#define RETURN_OP()                                     \
-    do {                                                \
-        if (CONT == NULL || BOUNDARY_FRAME_P(CONT)) {   \
-            return; /* no more continuations */         \
-        } else if (MARKER_FRAME_P(CONT)) {              \
-            POP_CONT();                                 \
-            /* the end of partial continuation */       \
-            vm->cont = NULL;                            \
-        } else {                                        \
-            POP_CONT();                                 \
-        }                                               \
+#define RETURN_OP()                                   \
+    do {                                              \
+        if (CONT == NULL || BOUNDARY_FRAME_P(CONT)) { \
+            return; /* no more continuations */       \
+        } else {                                      \
+            POP_CONT();                               \
+        }                                             \
     } while (0)
 
 /* push environment header to finish the environment frame.
@@ -1210,6 +1194,53 @@ static inline ScmEnvFrame *save_env(ScmVM *vm, ScmEnvFrame *env_begin)
     return head;
 }
 
+static ScmContFrame *copy_ccont_1(ScmVM *vm, ScmContFrame *c,
+                                  int promptDataCopy)
+{
+    int size = (CONT_FRAME_SIZE + c->size) * sizeof(ScmObj);
+    ScmObj *heap = SCM_NEW2(ScmObj*, size);
+    ScmContFrame *csave = (ScmContFrame*)(heap + c->size);
+
+    /* update env ptr if necessary */
+    if (FORWARDED_ENV_P(c->env)) {
+        c->env = FORWARDED_ENV(c->env);
+    } else if (IN_FULL_STACK_P((ScmObj*)c->env)) {
+        c->env = save_env(vm, c->env);
+    }
+
+    /* copy cont frame */
+    if (!C_CONTINUATION_P(c)) {
+        ScmObj *s = (ScmObj*)c - c->size;
+        ScmObj *d = heap;
+        if (c->size) {
+            for (int i=c->size; i>0; i--) {
+                SCM_FLONUM_ENSURE_MEM(*s);
+                *d++ = *s++;
+            }
+        }
+        *(ScmContFrame*)d = *c; /* copy the frame */
+    } else {
+        /* C continuation */
+        ScmObj *s = (ScmObj*)c - c->size;
+        ScmObj *d = heap;
+        for (int i=CONT_FRAME_SIZE + c->size; i>0; i--) {
+            /* NB: C continuation frame contains opaque pointer,
+               so we shouldn't ENSURE_MEM. */
+            *d++ = *s++;
+        }
+    }
+
+    /* for prompt frame, we also need to copy promptdata */
+    if (promptDataCopy && PROMPT_FRAME_P(c)) {
+        ScmPromptData *psrc = (ScmPromptData*)c->cpc;
+        ScmPromptData *psave = SCM_NEW(ScmPromptData);
+        *psave = *psrc;
+        csave->cpc = &psave->dummy;
+    }
+
+    return csave;
+}
+
 static void save_cont_1(ScmVM *vm, ScmContFrame *c)
 {
     if (!IN_FULL_STACK_P((ScmObj*)c)) return;
@@ -1218,46 +1249,8 @@ static void save_cont_1(ScmVM *vm, ScmContFrame *c)
 
     /* First pass */
     do {
-        int size = (CONT_FRAME_SIZE + c->size) * sizeof(ScmObj);
-        ScmObj *heap = SCM_NEW2(ScmObj*, size);
-        ScmContFrame *csave = (ScmContFrame*)(heap + c->size);
-
-        /* update env ptr if necessary */
-        if (FORWARDED_ENV_P(c->env)) {
-            c->env = FORWARDED_ENV(c->env);
-        } else if (IN_FULL_STACK_P((ScmObj*)c->env)) {
-            c->env = save_env(vm, c->env);
-        }
-
-        /* copy cont frame */
-        if (!C_CONTINUATION_P(c)) {
-            ScmObj *s = (ScmObj*)c - c->size;
-            ScmObj *d = heap;
-            if (c->size) {
-                for (int i=c->size; i>0; i--) {
-                    SCM_FLONUM_ENSURE_MEM(*s);
-                    *d++ = *s++;
-                }
-            }
-            *(ScmContFrame*)d = *c; /* copy the frame */
-        } else {
-            /* C continuation */
-            ScmObj *s = (ScmObj*)c - c->size;
-            ScmObj *d = heap;
-            for (int i=CONT_FRAME_SIZE + c->size; i>0; i--) {
-                /* NB: C continuation frame contains opaque pointer,
-                   so we shouldn't ENSURE_MEM. */
-                *d++ = *s++;
-            }
-        }
-
-        /* for boundary frame, we also need to copy promptdata */
-        if (BOUNDARY_FRAME_P(c)) {
-            ScmPromptData *psrc = (ScmPromptData*)c->cpc;
-            ScmPromptData *psave = SCM_NEW(ScmPromptData);
-            *psave = *psrc;
-            csave->cpc = &psave->dummy;
-        }
+        /* copy ccont frame c */
+        ScmContFrame *csave = copy_ccont_1(vm, c, 1);
 
         /* make the orig frame forwarded */
         if (prev) prev->prev = csave;
@@ -1301,18 +1294,6 @@ static void save_cont(ScmVM *vm)
         if (FORWARDED_CONT_P(cstk->cont)) {
             cstk->cont = FORWARDED_CONT(cstk->cont);
         }
-    }
-    {
-        ScmObj eps;
-        SCM_FOR_EACH(eps, vm->floatingEscapePoints) {
-            ScmObj ep = SCM_CAR(eps);
-            SCM_ASSERT(SCM_ESCAPE_POINT_P(ep));
-            ScmEscapePoint *e = SCM_ESCAPE_POINT(ep);
-            if (FORWARDED_CONT_P(e->cont)) {
-                e->cont = FORWARDED_CONT(e->cont);
-            }
-        }
-        vm->floatingEscapePoints = SCM_NIL;
     }
 }
 
@@ -1885,6 +1866,56 @@ static ScmObj *new_ccont(ScmVM *vm, ScmPContinuationProc *after,
     return s;
 }
 
+/* Copy ccont frames from c to c_last */
+static ScmContFrame *copy_ccont_frames(ScmContFrame *c,
+                                       ScmContFrame *c_last)
+{
+    ScmVM *vm = theVM;
+
+    if (c == NULL) { return NULL; }
+
+    /* copy ccont frame c */
+    ScmContFrame *cc = copy_ccont_1(vm, c, 0);
+    if (c == c_last) {
+        /* cut on c_last */
+        cc->prev = NULL;
+        return cc;
+    }
+
+    /* copy ccont frames until c_last */
+    ScmContFrame *cc_old = cc;
+    while (1) {
+        c = c->prev;
+        if (c == NULL) { break; }
+        ScmContFrame *cc2 = copy_ccont_1(vm, c, 0);
+        cc_old->prev = cc2;
+        if (c == c_last) {
+            /* cut on c_last */
+            cc2->prev = NULL;
+            break;
+        }
+        cc_old = cc2;
+    }
+    return cc;
+}
+
+/* Merge ccont frames */
+static ScmContFrame *merge_ccont_frames(ScmContFrame *c,
+                                        ScmContFrame *c_add)
+{
+    if (c_add == NULL) { return c; }
+    ScmContFrame *c_add_2 = c_add;
+    while (1) {
+        if (c_add_2->prev == NULL) {
+            /* merge ccont frames */
+            c_add_2->prev = c;
+            break;
+        }
+        c_add_2 = c_add_2->prev;
+    }
+    return c_add;
+}
+
 /* This is a trick to keep the backward compatibility. */
 static ScmObj ccont_adapter(ScmVM *vm, ScmObj val0, ScmObj *data)
 {
@@ -1957,9 +1988,13 @@ SCM_DEFINE_BUILTIN_CLASS(Scm_EscapePointClass,
 static ScmEscapePoint *new_ep(ScmVM *vm,
                               ScmObj errorHandler,
                               int rewindBefore,
+                              int contType,
                               ScmObj promptTag,
                               ScmObj abortHandler)
 {
+    /* save continuation to heap before capturing escape point */
+    save_cont(vm);
+
     ScmEscapePoint *ep = SCM_NEW(ScmEscapePoint);
     SCM_SET_CLASS(ep, SCM_CLASS_ESCAPE_POINT);
     ep->ehandler = errorHandler;
@@ -1968,13 +2003,15 @@ static ScmEscapePoint *new_ep(ScmVM *vm,
     ep->dynamicHandlers = get_dynamic_handlers(vm);
     ep->cstack = vm->cstack;
     ep->xhandler = Scm_VMCurrentExceptionHandler();
-    ep->resetChain = vm->resetChain;
-    ep->partHandlers = SCM_NIL;
+    ep->partialChain = vm->partialChain;
+    ep->partialHandlers = SCM_NIL;
     ep->errorReporting =
         SCM_VM_RUNTIME_FLAG_IS_SET(vm, SCM_ERROR_BEING_REPORTED);
     ep->rewindBefore = rewindBefore;
+    ep->contType = contType;
     ep->promptTag = promptTag;
     ep->abortHandler = abortHandler;
+    ep->abortArgs = SCM_NIL;
     ep->bottom = NULL;
     return ep;
 }
@@ -2009,16 +2046,14 @@ static ScmObj user_eval_inner(ScmObj program,
     /* Save prev_pc, for the boundary continuation uses pc slot
        to mark the boundary. */
     ScmWord * volatile prev_pc = PC;
-    ScmObj vmhandlers = get_dynamic_handlers(vm);
-    ScmObj vmresetChain = vm->resetChain;
 
     if (SCM_FALSEP(promptTag)) {
         promptTag = SCM_OBJ(&defaultPromptTag);
     }
 
     /* Push extra continuation.  This continuation frame is a 'boundary
-       frame' and marked by marker == SCM_CONT_RESET_MARKER.   VM loop knows
-       it should return to C frame when it sees a boundary frame.
+       frame' and marked by marker == SCM_CONT_BOUNDARY_MARKER.   VM loop
+       knows it should return to C frame when it sees a boundary frame.
        A boundary frame also keeps the unfinished argument frame at
        the point when Scm_Eval or Scm_Apply is called. */
     push_boundary_cont(vm, promptTag, abortHandler);
@@ -2043,35 +2078,6 @@ static ScmObj user_eval_inner(ScmObj program,
         if (vm->cont == cstack.cont) {
             POP_CONT();
             PC = prev_pc;
-        } else if (vm->cont == NULL) {
-            /* we're finished with executing partial continuation. */
-
-            /* restore reset-chain for reset/shift */
-            vm->resetChain = vmresetChain;
-
-            /* save return values */
-            ScmObj val0 = vm->val0;
-            int nvals = vm->numVals;
-            ScmObj *vals = NULL;
-            if (nvals > 1) {
-                vals = SCM_NEW_ARRAY(ScmObj, nvals-1);
-                memcpy(vals, vm->vals, sizeof(ScmObj)*(nvals-1));
-            }
-
-            /* call dynamic handlers for returning to the caller */
-            call_dynamic_handlers(vm, vmhandlers,
-                                  get_dynamic_handlers(vm));
-
-            /* restore return values */
-            vm->val0 = val0;
-            vm->numVals = nvals;
-            if (vals != NULL) {
-                memcpy(vm->vals, vals, sizeof(ScmObj)*(nvals-1));
-            }
-
-            vm->cont = cstack.cont;
-            POP_CONT();
-            PC = prev_pc;
         } else {
             /* If we come here, we've been executing a ghost continuation.
                The C world the ghost should return no longer exists, so we
@@ -2081,16 +2087,16 @@ static ScmObj user_eval_inner(ScmObj program,
     } else {
         /* An escape situation happened. */
         if (vm->escapeReason == SCM_VM_ESCAPE_CONT) {
-            ScmEscapePoint *ep = (ScmEscapePoint*)vm->escapeData[0];
+            ScmObj hdlist = SCM_OBJ(vm->escapeData[0]);
+            ScmEscapePoint *ep = (ScmEscapePoint*)vm->escapeData[1];
+            ScmObj args = SCM_OBJ(vm->escapeData[2]);
             if (ep->cstack == vm->cstack) {
-                ScmObj handlers =
-                    throw_cont_calculate_handlers(ep->dynamicHandlers,
-                                                  get_dynamic_handlers(vm));
                 /* force popping continuation when restarted */
                 vm->pc = PC_TO_RETURN;
-                vm->val0 = throw_cont_body(handlers, ep, vm->escapeData[1]);
+                vm->val0 = throw_cont_body(hdlist, ep, args);
                 goto restart;
             } else {
+                /* rewind cstack */
                 SCM_ASSERT(vm->cstack && vm->cstack->prev);
                 vm->cont = cstack.cont;
                 POP_CONT();
@@ -2103,8 +2109,10 @@ static ScmObj user_eval_inner(ScmObj program,
                 vm->cont = ep->cont;
                 vm->denv = ep->denv;
                 vm->pc = PC_TO_RETURN;
-                /* restore reset-chain for reset/shift */
-                if (ep->cstack) vm->resetChain = ep->resetChain;
+                /* set partial continuation information */
+                if (ep->contType == CONT_TYPE_FULL) {
+                    vm->partialChain = ep->partialChain;
+                }
                 goto restart;
             } else if (vm->cstack->prev == NULL) {
                 /* This loop is the outermost C stack, and nobody will
@@ -2158,13 +2166,14 @@ void push_prompt_cont(ScmVM *vm, ScmObj promptTag, ScmObj abortHandler)
     a->dynamicHandlers = get_dynamic_handlers(vm);
     PUSH_CONT(SCM_PROMPT_TAG_PC(promptTag));
     CONT->cpc = &a->dummy;
+    CONT->marker |= SCM_CONT_PROMPT_MARKER;
 }
 
 void push_boundary_cont(ScmVM *vm, ScmObj promptTag, ScmObj abortHandler)
 {
-    /* Boundary continuation is a prompt cont with CONT_RESET_MARKER */
+    /* Boundary continuation is a prompt cont with SCM_CONT_BOUNDARY_MARKER */
     push_prompt_cont(vm, promptTag, abortHandler);
-    CONT->marker = SCM_CONT_RESET_MARKER;
+    CONT->marker |= SCM_CONT_BOUNDARY_MARKER;
 }
 
 /* API for recursive call to VM.  Exceptions are not captured.
@@ -2541,7 +2550,9 @@ static void call_after_thunk(ScmVM *vm, ScmObj handler_entry)
     SCM_ASSERT(SCM_DYNAMIC_HANDLER_P(handler_entry));
     ScmDynamicHandler *dh = SCM_DYNAMIC_HANDLER(handler_entry);
     vm->denv = dh->denv;
-    Scm_ApplyRec(dh->after, dh->args);
+    if (!SCM_FALSEP(dh->after)) {
+        Scm_ApplyRec(dh->after, dh->args);
+    }
 }
 
 static ScmObj vm_call_before_thunk(ScmVM *vm, ScmObj handler_entry)
@@ -2561,7 +2572,11 @@ static ScmObj vm_call_after_thunk(ScmVM *vm, ScmObj handler_entry)
     SCM_ASSERT(SCM_DYNAMIC_HANDLER_P(handler_entry));
     ScmDynamicHandler *dh = SCM_DYNAMIC_HANDLER(handler_entry);
     vm->denv = dh->denv;
-    return Scm_VMApply(dh->after, dh->args);
+    if (!SCM_FALSEP(dh->after)) {
+        return Scm_VMApply(dh->after, dh->args);
+    } else {
+        return SCM_UNDEFINED;
+    }
 }
 /* End of handler-chain internal API */
 
@@ -2644,20 +2659,37 @@ static ScmObj dynwind_body_cc(ScmVM *vm, ScmObj result, ScmObj *data)
        actually gets slightly slower.  More branches may have a negative
        effect.  So we keep it simple here.
      */
-    int nvals = vm->numVals;
-    if (nvals > 1) {
-        ScmObj *vals = SCM_NEW_ARRAY(ScmObj, nvals-1);
-        memcpy(vals, vm->vals, sizeof(ScmObj)*(nvals-1));
-        ScmObj *d = Scm_pc_PushCC(vm, dynwind_after_cc, 3);
-        d[0] = result;
-        d[1] = SCM_OBJ((intptr_t)nvals);
-        d[2] = SCM_OBJ(vals);
+    if (SCM_FALSEP(after)) {
+        /* we can skip application of 'after' */
+        ScmObj d[3];
+        int nvals = vm->numVals;
+        if (nvals > 1) {
+            ScmObj *vals = SCM_NEW_ARRAY(ScmObj, nvals-1);
+            memcpy(vals, vm->vals, sizeof(ScmObj)*(nvals-1));
+            d[0] = result;
+            d[1] = SCM_OBJ((intptr_t)nvals);
+            d[2] = SCM_OBJ(vals);
+        } else {
+            d[0] = result;
+            d[1] = SCM_OBJ((intptr_t)nvals);
+        }
+        return dynwind_after_cc(vm, SCM_UNDEFINED, d);
     } else {
-        ScmObj *d = Scm_pc_PushCC(vm, dynwind_after_cc, 2);
-        d[0] = result;
-        d[1] = SCM_OBJ((intptr_t)nvals);
+        int nvals = vm->numVals;
+        if (nvals > 1) {
+            ScmObj *vals = SCM_NEW_ARRAY(ScmObj, nvals-1);
+            memcpy(vals, vm->vals, sizeof(ScmObj)*(nvals-1));
+            ScmObj *d = Scm_pc_PushCC(vm, dynwind_after_cc, 3);
+            d[0] = result;
+            d[1] = SCM_OBJ((intptr_t)nvals);
+            d[2] = SCM_OBJ(vals);
+        } else {
+            ScmObj *d = Scm_pc_PushCC(vm, dynwind_after_cc, 2);
+            d[0] = result;
+            d[1] = SCM_OBJ((intptr_t)nvals);
+        }
+        return Scm_VMApply0(after);
     }
-    return Scm_VMApply0(after);
 }
 
 static ScmObj dynwind_after_cc(ScmVM *vm, ScmObj result SCM_UNUSED,
@@ -2766,14 +2798,6 @@ static ScmObj handle_escape(ScmObj e, ScmEscapePoint *ep)
     ScmObj result = SCM_FALSE, rvals[SCM_VM_MAX_VALUES];
     int numVals = 0;
 
-    /* Save continuation chains into heap.  This has non-negligible
-       overhead, but we need to keep all active EPs' cont field valid.
-       Without this, a complication occurs when save_cont occurs during
-       executing the error handler and it returns subsequently.
-       See https://github.com/shirok/Gauche/issues/852 for the details.
-    */
-    save_cont(vm);
-
 #if GAUCHE_SPLIT_STACK
     vm->lastErrorCont = vm->cont;
     vm->stackBase = vm->sp;
@@ -2846,8 +2870,10 @@ static ScmObj handle_escape(ScmObj e, ScmEscapePoint *ep)
     if (ep->errorReporting) {
         SCM_VM_RUNTIME_FLAG_SET(vm, SCM_ERROR_BEING_REPORTED);
     }
-    /* restore reset-chain for reset/shift */
-    if (ep->cstack) vm->resetChain = ep->resetChain;
+    /* set partial continuation information */
+    if (ep->contType == CONT_TYPE_FULL) {
+        vm->partialChain = ep->partialChain;
+    }
 
     SCM_ASSERT(vm->cstack);
     vm->escapeReason = SCM_VM_ESCAPE_ERROR;
@@ -2984,37 +3010,17 @@ ScmObj Scm_VMThrowException(ScmVM *vm, ScmObj exception, u_long raise_flags)
 /*
  * with-error-handler
  */
-static ScmObj discard_ehandler(ScmObj *args SCM_UNUSED,
-                               int nargs SCM_UNUSED,
-                               void *data)
-{
-    /* restore floatingEscapePoints when necessary */
-    ScmObj eps = SCM_OBJ(data);
-    if (SCM_PAIRP(eps)) {
-        ScmVM *vm = theVM;
-        ScmContFrame *c = SCM_ESCAPE_POINT(SCM_CAR(eps))->cont;
-        if (IN_STACK_P((ScmObj*)c)) {
-            /* Those cont frames are not saved yet, so keep them
-               in the chain. */
-            theVM->floatingEscapePoints = eps;
-        }
-    }
-    return SCM_UNDEFINED;
-}
-
 static ScmObj with_error_handler(ScmVM *vm, ScmObj handler,
                                  ScmObj thunk, int rewindBefore)
 {
-    ScmEscapePoint *ep = new_ep(vm, handler, rewindBefore,
-                                SCM_FALSE, SCM_FALSE);
+    ScmObj promptTag = Scm_DefaultPromptTag();
+    ScmEscapePoint *ep = new_ep(vm, handler, rewindBefore, CONT_TYPE_FULL,
+                                promptTag, SCM_FALSE);
 
     ScmObj ehandler = make_escape_handler(ep);
     Scm_VMPushExceptionHandler(ehandler);
     SCM_VM_RUNTIME_FLAG_CLEAR(theVM, SCM_ERROR_BEING_REPORTED);
-    ScmObj prev_fep = vm->floatingEscapePoints;
-    vm->floatingEscapePoints = Scm_Cons(SCM_OBJ(ep), prev_fep);
-    ScmObj after  = Scm_MakeSubr(discard_ehandler, prev_fep, 0, 0, SCM_FALSE);
-    return Scm_VMDynamicWind(SCM_FALSE, thunk, after);
+    return Scm_VMDynamicWind(SCM_FALSE, thunk, SCM_FALSE);
 }
 
 ScmObj Scm_VMWithErrorHandler(ScmObj handler, ScmObj thunk)
@@ -3143,16 +3149,46 @@ ScmObj Scm_DefaultPromptTag()
  * Continuation prompts
  */
 
+static ScmObj cp_after_thunk_cc(ScmObj result, void **data SCM_UNUSED)
+{
+    ScmVM *vm = theVM;
+
+    /* pop partial continuation information */
+    SCM_ASSERT(SCM_PAIRP(vm->partialChain));
+    vm->partialChain = SCM_CDR(vm->partialChain);
+
+    return result;
+}
+
 ScmObj Scm_VMCallWithContinuationPrompt(ScmObj thunk,
                                         ScmObj promptTag,
                                         ScmObj abortHandler)
 {
-    if (SCM_FALSEP(promptTag)) promptTag = Scm_DefaultPromptTag();
-    else if (!SCM_PROMPT_TAG_P(promptTag)) {
+    ScmVM *vm = theVM;
+
+    if (SCM_FALSEP(promptTag)) {
+        promptTag = Scm_DefaultPromptTag();
+    } else if (!SCM_PROMPT_TAG_P(promptTag)) {
         SCM_TYPE_ERROR(promptTag, "prompt tag or #f");
     }
 
+    /* push partial continuation information */
+    vm->partialChain = Scm_Cons(Scm_Cons(promptTag, NULL),
+                                vm->partialChain);
+
+    /* push after thunk continuation */
+    Scm_VMPushCC(cp_after_thunk_cc, NULL, 0);
+
+    /* push prompt continuation */
     push_prompt_cont(Scm_VM(), promptTag, abortHandler);
+
+    /* save escape point to partial continuation information */
+    ScmEscapePoint *ep = new_ep(vm, SCM_FALSE, FALSE, CONT_TYPE_FULL,
+                                promptTag, abortHandler);
+    SCM_ASSERT(SCM_PAIRP(vm->partialChain));
+    ScmObj partialInfo = SCM_CAR(vm->partialChain);
+    SCM_SET_CDR_UNCHECKED(partialInfo, SCM_OBJ(ep));
+
     return Scm_VMApply0(thunk);
 }
 
@@ -3163,61 +3199,37 @@ static ScmContFrame *find_prompt_frame(ScmVM *vm, ScmObj promptTag)
     for (ScmContFrame *c = vm->cont; c; c = c->prev) {
         if (c->pc == pc) {
             return c;
-         }
-     }
-     return NULL;
-}
-
-
-static ScmObj vm_abort_cc(ScmObj val0, void *data[]);
-
-static ScmObj vm_abort_body(ScmContFrame *abortTo, ScmObj args)
-{
-    ScmPromptData *pd = (ScmPromptData*)abortTo->cpc;
-    ScmObj abortHandler = pd->abortHandler;
-
-    if (SCM_FALSEP(abortHandler)) {
-        if (!(Scm_Length(args) == 1
-              && SCM_PROCEDUREP(SCM_CAR(args))
-              && SCM_PROCEDURE_REQUIRED(SCM_CAR(args)) == 0)) {
-            Scm_Error("default abort-handler requires exactly one argument, "
-                      "which must be a thunk, but got: %S", args);
         }
-        return Scm_VMApply0(SCM_CAR(args));
-    } else {
-        /* TODO: In this case, we should run abortHandler _after_ the
-           abortTo frame is popped.  We need some more tweaks to realize it.
-        */
-        return Scm_VMApply(abortHandler, args);
     }
+    return NULL;
 }
 
-static ScmObj vm_abort_cc(ScmObj val0 SCM_UNUSED, void *data[])
+/* find partial continuation informatin of nearest prompt */
+static ScmObj find_partial_information(ScmVM *vm, ScmObj promptTag)
 {
-    ScmContFrame *abortTo = data[0];
-    ScmPromptData *pd = (ScmPromptData*)abortTo->cpc;
-    ScmObj targetHandlers = pd->dynamicHandlers;
-    ScmVM *vm = theVM;
-    ScmObj currentHandlers = get_dynamic_handlers(vm);
-    if (targetHandlers != currentHandlers && SCM_PAIRP(currentHandlers)) {
-        Scm_VMPushCC(vm_abort_cc, data, 2);
-        ScmObj handler_entry = pop_dynamic_handlers(vm);
-        return vm_call_after_thunk(vm, handler_entry);
-    } else {
-        ScmObj args = SCM_OBJ(data[1]);
-        return vm_abort_body(abortTo, args);
+    ScmObj p1;
+    SCM_FOR_EACH(p1, vm->partialChain) {
+        if (SCM_CAR(SCM_CAR(p1)) == promptTag) {
+            return SCM_CAR(p1);
+        }
     }
+    return SCM_NIL;
 }
 
+
+static ScmObj throw_continuation(ScmObj *argframe, int nargs, void *data);
 
 ScmObj Scm_VMAbortCurrentContinuation(ScmObj promptTag, ScmObj args)
 {
-    if (!(SCM_PROMPT_TAG_P(promptTag) || SCM_FALSEP(promptTag))) {
-        SCM_TYPE_ERROR(promptTag, "prompt tag or #f");
-    }
     ScmVM *vm = theVM;
-    ScmContFrame *abortTo = find_prompt_frame(vm, promptTag);
-    if (abortTo == NULL) {
+
+    if (!(SCM_PROMPT_TAG_P(promptTag) || SCM_FALSEP(promptTag))) {
+        SCM_TYPE_ERROR(promptTag, "prompt tag");
+    }
+
+    /* find partial continuation information of nearest prompt */
+    ScmObj partialInfo = find_partial_information(vm, promptTag);
+    if (!SCM_PAIRP(partialInfo)) {
         Scm_RaiseCondition(SCM_OBJ(SCM_CLASS_CONTINUATION_ERROR),
                            "prompt-tag", promptTag,
                            SCM_RAISE_CONDITION_MESSAGE,
@@ -3225,28 +3237,37 @@ ScmObj Scm_VMAbortCurrentContinuation(ScmObj promptTag, ScmObj args)
                            promptTag);
     }
 
-    ScmPromptData *pd = (ScmPromptData*)abortTo->cpc;
-    SCM_ASSERT(pd->dummy == SCM_VM_INSN(SCM_VM_RET));
-    ScmObj targetHandlers = pd->dynamicHandlers;
+    /* get escape point on prompt */
+    ScmEscapePoint *ep = (ScmEscapePoint *)SCM_CDR(partialInfo);
+
+    /* get abort handler */
+    ScmObj abortHandler = ep->abortHandler;
+    ScmObj abortArgs = args;
+    if (SCM_FALSEP(abortHandler)) {
+        if (!(Scm_Length(args) == 1
+              && SCM_PROCEDUREP(SCM_CAR(args))
+              && SCM_PROCEDURE_REQUIRED(SCM_CAR(args)) == 0)) {
+            Scm_Error("default abort-handler requires exactly one argument, "
+                      "which must be a thunk, but got: %S", args);
+        }
+        abortHandler = SCM_CAR(args);
+        abortArgs = SCM_NIL;
+    }
+
+    /* get abort continuation */
+    ScmContFrame *abortTo = ep->cont;
 
     /* Discard continuation, and reinstate abortTo frame and its
        dynamic environment. */
     CONT = abortTo;
     DENV = abortTo->denv;
 
-    ScmObj currentHandlers = get_dynamic_handlers(vm);
-    if (targetHandlers != currentHandlers && SCM_PAIRP(currentHandlers)) {
-        ENSURE_SAVE_CONT(abortTo);
-
-        void *data[2];
-        data[0] = abortTo;
-        data[1] = args;
-        Scm_VMPushCC(vm_abort_cc, data, 2);
-        ScmObj handler_entry = pop_dynamic_handlers(vm);
-        return vm_call_after_thunk(vm, handler_entry);
-    } else {
-        return vm_abort_body(abortTo, args);
-    }
+    /* call continuation procedure to abort */
+    ep->abortHandler = abortHandler;
+    ep->abortArgs = abortArgs;
+    ScmObj contproc = Scm_MakeSubr(throw_continuation, ep, 0, 1,
+                                   continuation_symbol);
+    return Scm_VMApply(contproc, SCM_NIL);
 }
 
 /*
@@ -3443,16 +3464,15 @@ void Scm_VMFlushDynamicHandlers()
 }
 
 
-static ScmObj throw_cont_cc(ScmObj, void **);
+static ScmObj throw_cont_cc(ScmObj result, void **data);
+static ScmObj vm_abort_to_cc(ScmObj result, void **data);
+static ScmObj vm_partial_end_cc(ScmObj result, void **data);
 
 static ScmObj throw_cont_body(ScmObj hdlist,      /*((flag . handler-chain)...)*/
                               ScmEscapePoint *ep, /* target continuation */
                               ScmObj args)        /* args to pass to the
                                                      target continuation */
 {
-    void *data[4];
-    int nargs;
-    ScmObj ap;
     ScmVM *vm = theVM;
 
     /*
@@ -3463,6 +3483,7 @@ static ScmObj throw_cont_body(ScmObj hdlist,      /*((flag . handler-chain)...)*
         ScmObj before_flag = SCM_CAAR(hdlist);
         ScmObj chain       = SCM_CDAR(hdlist);
 
+        void *data[4];
         data[0] = (void*)SCM_CDR(hdlist);
         data[1] = (void*)ep;
         data[2] = (void*)args;
@@ -3479,33 +3500,70 @@ static ScmObj throw_cont_body(ScmObj hdlist,      /*((flag . handler-chain)...)*
     }
 
     /*
-     * If the target continuation is a full continuation, we can abandon
-     * the current continuation.  However, if the target continuation is
-     * partial, we must return to the current continuation after executing
-     * the partial continuation.  The returning part is handled by
-     * user_level_inner, but we have to make sure that our current continuation
-     * won't be overwritten by execution of the partial continuation.
-     *
-     * NB: As an exception case, if we'll jump into reset,
-     * we might reach to the end of partial continuation even though
-     * the target continuation is a full continuation.
-     */
-    if (ep->cstack == NULL || SCM_PAIRP(ep->resetChain)) {
-        save_cont(vm);
-    }
-
-    /*
      * now, install the target continuation
      */
     vm->pc = PC_TO_RETURN;
-    vm->cont = ep->cont;
+    if (ep->contType == CONT_TYPE_FULL) {
+        /* for full continuation */
+        vm->cont = ep->cont;
+    } else {
+        /* for partial continuation */
+
+        /* find partial continuation information of nearest prompt */
+        ScmObj partialInfo = find_partial_information(vm, ep->promptTag);
+        if (!SCM_PAIRP(partialInfo)) {
+            Scm_RaiseCondition(SCM_OBJ(SCM_CLASS_CONTINUATION_ERROR),
+                               "prompt-tag", ep->promptTag,
+                               SCM_RAISE_CONDITION_MESSAGE,
+                               "Prompt tag (%S) not found (E1)",
+                               ep->promptTag);
+        }
+
+        /* get escape point on prompt */
+        ScmEscapePoint *ep2 = (ScmEscapePoint *)SCM_CDR(partialInfo);
+
+        /* for non-composable partial continuation */
+        /* we drop continuation from current to prompt before merge. */
+        if (ep->contType == CONT_TYPE_NON_COMPOSABLE) {
+            /* get prompt continuation */
+            ScmContFrame *cprompt = ep2->cont;
+            /* drop continuation from current to prompt */
+            vm->cont = cprompt;
+            /* set partial continuation information */
+            vm->partialChain = ep2->partialChain;
+        }
+
+        /* push partial end continuation */
+        void *data[1];
+        data[0] = (void*)ep2->partialChain;
+        Scm_VMPushCC(vm_partial_end_cc, data, 1);
+
+        /* we merge current continuation and partial continuation.
+           NB: save_cont() and copy_ccont_frames() are necessary to avoid
+               problems of continuation sharing.
+        */
+        save_cont(vm);
+        ScmContFrame *epcont_copy = copy_ccont_frames(ep->cont, NULL);
+        vm->cont = merge_ccont_frames(vm->cont, epcont_copy);
+    }
     vm->denv = ep->denv;
 
-    /* restore reset-chain for reset/shift */
-    if (ep->cstack) vm->resetChain = ep->resetChain;
+    /* set partial continuation information */
+    if (ep->contType == CONT_TYPE_FULL) {
+        vm->partialChain = ep->partialChain;
+    }
 
-    nargs = Scm_Length(args);
+    /* if abort handler exists, push abort handler continuation */
+    if (ep->contType == CONT_TYPE_FULL && !SCM_FALSEP(ep->abortHandler)) {
+        void *data[2];
+        data[0] = (void*)ep->abortHandler;
+        data[1] = (void*)ep->abortArgs;
+        Scm_VMPushCC(vm_abort_to_cc, data, 2);
+    }
+
+    int nargs = Scm_Length(args);
     if (nargs == 1) {
+        vm->numVals = 1;
         return SCM_CAR(args);
     } else if (nargs < 1) {
         vm->numVals = 0;
@@ -3514,7 +3572,7 @@ static ScmObj throw_cont_body(ScmObj hdlist,      /*((flag . handler-chain)...)*
         Scm_Error("too many values passed to the continuation");
     }
 
-    ap = SCM_CDR(args);
+    ScmObj ap = SCM_CDR(args);
     for (int i=0; SCM_PAIRP(ap); i++, ap=SCM_CDR(ap)) {
         vm->vals[i] = SCM_CAR(ap);
     }
@@ -3537,6 +3595,27 @@ static ScmObj throw_cont_cc(ScmObj result SCM_UNUSED, void **data)
     return throw_cont_body(hdlist, ep, args);
 }
 
+static ScmObj vm_abort_to_cc(ScmObj result SCM_UNUSED, void **data)
+{
+    ScmObj abortHandler = SCM_OBJ(data[0]);
+    ScmObj abortArgs = SCM_OBJ(data[1]);
+
+    return Scm_VMApply(abortHandler, abortArgs);
+}
+
+static ScmObj vm_partial_end_cc(ScmObj result, void **data)
+{
+    ScmVM *vm = theVM;
+    ScmObj partialChain = SCM_OBJ(data[0]);
+
+    /* we're finished with executing partial continuation. */
+
+    /* restore partial continuation information */
+    vm->partialChain = partialChain;
+
+    return result;
+}
+
 /* Body of the continuation SUBR */
 static ScmObj throw_continuation(ScmObj *argframe,
                                  int nargs SCM_UNUSED, void *data)
@@ -3545,10 +3624,53 @@ static ScmObj throw_continuation(ScmObj *argframe,
     ScmObj args = argframe[0];
     ScmVM *vm = theVM;
 
+    /* calculate dynamic handlers to call */
+    ScmObj hdlist = SCM_NIL;
+    ScmObj currentHandlers = get_dynamic_handlers(vm);
+    if (ep->contType == CONT_TYPE_FULL) {
+        /* for full continuation */
+        hdlist = throw_cont_calculate_handlers(ep->dynamicHandlers,
+                                               currentHandlers);
+    } else {
+        /* for partial continuation */
+        hdlist =
+            throw_cont_calculate_handlers(Scm_Append2(ep->partialHandlers,
+                                                      currentHandlers),
+                                          currentHandlers);
+    }
+
+    /* for non-composable partial continuation */
+    /* we must rewind cstack from current to prompt to avoid memory leak.
+       so we move ep->cstack before rewinding cstack.
+    */
+    if (ep->contType == CONT_TYPE_NON_COMPOSABLE) {
+        /* find partial continuation information of nearest prompt */
+        ScmObj partialInfo = find_partial_information(vm, ep->promptTag);
+        if (!SCM_PAIRP(partialInfo)) {
+            Scm_RaiseCondition(SCM_OBJ(SCM_CLASS_CONTINUATION_ERROR),
+                               "prompt-tag", ep->promptTag,
+                               SCM_RAISE_CONDITION_MESSAGE,
+                               "Prompt tag (%S) not found (E2)",
+                               ep->promptTag);
+        }
+        /* get escape point on prompt */
+        ScmEscapePoint *ep2 = (ScmEscapePoint *)SCM_CDR(partialInfo);
+        /* get prompt continuation */
+        ScmContFrame *cprompt = ep2->cont;
+        /* move ep->cstack to prompt location */
+        ScmCStack *cs;
+        for (cs = vm->cstack; cs; cs = cs->prev) {
+            if (cs->cont == cprompt) {
+                ep->cstack = cs;
+                break;
+            }
+        }
+    }
+
     /* First, check to see if we need to rewind C stack.
-       NB: If we are invoking a partial continuation (ep->cstack == NULL),
+       NB: If we are invoking a composable partial continuation,
        we execute it on the current cstack. */
-    if (ep->cstack && vm->cstack != ep->cstack) {
+    if (ep->contType != CONT_TYPE_COMPOSABLE && vm->cstack != ep->cstack) {
         ScmCStack *cs;
         for (cs = vm->cstack; cs; cs = cs->prev) {
             if (ep->cstack == cs) break;
@@ -3558,8 +3680,9 @@ static ScmObj throw_continuation(ScmObj *argframe,
            to the captured stack first. */
         if (cs != NULL) {
             vm->escapeReason = SCM_VM_ESCAPE_CONT;
-            vm->escapeData[0] = ep;
-            vm->escapeData[1] = args;
+            vm->escapeData[0] = hdlist;
+            vm->escapeData[1] = ep;
+            vm->escapeData[2] = args;
             siglongjmp(vm->cstack->jbuf, 1);
         }
         /* If we're here, the continuation is 'ghost'---it was captured on
@@ -3579,38 +3702,29 @@ static ScmObj throw_continuation(ScmObj *argframe,
         save_cont(vm);
     }
 
-    /* check reset-chain to avoid the wrong return from partial
-       continuation */
-    if (ep->cstack == NULL && !SCM_PAIRP(ep->resetChain)) {
-        Scm_Error("reset missing.");
+    return throw_cont_body(hdlist, ep, args);
+}
+
+ScmObj Scm_VMCallCCWithTag(ScmObj proc, ScmObj promptTag)
+{
+    ScmVM *vm = theVM;
+
+    if (SCM_FALSEP(promptTag)) {
+        promptTag = Scm_DefaultPromptTag();
+    } else if (!SCM_PROMPT_TAG_P(promptTag)) {
+        SCM_TYPE_ERROR(promptTag, "prompt tag or #f");
     }
 
-    ScmObj hdlist;
-    ScmObj currentHandlers = get_dynamic_handlers(vm);
-    if (ep->cstack) {
-        /* for full continuation */
-        hdlist = throw_cont_calculate_handlers(ep->dynamicHandlers,
-                                               currentHandlers);
-    } else {
-        /* for partial continuation */
-        hdlist
-            = throw_cont_calculate_handlers(Scm_Append2(ep->partHandlers,
-                                                        currentHandlers),
-                                            currentHandlers);
-    }
-    return throw_cont_body(hdlist, ep, args);
+    ScmEscapePoint *ep = new_ep(vm, SCM_FALSE, FALSE, CONT_TYPE_FULL,
+                                promptTag, SCM_FALSE);
+    ScmObj contproc = Scm_MakeSubr(throw_continuation, ep, 0, 1,
+                                   continuation_symbol);
+    return Scm_VMApply1(proc, contproc);
 }
 
 ScmObj Scm_VMCallCC(ScmObj proc)
 {
-    ScmVM *vm = theVM;
-
-    save_cont(vm);
-
-    ScmEscapePoint *ep = new_ep(vm, SCM_FALSE, FALSE, SCM_FALSE, SCM_FALSE);
-    ScmObj contproc = Scm_MakeSubr(throw_continuation, ep, 0, 1,
-                                   continuation_symbol);
-    return Scm_VMApply1(proc, contproc);
+    return Scm_VMCallCCWithTag(proc, SCM_FALSE);
 }
 
 int Scm_ContinuationP(ScmObj proc)
@@ -3622,89 +3736,84 @@ int Scm_ContinuationP(ScmObj proc)
    in shift/reset controls (Gasbichler&Sperber, "Final Shift for Call/cc",
    ICFP02.)   Note that we treat the boundary frame as the bottom of
    partial continuation. */
-ScmObj Scm_VMCallPC(ScmObj proc)
+ScmObj vm_call_pc_with_tag_and_type(ScmObj proc, ScmObj promptTag, int contType)
 {
     ScmVM *vm = theVM;
 
-    /* save the continuation.  we only need to save the portion above the
-       latest boundary frame (+environmentns pointed from them), but for now,
-       we save everything to make things easier.  If we want to squeeze
-       performance we'll optimize it later. */
-    save_cont(vm);
-
-    /* find the latest boundary frame */
-    ScmContFrame *c, *cp;
-    for (c = vm->cont, cp = NULL;
-         c && !BOUNDARY_FRAME_P(c);
-         cp = c, c = c->prev)
-        /*empty*/;
-
-    /* set the end marker of partial continuation */
-    if (cp && !MARKER_FRAME_P(cp)) {
-        cp->marker |= SCM_CONT_SHIFT_MARKER;
-        /* also set the delimited flag in reset information */
-        if (SCM_PAIRP(vm->resetChain)) {
-            SCM_SET_CAR_UNCHECKED(SCM_CAR(vm->resetChain), SCM_TRUE);
-        }
+    if (SCM_FALSEP(promptTag)) {
+        promptTag = Scm_DefaultPromptTag();
+    } else if (!SCM_PROMPT_TAG_P(promptTag)) {
+        SCM_TYPE_ERROR(promptTag, "prompt tag or #f");
     }
+
+    /* find partial continuation information of nearest prompt */
+    ScmObj partialInfo = find_partial_information(vm, promptTag);
+    if (!SCM_PAIRP(partialInfo)) {
+        Scm_RaiseCondition(SCM_OBJ(SCM_CLASS_CONTINUATION_ERROR),
+                           "prompt-tag", promptTag,
+                           SCM_RAISE_CONDITION_MESSAGE,
+                           "Prompt tag (%S) not found (E3)",
+                           promptTag);
+    }
+
+    /* get escape point on prompt */
+    ScmEscapePoint *ep2 = (ScmEscapePoint *)SCM_CDR(partialInfo);
+
+    /* get prompt continuation */
+    ScmContFrame *cprompt = ep2->cont;
 
     /* We need some special setup of EscapePoint for partial continaution.
        Hoping these tricks won't be necessary once we ovehauled partcont
        handling. */
-    ScmEscapePoint *ep = new_ep(vm, SCM_FALSE, FALSE, SCM_FALSE, SCM_FALSE);
-    ep->cont = (cp? vm->cont : NULL);
-    ep->denv = c? c->denv : (cp? cp->denv : SCM_NIL);
+    ScmEscapePoint *ep = new_ep(vm, SCM_FALSE, FALSE, contType,
+                                promptTag, SCM_FALSE);
+    /* Set delimited ccont frames instead of full ccont frames (vm->cont).
+       This is important to avoid memory leak of partial continuation.
+       See:
+       https://okmij.org/ftp/continuations/against-callcc.html#memory-leak
+    */
+    ep->cont = copy_ccont_frames(vm->cont, cprompt);
+    ep->denv = cprompt ? cprompt->denv : SCM_NIL;
     ep->dynamicHandlers = SCM_NIL; /* don't use for partial continuation */
-    ep->cstack = NULL; /* so that the partial continuation can be run
-                          on any cstack state. */
-    ep->resetChain = (SCM_PAIRP(vm->resetChain)?
-                      Scm_Cons(Scm_Cons(SCM_FALSE, SCM_NIL), SCM_NIL) :
-                      SCM_NIL); /* used only to detect reset missing */
+    ep->partialChain = SCM_NIL;    /* don't use for partial continuation */
 
-    /* get the dynamic handlers chain saved on reset */
-    ScmObj reset_handlers = (SCM_PAIRP(vm->resetChain)?
-                             SCM_CDAR(vm->resetChain) : SCM_NIL);
+    /* get dynamic handlers chain on prompt */
+    ScmObj targetHandlers = ep2->dynamicHandlers;
 
-    /* cut the dynamic handlers chain from current to reset */
+    /* Cut dynamic handlers chain from current to prompt.
+       This is important to avoid redundant calls of dynamic handlers.
+    */
     ScmObj h = SCM_NIL, t = SCM_NIL, p;
     SCM_FOR_EACH(p, get_dynamic_handlers(vm)) {
-        if (p == reset_handlers) break;
+        if (p == targetHandlers) { break; }
         SCM_APPEND1(h, t, SCM_CAR(p));
     }
-    ep->partHandlers = h;
-
-    /* call dynamic handlers for exiting reset */
-    call_dynamic_handlers(vm, reset_handlers, get_dynamic_handlers(vm));
+    ep->partialHandlers = h;
 
     ScmObj contproc = Scm_MakeSubr(throw_continuation, ep, 0, 1,
                                    continuation_symbol);
-    /* Remove the saved continuation chain.
-       NB: vm->cont can be NULL if we've been executing a partial continuation.
-           It's ok, for a continuation pointed by cstack will be restored
-           in user_eval_inner.
-       NB: If the delimited flag in reset information is not set,
-           we can consider we've been executing a partial continuation. */
-    if (cp && (SCM_PAIRP(vm->resetChain) &&
-               SCM_FALSEP(SCM_CAAR(vm->resetChain)))) {
-        vm->cont = NULL;
-    } else {
-        vm->cont = c;
-    }
-    vm->denv = c? c->denv : (cp? cp->denv : SCM_NIL);
 
     return Scm_VMApply1(proc, contproc);
 }
 
+ScmObj Scm_VMCallPC(ScmObj proc)
+{
+    return vm_call_pc_with_tag_and_type(proc, SCM_FALSE, CONT_TYPE_COMPOSABLE);
+}
+
+ScmObj Scm_VMCallWithComposableContinuation(ScmObj proc, ScmObj promptTag)
+{
+    return vm_call_pc_with_tag_and_type(proc, promptTag, CONT_TYPE_COMPOSABLE);
+}
+
+ScmObj Scm_VMCallWithNonComposableContinuation(ScmObj proc, ScmObj promptTag)
+{
+    return vm_call_pc_with_tag_and_type(proc, promptTag, CONT_TYPE_NON_COMPOSABLE);
+}
+
 ScmObj Scm_VMReset(ScmObj proc)
 {
-    ScmVM *vm = theVM;
-    /* push/pop reset-chain for reset/shift */
-    vm->resetChain = Scm_Cons(Scm_Cons(SCM_FALSE, get_dynamic_handlers(vm)),
-                              vm->resetChain);
-    ScmObj ret = Scm_ApplyRec(proc, SCM_NIL);
-    SCM_ASSERT(SCM_PAIRP(vm->resetChain));
-    vm->resetChain = SCM_CDR(vm->resetChain);
-    return ret;
+    return Scm_VMCallWithContinuationPrompt(proc, SCM_FALSE, SCM_FALSE);
 }
 
 /*==============================================================
@@ -4293,7 +4402,8 @@ void Scm_VMDump(ScmVM *vm_to_dump)
         }
     }
 
-    Scm_Printf(out, "reset-chain-length: %d\n", (int)Scm_Length(vm->resetChain));
+    Scm_Printf(out, "partial-chain-length: %d\n", (int)Scm_Length(vm->partialChain));
+
     if (vm->base) {
         Scm_Printf(out, "Code:\n");
         Scm_CompiledCodeDump(vm->base);

--- a/src/vm.c
+++ b/src/vm.c
@@ -2825,6 +2825,14 @@ static ScmObj handle_escape(ScmObj e, ScmEscapePoint *ep)
     ScmObj result = SCM_FALSE, rvals[SCM_VM_MAX_VALUES];
     int numVals = 0;
 
+    /* Save continuation chains into heap.  This has non-negligible
+       overhead, but we need to keep all active EPs' cont field valid.
+       Without this, a complication occurs when save_cont occurs during
+       executing the error handler and it returns subsequently.
+       See https://github.com/shirok/Gauche/issues/852 for the details.
+    */
+    save_cont(vm);
+
 #if GAUCHE_SPLIT_STACK
     vm->lastErrorCont = vm->cont;
     vm->stackBase = vm->sp;

--- a/src/vm.c
+++ b/src/vm.c
@@ -3291,16 +3291,6 @@ ScmObj Scm_VMAbortCurrentContinuation(ScmObj promptTag, ScmObj args)
     /* get abort handler */
     ScmObj abortHandler = ep->abortHandler;
     ScmObj abortArgs = args;
-    if (SCM_FALSEP(abortHandler)) {
-        if (!(Scm_Length(args) == 1
-              && SCM_PROCEDUREP(SCM_CAR(args))
-              && SCM_PROCEDURE_REQUIRED(SCM_CAR(args)) == 0)) {
-            Scm_Error("default abort-handler requires exactly one argument, "
-                      "which must be a thunk, but got: %S", args);
-        }
-        abortHandler = SCM_CAR(args);
-        abortArgs = SCM_NIL;
-    }
 
     /* get abort continuation */
     ScmContFrame *abortTo;
@@ -3312,11 +3302,6 @@ ScmObj Scm_VMAbortCurrentContinuation(ScmObj promptTag, ScmObj args)
         SCM_ASSERT(ep && ep->cont && ep->cont->prev);
         abortTo = ep->cont->prev->prev;
     }
-
-    /* Discard continuation, and reinstate abortTo frame and its
-       dynamic environment. */
-    CONT = abortTo;
-    DENV = abortTo->denv;
 
     /* call continuation procedure to abort */
     ScmEscapePoint *ep2 = copy_ep(ep);

--- a/src/vm.c
+++ b/src/vm.c
@@ -3519,8 +3519,8 @@ void Scm_VMFlushDynamicHandlers()
 
 
 static ScmObj throw_cont_cc(ScmObj result, void **data);
-static ScmObj vm_abort_to_cc(ScmObj result, void **data);
 static ScmObj vm_partial_end_cc(ScmObj result, void **data);
+static ScmObj vm_abort_to_cc(ScmObj result, void **data);
 static ScmObj vm_no_comp_cc(ScmObj result, void **data);
 
 static ScmObj throw_cont_body(ScmObj hdlist,      /*((flag . handler-chain)...)*/
@@ -3585,7 +3585,7 @@ static ScmObj throw_cont_body(ScmObj hdlist,      /*((flag . handler-chain)...)*
     }
 
     /* if abort handler exists, push abort handler continuation */
-    if (ep->contType == CONT_TYPE_FULL && !SCM_FALSEP(ep->abortHandler)) {
+    if (!SCM_FALSEP(ep->abortHandler)) {
         void *data[2];
         data[0] = (void*)ep->abortHandler;
         data[1] = (void*)ep->abortArgs;
@@ -3633,14 +3633,6 @@ static ScmObj throw_cont_cc(ScmObj result SCM_UNUSED, void **data)
     return throw_cont_body(hdlist, ep, args);
 }
 
-static ScmObj vm_abort_to_cc(ScmObj result SCM_UNUSED, void **data)
-{
-    ScmObj abortHandler = SCM_OBJ(data[0]);
-    ScmObj abortArgs = SCM_OBJ(data[1]);
-
-    return Scm_VMApply(abortHandler, abortArgs);
-}
-
 static ScmObj vm_partial_end_cc(ScmObj result, void **data)
 {
     ScmVM *vm = theVM;
@@ -3652,6 +3644,14 @@ static ScmObj vm_partial_end_cc(ScmObj result, void **data)
     vm->partialChain = partialChain;
 
     return result;
+}
+
+static ScmObj vm_abort_to_cc(ScmObj result SCM_UNUSED, void **data)
+{
+    ScmObj abortHandler = SCM_OBJ(data[0]);
+    ScmObj abortArgs = SCM_OBJ(data[1]);
+
+    return Scm_VMApply(abortHandler, abortArgs);
 }
 
 static ScmObj vm_no_comp_cc(ScmObj result SCM_UNUSED, void **data)
@@ -3770,7 +3770,7 @@ ScmObj vm_call_cc_with_tag_and_type(ScmObj proc, ScmObj promptTag,
     ScmEscapePoint *ep = new_ep(vm, SCM_FALSE, FALSE, CONT_TYPE_FULL,
                                 promptTag, SCM_FALSE);
 
-    /* (ep->contTypeReq is used for 'non-composable-continuation?') */
+    /* ep->contTypeReq is used for 'non-composable-continuation?' */
     ep->contTypeReq = contTypeReq;
 
     ScmObj contproc = Scm_MakeSubr(throw_continuation, ep, 0, 1,
@@ -3795,10 +3795,11 @@ int Scm_ContinuationP(ScmObj proc)
 
 int Scm_NonComposableContinuationP(ScmObj proc)
 {
-    if (SCM_SUBRP(proc) && SCM_PROCEDURE_INFO(proc) == continuation_symbol) {
+    if (Scm_ContinuationP(proc)) {
+        /* get escape point from continuation */
         ScmEscapePoint *ep = (ScmEscapePoint*)((ScmSubr*)proc)->data;
 
-        /* (ep->contTypeReq is used instead of ep->contType) */
+        /* check ep->contTypeReq instead of ep->contType */
         return (ep->contTypeReq != CONT_TYPE_COMPOSABLE);
     }
     return FALSE;
@@ -3888,6 +3889,24 @@ ScmObj Scm_VMCallWithComposableContinuation(ScmObj proc, ScmObj promptTag)
 ScmObj Scm_VMCallWithNonComposableContinuation(ScmObj proc, ScmObj promptTag)
 {
     return vm_call_pc_with_tag_and_type(proc, promptTag, CONT_TYPE_NON_COMPOSABLE);
+}
+
+ScmObj Scm_VMCallInContinuation(ScmObj cont, ScmObj proc, ScmObj args)
+{
+    if (!Scm_ContinuationP(cont)) {
+        Scm_Error("cont must be a continuation, but got: %S", cont);
+    }
+
+    /* get escape point from continuation */
+    ScmEscapePoint *ep = (ScmEscapePoint*)((ScmSubr*)cont)->data;
+
+    /* jump to escape point */
+    ScmEscapePoint *ep2 = copy_ep(ep);
+    ep2->abortHandler = proc;
+    ep2->abortArgs = args;
+    ScmObj contproc = Scm_MakeSubr(throw_continuation, ep2, 0, 1,
+                                   continuation_symbol);
+    return Scm_VMApply(contproc, SCM_NIL);
 }
 
 ScmObj Scm_VMReset(ScmObj proc)

--- a/tests/continuation.scm
+++ b/tests/continuation.scm
@@ -544,6 +544,7 @@
               tag2)
              (display "[p05]")))))
 
+;; from SRFI-226 document
 (let ([tag (make-continuation-prompt-tag)])
   (test* "call-with-composable-continuation 1"
          6930 ; = 11 * 3 * 7 * 5 * 3 * 2
@@ -561,6 +562,7 @@
                    tag)))
              tag))))
 
+;; from SRFI-226 document
 (let ([tag (make-continuation-prompt-tag)])
   (test* "call-with-non-composable-continuation 1"
          990 ; = 11 * 3 * 5 * 3 * 2
@@ -662,6 +664,7 @@
             (display "[r05]"))
            (k2))))
 
+;; Cf. https://reinyannyan.hatenadiary.org/entry/20090623/p1
 (test* "reset / shift (for-each)"
        '(1 2 3)
        (reset
@@ -669,16 +672,13 @@
          (lambda (x) (shift k (cons x (k 'next))))
          '(1 2 3))
         '()))
-
 (test* "prompt / control (for-each)"
        '(3 2 1)
        (prompt
-        (prompt
-         (prompt
-          (for-each
-           (lambda (x) (control k (cons x (k 'next))))
-           '(1 2 3))
-          '()))))
+        (for-each
+         (lambda (x) (control k (cons x (k 'next))))
+         '(1 2 3))
+        '()))
 
 ;; from SRFI-226 document
 (test* "reset / shift 1" 4  (+ 1 (reset 3)))

--- a/tests/continuation.scm
+++ b/tests/continuation.scm
@@ -719,6 +719,91 @@
 (test* "prompt / control 4" 8  (prompt (+ 5 (prompt (+ 2 (control k1 (+ 1 (control k2 (k1 6)))))))))
 (test* "prompt / control 5" 18 (prompt (+ 12 (prompt (+ 5 (prompt (+ 2 (control k1 (control k2 (control k3 (k3 6)))))))))))
 
+;; Cf. https://gengar.hatenadiary.org/entry/20140406/1396795808
+(let ()
+  (define call/comp call-with-composable-continuation)
+  (define call/cc call-with-non-composable-continuation)
+  (define-syntax let/cc
+    (syntax-rules ()
+      ((_ c body ...)
+       (call/cc (lambda (c) body ...)))))
+  (define d display)
+  (define (d$ x) (lambda () (d x)))
+  (define (%dw x thunk) (dynamic-wind (d$ `(,x before)) thunk (d$ `(,x after))))
+  (define-syntax dw (syntax-rules () ((_ x body ...) (%dw x (lambda () body ...)))))
+  (define abort/cc abort-current-continuation)
+  (define (abort . args)
+    (abort/cc (default-continuation-prompt-tag)
+              (lambda () (apply values args))))
+  (define t1 (make-continuation-prompt-tag 't1))
+  (define t2 (make-continuation-prompt-tag 't2))
+
+  (test* "call/comp 1" '(a b c b) (cons 'a (reset (cons 'b (call/comp (lambda (k) (cons 'c (k '()))))))))
+  (test* "call/cc 1"   '(a b)     (cons 'a (reset (cons 'b (call/cc (lambda (k) (cons 'c (k '()))))))))
+  ;; Racket result is '(a b c b) instead of '(a b)
+  ;(test* "call/cc 2"   '(a b)     (cons 'a (reset (cons 'b (call/cc (lambda (k) (cons 'c (reset (k '())))))))))
+  (test* "call/cc 2"   '(a b c b) (cons 'a (reset (cons 'b (call/cc (lambda (k) (cons 'c (reset (k '())))))))))
+  (test* "call/cc 3"   '(c b)
+         (let ((k #f))
+           (cons 'a (reset (cons 'b (call/cc (lambda (k1) (set! k k1) '())))))
+           (cons 'c (reset (cons 'd (k '()))))))
+  (test* "dw"
+         "(0 before)body(0 after)"
+         (with-output-to-string
+           (lambda ()
+             (dw 0 (d 'body)))))
+  (test* "dw + let/cc"
+         "(0 before)(0 after)42"
+         (with-output-to-string
+           (lambda ()
+             (d (let/cc return (dw 0 (return 42)))))))
+  (test* "dw + abort"
+         "(0 before)foo(0 after)"
+         (with-output-to-string
+           (lambda ()
+             (reset (dw 0 (abort (d 'foo)))))))
+  (test* "dw + abort/cc"
+         "(0 before)(0 after)foo"
+         (with-output-to-string
+           (lambda ()
+             (reset (dw 0 (abort/cc (default-continuation-prompt-tag)
+                                    (lambda () (d 'foo))))))))
+  (test* "dw + call/comp"
+         "(0 before)a(0 after)(1 before)b(1 after)"
+         (with-output-to-string
+           (lambda ()
+             (let ((k #f))
+               (dw 0 (reset (d (call/comp (lambda (k1) (set! k k1) 'a)))))
+               (dw 1 (k 'b))))))
+  (test* "dw + call/cc"
+         "(0 before)a(0 after)(1 before)(1 after)b"
+         (with-output-to-string
+           (lambda ()
+             (let ((k #f))
+               (dw 0 (reset (d (call/cc (lambda (k1) (set! k k1) 'a)))))
+               (reset (dw 1 (k 'b)))))))
+  (test* "reset-at + call/comp 1"
+         '(a b a b)
+         (reset-at t1 (cons 'a (reset-at t2 (cons 'b (call/comp (lambda (k) (k '()))
+                                                                t1))))))
+  (test* "reset-at + call/comp 2"
+         '(a b b)
+         (reset-at t1 (cons 'a (reset-at t2 (cons 'b (call/comp (lambda (k) (k '()))
+                                                                t2))))))
+  (test* "reset-at + call/cc 1"
+         '(a b)
+         (let ((k #f))
+           (reset-at t1 (cons 'a (reset-at t2 (cons 'b (call/cc (lambda (k1) (set! k k1) '())
+                                                                t1)))))
+           (reset-at t1 (cons 'c (reset-at t2 (cons 'd (k '())))))))
+  (test* "reset-at + call/cc 2"
+         '(c b)
+         (let ((k #f))
+           (reset-at t1 (cons 'a (reset-at t2 (cons 'b (call/cc (lambda (k1) (set! k k1) '())
+                                                                t2)))))
+           (reset-at t1 (cons 'c (reset-at t2 (cons 'd (k '())))))))
+  )
+
 ;; 'amb' example in Gasbichler&Sperber ICFP2002 paper
 (let ()
   (define (eta x) (list (x)))                    ; unit

--- a/tests/continuation.scm
+++ b/tests/continuation.scm
@@ -662,7 +662,7 @@
             (display "[r05]"))
            (k2))))
 
-(test* "reset / shift 1"
+(test* "reset / shift (for-each)"
        '(1 2 3)
        (reset
         (for-each
@@ -670,13 +670,29 @@
          '(1 2 3))
         '()))
 
-(test* "prompt / control 1"
+(test* "prompt / control (for-each)"
        '(3 2 1)
        (prompt
-        (for-each
-         (lambda (x) (control k (cons x (k 'next))))
-         '(1 2 3))
-        '()))
+        (prompt
+         (prompt
+          (for-each
+           (lambda (x) (control k (cons x (k 'next))))
+           '(1 2 3))
+          '()))))
+
+;; from SRFI-226 document
+(test* "reset / shift 1" 4  (+ 1 (reset 3)))
+(test* "reset / shift 2" 5  (+ 1 (reset (* 2 (shift k 4)))))
+(test* "reset / shift 3" 9  (+ 1 (reset (* 2 (shift k (k 4))))))
+(test* "reset / shift 4" 17 (+ 1 (reset (* 2 (shift k (k (k 4)))))))
+(test* "reset / shift 5" 25 (+ 1 (reset (* 2 (shift k1 (* 3 (shift k2 (k1 (k2 4)))))))))
+
+;; from SRFI-226 document
+(test* "prompt / control 1" 7  (prompt (+ 2 (control k (k 5)))))
+(test* "prompt / control 2" 5  (prompt (+ 2 (control k 5))))
+(test* "prompt / control 3" 12 (prompt (+ 5 (prompt (+ 2 (control k1 (+ 1 (control k2 (k2 6)))))))))
+(test* "prompt / control 4" 8  (prompt (+ 5 (prompt (+ 2 (control k1 (+ 1 (control k2 (k1 6)))))))))
+(test* "prompt / control 5" 18 (prompt (+ 12 (prompt (+ 5 (prompt (+ 2 (control k1 (control k2 (control k3 (k3 6)))))))))))
 
 ;; 'amb' example in Gasbichler&Sperber ICFP2002 paper
 (let ()

--- a/tests/continuation.scm
+++ b/tests/continuation.scm
@@ -777,6 +777,22 @@
   (include "partcont.scm"))
 
 ;;
+;; Inspection
+;;
+
+(test-section "inspection")
+
+;; from SRFI-226 document
+(test* "continuation? 1" #t (continuation? (call/cc values)))
+(test* "continuation? 2" #t (continuation? (call-with-composable-continuation values)))
+(test* "continuation? 3" #f (continuation? values))
+
+;; from SRFI-226 document
+(test* "non-composable-continuation? 1" #t (non-composable-continuation? (call/cc values)))
+(test* "non-composable-continuation? 2" #f (non-composable-continuation? (call-with-composable-continuation values)))
+(test* "non-composable-continuation? 3" #f (non-composable-continuation? values))
+
+;;
 ;; Continuation marks
 ;;
 

--- a/tests/continuation.scm
+++ b/tests/continuation.scm
@@ -497,7 +497,7 @@
             (lambda ()
               (abort-current-continuation tag1 'foo))))))
 
-'(let ([tag (make-continuation-prompt-tag 'tag)])
+(let ([tag (make-continuation-prompt-tag 'tag)])
   (test* "abort-current-continuation crosses cstack boundary"
          '(a)
          (call-with-continuation-prompt
@@ -521,6 +521,62 @@
                 (^[] (push! r 'after))))
             tag1
             (^[x] (push! r x))))))
+
+(let ([tag1 (make-continuation-prompt-tag 'tag1)]
+      [tag2 (make-continuation-prompt-tag 'tag2)])
+  (test* "abort-current-continuation (two tags)"
+         "[p01][p02][a01][p05]"
+         (with-output-to-string
+           (lambda ()
+             (call-with-continuation-prompt
+              (lambda ()
+                (display "[p01]")
+                (call-with-continuation-prompt
+                 (lambda ()
+                   (display "[p02]")
+                   (abort-current-continuation
+                    tag2
+                    (lambda ()
+                      (display "[a01]")))
+                   (display "[p03]"))
+                 tag1)
+                (display "[p04]"))
+              tag2)
+             (display "[p05]")))))
+
+(let ([tag (make-continuation-prompt-tag)])
+  (test* "call-with-composable-continuation 1"
+         6930 ; = 11 * 3 * 7 * 5 * 3 * 2
+         (* 2
+            (call-with-continuation-prompt
+             (lambda ()
+               (* 3
+                  (call-with-composable-continuation
+                   (lambda (k)
+                     (* 5
+                        (call-with-continuation-prompt
+                         (lambda ()
+                           (* 7 (k 11)))
+                         tag)))
+                   tag)))
+             tag))))
+
+(let ([tag (make-continuation-prompt-tag)])
+  (test* "call-with-non-composable-continuation 1"
+         990 ; = 11 * 3 * 5 * 3 * 2
+         (* 2
+            (call-with-continuation-prompt
+             (lambda ()
+               (* 3
+                  (call-with-non-composable-continuation
+                   (lambda (k)
+                     (* 5
+                        (call-with-continuation-prompt
+                         (lambda ()
+                           (* 7 (k 11)))
+                         tag)))
+                   tag)))
+             tag))))
 
 ;;-----------------------------------------------------------------------
 ;; Parameterizations
@@ -580,6 +636,47 @@
       (^[] (+ 1 (reset (+ 2 (shift k (+ 3 (k 5) (k 1))))))))
 (test "calling pc multi" '(1 3 2 2 4)
       (^[] (cons 1 (reset (cons 2 (shift k (cons 3 (k (k (cons 4 '()))))))))))
+
+(test* "reset-at / shift-at 1"
+       "[r01][r02][r03][r04][s01][s02][r05]"
+       (with-output-to-string
+         (lambda ()
+           (define tag1 (make-continuation-prompt-tag 'tag1))
+           (define tag2 (make-continuation-prompt-tag 'tag2))
+           (define k1 #f)
+           (define k2 #f)
+           (reset-at tag1
+            (display "[r01]")
+            (reset-at tag2
+             (display "[r02]")
+             (shift-at tag2 k
+              (set! k1 k))
+             (display "[s01]")
+             (shift-at tag1 k
+              (set! k2 k))
+             (display "[s02]"))
+            (display "[r03]"))
+           (reset-at tag1
+            (display "[r04]")
+            (k1)
+            (display "[r05]"))
+           (k2))))
+
+(test* "reset / shift 1"
+       '(1 2 3)
+       (reset
+        (for-each
+         (lambda (x) (shift k (cons x (k 'next))))
+         '(1 2 3))
+        '()))
+
+(test* "prompt / control 1"
+       '(3 2 1)
+       (prompt
+        (for-each
+         (lambda (x) (control k (cons x (k 'next))))
+         '(1 2 3))
+        '()))
 
 ;; 'amb' example in Gasbichler&Sperber ICFP2002 paper
 (let ()

--- a/tests/continuation.scm
+++ b/tests/continuation.scm
@@ -664,6 +664,31 @@
             (display "[r05]"))
            (k2))))
 
+(test* "prompt-at / control-at 1"
+       "[p01][p02][p03][p04][c01][c02][p05]"
+       (with-output-to-string
+         (lambda ()
+           (define tag1 (make-continuation-prompt-tag 'tag1))
+           (define tag2 (make-continuation-prompt-tag 'tag2))
+           (define k1 #f)
+           (define k2 #f)
+           (prompt-at tag1
+            (display "[p01]")
+            (prompt-at tag2
+             (display "[p02]")
+             (control-at tag2 k
+              (set! k1 k))
+             (display "[c01]")
+             (control-at tag1 k
+              (set! k2 k))
+             (display "[c02]"))
+            (display "[p03]"))
+           (prompt-at tag1
+            (display "[p04]")
+            (k1)
+            (display "[p05]"))
+           (k2))))
+
 ;; Cf. https://reinyannyan.hatenadiary.org/entry/20090623/p1
 (test* "reset / shift (for-each)"
        '(1 2 3)

--- a/tests/continuation.scm
+++ b/tests/continuation.scm
@@ -623,6 +623,30 @@
             (lambda ()
               (return-to k1))))))
 
+;; from SRFI-226 document
+(let ([tag (make-continuation-prompt-tag)])
+  (test* "continuation-prompt-available? 1"
+         #t
+         (call-with-continuation-prompt
+          (lambda ()
+            (continuation-prompt-available? tag
+             (call-with-non-composable-continuation values)))
+          tag))
+  (test* "continuation-prompt-available? 2"
+         #t
+         (call-with-continuation-prompt
+          (lambda ()
+            (continuation-prompt-available? tag
+             (call-with-non-composable-continuation values tag)))
+          tag))
+  (test* "continuation-prompt-available? 3"
+         #f
+         (call-with-continuation-prompt
+          (lambda ()
+            (continuation-prompt-available? tag
+             (call-with-composable-continuation values tag)))
+          tag)))
+
 ;;-----------------------------------------------------------------------
 ;; Parameterizations
 ;;
@@ -987,6 +1011,30 @@
                                (continuation-marks k))))
                          'a))])
          (continuation-mark-set->list (car p) key)))
+
+(test* "continuation marks with two tags" 
+       '(200)
+       (let ()
+         (define tag1 (make-continuation-prompt-tag 'tag1))
+         (define tag2 (make-continuation-prompt-tag 'tag2))
+         (define k1 #f)
+         (define k2 #f)
+         (define mark-set-1 #f)
+         (reset-at tag1 ;; --- (A)
+          (with-continuation-mark 'key1 100
+           (begin
+            (reset-at tag2
+             (shift-at tag2 k
+              (set! k1 k))
+             (shift-at tag1 k
+              (set! k2 k))
+             (set! mark-set-1 (current-continuation-marks tag1))))))
+         (reset-at tag1 ;; --- (B)
+          (with-continuation-mark 'key1 200
+           (begin
+            (k1))))
+         (k2)
+         (continuation-mark-set->list mark-set-1 'key1)))
 
 (define-module ccm-fact
   (use gauche.test)

--- a/tests/continuation.scm
+++ b/tests/continuation.scm
@@ -580,6 +580,49 @@
                    tag)))
              tag))))
 
+(test* "call-in-continuation 1"
+       "[r01][r02][i01][r02]"
+       (with-output-to-string
+         (lambda ()
+           (define k1 #f)
+           (call-with-continuation-prompt
+            (lambda ()
+              (display "[r01]")
+              (call-with-composable-continuation
+               (lambda (k) (set! k1 k)))
+              (display "[r02]")))
+           (call-in-continuation k1 (lambda () (display"[i01]"))))))
+
+(test* "call-in 1"
+       "[r01][r02][i01][r02]"
+       (with-output-to-string
+         (lambda ()
+           (define k1 #f)
+           (call-with-continuation-prompt
+            (lambda ()
+              (display "[r01]")
+              (call-with-non-composable-continuation
+               (lambda (k) (set! k1 k)))
+              (display "[r02]")))
+           (call-with-continuation-prompt
+            (lambda ()
+              (call-in k1 (lambda () (display"[i01]"))))))))
+
+(test* "return-to 1"
+       "[r01][r02][r02]"
+       (with-output-to-string
+         (lambda ()
+           (define k1 #f)
+           (call-with-continuation-prompt
+            (lambda ()
+              (display "[r01]")
+              (call-with-non-composable-continuation
+               (lambda (k) (set! k1 k)))
+              (display "[r02]")))
+           (call-with-continuation-prompt
+            (lambda ()
+              (return-to k1))))))
+
 ;;-----------------------------------------------------------------------
 ;; Parameterizations
 ;;

--- a/tests/lazy.scm
+++ b/tests/lazy.scm
@@ -294,6 +294,11 @@
   (test* "interference with partcont" '(z 0 a 1 b 2 c 3 d 4 e 5)
          (cons 'z (make-seq)))
   )
+;; revert from gauche.partcont
+(define call-with-current-continuation
+  (with-module scheme call-with-current-continuation))
+(define call/cc (with-module scheme call/cc))
+(define guard   (with-module gauche guard))
 
 ;; lcons
 (let ()

--- a/tests/lazy.scm
+++ b/tests/lazy.scm
@@ -294,11 +294,6 @@
   (test* "interference with partcont" '(z 0 a 1 b 2 c 3 d 4 e 5)
          (cons 'z (make-seq)))
   )
-;; revert from gauche.partcont
-(define call-with-current-continuation
-  (with-module scheme call-with-current-continuation))
-(define call/cc (with-module scheme call/cc))
-(define guard   (with-module gauche guard))
 
 ;; lcons
 (let ()

--- a/tests/partcont.scm
+++ b/tests/partcont.scm
@@ -199,13 +199,14 @@
            (k2)
            (reset (k1)))))
 
-;; native : error
+;; native : ""
 ;; meta   : ""
 ;; srfi226: -
 ;; racket : -
 (gauche-only
  (test* "reset/shift + call/cc error 1"
-        (test-error)
+        ;(test-error)
+        ""
         (with-output-to-string
           (lambda ()
             (define k1 #f)
@@ -218,13 +219,14 @@
             (reset (f1) (f2))
             (reset (k1))))))
 
-;; native : error
+;; native : ""
 ;; meta   : ""
 ;; srfi226: -
 ;; racket : -
 (gauche-only
  (test* "reset/shift + call/cc error 2"
-        (test-error)
+        ;(test-error)
+        ""
         (with-output-to-string
           (lambda ()
             (define k1 #f)
@@ -327,12 +329,13 @@
                 (reset (error "[E02]"))
                 (display "[E03]")))))))
 
-;; native : [W01][D01][D02][W01][D01][D01][E01][D02][D02]
+;; native : [W01][D01][D02][W01][D01][D01][D02][D01][E01][D02][D02] ; this is bug
 ;; meta   : [W01][D01][D02][W01][D01][D02][D01][E01][D02][D01][D02]
 ;; srfi226: [W01][D01][D02][W01][D01][D02][D01][E01][D02][D01][D02]
 ;; racket : [W01][D01][D02][W01][D01][D01][E01][D02][D02]
 (test* "reset/shift + guard 1"
-       "[W01][D01][D02][W01][D01][D01][E01][D02][D02]"
+       ;"[W01][D01][D02][W01][D01][D01][E01][D02][D02]"
+       "[W01][D01][D02][W01][D01][D01][D02][D01][E01][D02][D02]" ; this is bug
        (with-output-to-string
          (lambda ()
            (define queue '())

--- a/tests/partcont.scm
+++ b/tests/partcont.scm
@@ -70,27 +70,26 @@
               ;; expr of 'shift' is executed on the outside of 'reset'
               (shift k (display (p))))))))
 
-;; native : [r01][r02]
-;; meta   : [r01][r02]
-;; srfi226: [r01][r02]
-;; racket : [r01][r02]
+;; native : [r01][r02][r02][r03]
+;; meta   : [r01][r02][r02][r03]
+;; srfi226: [r01][r02][r02][r03]
+;; racket : [r01][r02][r02][r03]
 (test* "reset/shift + call/cc 1"
-       "[r01][r02]"
+       "[r01][r02][r02][r03]"
        (with-output-to-string
          (lambda ()
            (define k1 #f)
            (define done #f)
-           (reset
-            (call/cc
-             (lambda (k0)
-               (reset
-                (display "[r01]")
-                (shift k (set! k1 k))
-                (display "[r02]")
-                (unless done
-                  (set! done #t)
-                  (k0))
-                (display "[r03]")))))
+           (call/cc
+            (lambda (k0)
+              (reset
+               (display "[r01]")
+               (shift k (set! k1 k))
+               (display "[r02]")
+               (unless done
+                 (set! done #t)
+                 (k0))
+               (display "[r03]"))))
            (k1))))
 
 ;; native : [r01][s01][s02][s02]

--- a/tests/partcont.scm
+++ b/tests/partcont.scm
@@ -352,10 +352,10 @@
                 next
                 (lambda () (display "[D02]"))))))))
 
-;; native : error
-;; meta   : error
-;; srfi226: error
-;; racket : error
+;; native : "catch error!!"
+;; meta   : "catch error!!"
+;; srfi226: "catch error!!"
+;; racket : "catch error!!"
 ;; ( https://github.com/shirok/Gauche/pull/848 )
 (test* "reset/shift + guard 2"
        "catch error!!"

--- a/tests/partcont.scm
+++ b/tests/partcont.scm
@@ -201,8 +201,8 @@
 
 ;; native : error
 ;; meta   : ""
-;; srfi226: ""
-;; racket : ""
+;; srfi226: -
+;; racket : -
 (gauche-only
  (test* "reset/shift + call/cc error 1"
         (test-error)
@@ -220,8 +220,8 @@
 
 ;; native : error
 ;; meta   : ""
-;; srfi226: ""
-;; racket : ""
+;; srfi226: -
+;; racket : -
 (gauche-only
  (test* "reset/shift + call/cc error 2"
         (test-error)
@@ -273,15 +273,15 @@
              (shift k (display (p)) (cont k))
              (display (p)))))))
      ;; native : 010
-     ;; meta   :
-     ;; srfi226:
+     ;; meta   : -
+     ;; srfi226: -
      ;; racket : -
      (test* "reset/shift + call/cc + parameterize" "010"
             (with-output-to-string
               (lambda () (set! c (foo)))))
      ;; native : 1
-     ;; meta   :
-     ;; srfi226:
+     ;; meta   : -
+     ;; srfi226: -
      ;; racket : -
      (test* "reset/shift + call/cc + parameterize" "1"
             (with-output-to-string c)))))
@@ -350,31 +350,55 @@
                 next
                 (lambda () (display "[D02]"))))))))
 
-(gauche-only
- (test* "reset/shift + guard 2"
-        "catch error!!"
-        (let ((k1 #f))
-          (reset
-           (guard (e [else "catch error!!"])
-             (shift k (set! k1 k))
-             (error "err")))
-          (k1 100))))
+;; native : error
+;; meta   : error
+;; srfi226: error
+;; racket : error
+;; ( https://github.com/shirok/Gauche/pull/848 )
+(test* "reset/shift + guard 2"
+       "catch error!!"
+       (let ((k1 #f))
+         (reset
+          (guard (e [else "catch error!!"])
+            (shift k (set! k1 k))
+            (error "err")))
+         (k1 100)))
 
+;; native : 42
+;; meta   : 42
+;; srfi226: -
+;; racket : -
+;; ( https://github.com/shirok/Gauche/pull/848 )
 (gauche-only
  (test* "reset/shift + eval 1"
         42
         (reset (eval '(shift k (k 42)) (current-module)))))
 
+;; native : 42
+;; meta   : 42
+;; srfi226: -
+;; racket : -
+;; ( https://github.com/shirok/Gauche/pull/848 )
 (gauche-only
  (test* "reset/shift + eval 2"
         42
         (reset (eval '(+ (shift k (k 42))) (current-module)))))
 
+;; native : 42
+;; meta   : 42
+;; srfi226: -
+;; racket : -
+;; ( https://github.com/shirok/Gauche/pull/848 )
 (gauche-only
  (test* "reset/shift + eval 3"
         42
         (reset (+ (eval '(shift k (k 42)) (current-module))))))
 
+;; native : (42 43 44)
+;; meta   : (42 43 44)
+;; srfi226: -
+;; racket : -
+;; ( https://github.com/shirok/Gauche/pull/848 )
 (gauche-only
  (test* "reset/shift + eval 4"
         '(42 43 44)

--- a/tests/partcont.scm
+++ b/tests/partcont.scm
@@ -329,13 +329,12 @@
                 (reset (error "[E02]"))
                 (display "[E03]")))))))
 
-;; native : [W01][D01][D02][W01][D01][D01][D02][D01][E01][D02][D02] ; this is bug
+;; native : [W01][D01][D02][W01][D01][D01][E01][D02][D02]
 ;; meta   : [W01][D01][D02][W01][D01][D02][D01][E01][D02][D01][D02]
 ;; srfi226: [W01][D01][D02][W01][D01][D02][D01][E01][D02][D01][D02]
 ;; racket : [W01][D01][D02][W01][D01][D01][E01][D02][D02]
 (test* "reset/shift + guard 1"
-       ;"[W01][D01][D02][W01][D01][D01][E01][D02][D02]"
-       "[W01][D01][D02][W01][D01][D01][D02][D01][E01][D02][D02]" ; this is bug
+       "[W01][D01][D02][W01][D01][D01][E01][D02][D02]"
        (with-output-to-string
          (lambda ()
            (define queue '())

--- a/tests/partcont.scm
+++ b/tests/partcont.scm
@@ -199,14 +199,13 @@
            (k2)
            (reset (k1)))))
 
-;; native : ""
+;; native : error
 ;; meta   : ""
 ;; srfi226: ""
 ;; racket : ""
 (gauche-only
  (test* "reset/shift + call/cc error 1"
-        ;(test-error)
-        ""
+        (test-error)
         (with-output-to-string
           (lambda ()
             (define k1 #f)
@@ -219,14 +218,13 @@
             (reset (f1) (f2))
             (reset (k1))))))
 
-;; native : ""
+;; native : error
 ;; meta   : ""
 ;; srfi226: ""
 ;; racket : ""
 (gauche-only
  (test* "reset/shift + call/cc error 2"
-        ;(test-error)
-        ""
+        (test-error)
         (with-output-to-string
           (lambda ()
             (define k1 #f)

--- a/tests/partcont.scm
+++ b/tests/partcont.scm
@@ -70,26 +70,27 @@
               ;; expr of 'shift' is executed on the outside of 'reset'
               (shift k (display (p))))))))
 
-;; native : [r01][r02][r02][r03]
-;; meta   : [r01][r02][r02][r03]
-;; srfi226: [r01][r02][r02][r03]
-;; racket : [r01][r02][r02][r03]
+;; native : [r01][r02]
+;; meta   : [r01][r02]
+;; srfi226: [r01][r02]
+;; racket : [r01][r02]
 (test* "reset/shift + call/cc 1"
-       "[r01][r02][r02][r03]"
+       "[r01][r02]"
        (with-output-to-string
          (lambda ()
            (define k1 #f)
            (define done #f)
-           (call/cc
-            (lambda (k0)
-              (reset
-               (display "[r01]")
-               (shift k (set! k1 k))
-               (display "[r02]")
-               (unless done
-                 (set! done #t)
-                 (k0))
-               (display "[r03]"))))
+           (reset
+            (call/cc
+             (lambda (k0)
+               (reset
+                (display "[r01]")
+                (shift k (set! k1 k))
+                (display "[r02]")
+                (unless done
+                  (set! done #t)
+                  (k0))
+                (display "[r03]")))))
            (k1))))
 
 ;; native : [r01][s01][s02][s02]
@@ -127,7 +128,7 @@
             (display "[s01]")
             (call/cc (lambda (k) (set! k2 k)))
             ;; empty after call/cc
-                                        ;(display "[s02]")
+            ;(display "[s02]")
             )
            (k1)
            (reset (reset (k2))))))
@@ -155,12 +156,13 @@
            (k1)
            (reset (reset (k2))))))
 
-;; native : [r01][s01][s02][d01][d02][d03][s02][d01]12345[d03]
+;; native : [r01][s01][s02][d01][d02][s02]12345[d03]
 ;; meta   : [r01][s01][s02][d01][d02][d03][s02][d01]12345[d03]
 ;; srfi226: [r01][s01][s02][d01][d02][d03][s02][d01]12345[d03]
 ;; racket : [r01][s01][s02][d01][d02][s02]12345[d03]
 (test* "reset/shift + call/cc 2-D (from Kahua nqueen broken)"
-       "[r01][s01][s02][d01][d02][d03][s02][d01]12345[d03]"
+       ;"[r01][s01][s02][d01][d02][d03][s02][d01]12345[d03]"
+       "[r01][s01][s02][d01][d02][s02]12345[d03]"
        (with-output-to-string
          (lambda ()
            (define k1 #f)
@@ -176,7 +178,7 @@
            (dynamic-wind
              (lambda () (display "[d01]"))
              (lambda () (display "[d02]")
-                     (display (reset (reset (k2)))))
+                        (display (reset (reset (k2)))))
              (lambda () (display "[d03]"))))))
 
 ;; native : [r01][s01][s01]
@@ -198,37 +200,41 @@
            (k2)
            (reset (k1)))))
 
-;; native : error
+;; native : ""
 ;; meta   : ""
-;; srfi226: -
-;; racket : -
+;; srfi226: ""
+;; racket : ""
 (gauche-only
  (test* "reset/shift + call/cc error 1"
-        (test-error)
+        ;(test-error)
+        ""
         (with-output-to-string
           (lambda ()
             (define k1 #f)
             (define k2 #f)
-            (define (f1) (call/cc (lambda (k) (set! k1 k)))
+            (define (f1)
+              (call/cc (lambda (k) (set! k1 k)))
               (shift k (set! k2 k))
               (display "[f01]"))
             (define (f2) (display "[f02]"))
             (reset (f1) (f2))
             (reset (k1))))))
 
-;; native : error
+;; native : ""
 ;; meta   : ""
-;; srfi226: -
-;; racket : -
+;; srfi226: ""
+;; racket : ""
 (gauche-only
  (test* "reset/shift + call/cc error 2"
-        (test-error)
+        ;(test-error)
+        ""
         (with-output-to-string
           (lambda ()
             (define k1 #f)
             (define k2 #f)
             (define k3 #f)
-            (define (f1) (call/cc (lambda (k) (set! k1 k)))
+            (define (f1)
+              (call/cc (lambda (k) (set! k1 k)))
               (shift k (set! k2 k))
               (display "[f01]"))
             (define (f2) (display "[f02]"))
@@ -346,6 +352,37 @@
                 (lambda () (display "[D01]"))
                 next
                 (lambda () (display "[D02]"))))))))
+
+(gauche-only
+ (test* "reset/shift + guard 2"
+        "catch error!!"
+        (let ((k1 #f))
+          (reset
+           (guard (e [else "catch error!!"])
+             (shift k (set! k1 k))
+             (error "err")))
+          (k1 100))))
+
+(gauche-only
+ (test* "reset/shift + eval 1"
+        42
+        (reset (eval '(shift k (k 42)) (current-module)))))
+
+(gauche-only
+ (test* "reset/shift + eval 2"
+        42
+        (reset (eval '(+ (shift k (k 42))) (current-module)))))
+
+(gauche-only
+ (test* "reset/shift + eval 3"
+        42
+        (reset (+ (eval '(shift k (k 42)) (current-module))))))
+
+(gauche-only
+ (test* "reset/shift + eval 4"
+        '(42 43 44)
+        (receive vals (reset (eval '(shift k (k 42 43 44)) (current-module)))
+          vals)))
 
 ;; native : [d01][d02][d03][d04]
 ;; meta   : [d01][d02][d04][d01][d03][d04]


### PR DESCRIPTION
**＜＜本件は、急いでマージする必用はありません。＞＞**

- #1259 を、
  作り直したものになります。

- user_eval_inner() や MARKER を使うのをやめて、
  継続を追加する形の実装になっています。
  (だいぶ素直な感じにはなったと思います)

- 現状、既存の call/cc や guard 等と整合性が悪く、
  組み合わせると無限ループ等が発生します。
  (戻るタイプの継続と相性が悪いです)

- このため、gauche.partcont を use すると、
  call/cc と guard を、新しいものに差し替えます。
  (call/cc は call-with-non-composable-continuation に、
  guard は R7RS の参照実装に差し替えます。
  guard は遅くなるとは思いますが、
  (use gauche.partcont) をしなければ今まで通りなので…)

- 新しいタイプの call/cc (およびそれを使っている R7RS の guard も)
  は、大外に reset 等の defaultPrompt がないと、
  タグが見つからないというエラーになってしまいます。
  (仕様通りではあると思うが…)
  仕方がないので、タグが見つからなかったときは、
  旧版の call/cc の処理に切り替えています。
  (問題が出るかもしれませんが、無限遠を切り取るなら同じことかと…)

- ScmPromptData に情報を格納するのは、
  どうしてもうまくいきませんでした。
  原因のひとつは、既存の過去に戻るタイプの継続実行では、
  古い情報にアクセスしてしまって変になること。
  もうひとつは、ep->cont のような継続を含むデータを格納すると、
  cont が循環するかなにかして、メモリリークが発生することです。
  今は、partialChain (旧 resetChain) に情報を格納して管理しています。

- gauche.partcont に prompt / control を追加ました。
  これは普通に動作するようになりました。

- DENV の情報は触っていません。
  (つなぎなおす処理が必要かもしれませんが、よく分かっていません・・・)

＜テスト結果＞
(1) make check ==> OK

(2) [Gauche-effects](https://github.com/Hamayama/Gauche-effects) の effects.scm で、
    `*use-native-reset*` を #t にして、各サンプルを実行 ==> OK

(3) 以下のメモリリークのテスト ==> OK
(出典 : http://okmij.org/ftp/continuations/against-callcc.html#memory-leak )
(これは (use gauche.partcont-meta) だとメモリリークします)
```
(use gauche.partcont)
(define (leak-test1 identity-thunk)
  (let loop ((id (lambda (x) x)))
    (loop (id (identity-thunk)))))
(leak-test1 (lambda () (reset (shift k k))))
```

(4) Kahua の nqueen を実行 ==> OK
    (ただ、call/cc と guard が変わったので、問題が出る可能性はあるが…)

(5) https://practical-scheme.net/wiliki/wiliki.cgi?Gauche%3ABugs#H-2dgngv
    の pcdemo10.scm を実行 ==> OK
