### PR TITLE
Support SRFI 273 return checks in SRFI 253

### DIFF
--- a/lib/srfi/253.scm
+++ b/lib/srfi/253.scm
@@ -79,30 +79,30 @@
        (%check-case v () clause ...)))))
 
 (define-syntax %lambda-checked
-  (syntax-rules ()
-    ((_ name (body ...) args (checks ...) ())
+  (syntax-rules (=>)
+    ((_ name (=> (returns ...) body ...) args (checks ...))
+     (lambda args
+       checks ...
+       (values-checked
+        (returns ...)
+        (begin body ...))))
+    ((_ name (body ...) args (checks ...))
      (lambda args
        checks ...
        body ...))
-    ((_ name body (args ...) (checks ...) ((arg pred) . rest))
+    ((_ name body (args ...) (checks ...) (arg pred) rest ...)
      (%lambda-checked
       name body
-      (args ... arg) (checks ... (check-arg pred arg 'name)) rest))
-    ((_ name body (args ...) (checks ...) (arg . rest))
+      (args ... arg) (checks ... (check-arg pred arg 'name)) rest ...))
+    ((_ name body (args ...) (checks ...) arg rest ...)
      (%lambda-checked
       name body
-      (args ... arg) (checks ...) rest))
-    ((_ name body (args ...) (checks ...) last)
-     (%lambda-checked
-      name body
-      (args ... . last) (checks ...) ()))))
+      (args ... arg) (checks ...) rest ...))))
 
 (define-syntax lambda-checked
   (syntax-rules ()
-    ((_ () body ...)
-     (lambda () body ...))
-    ((_ (arg . args) body ...)
-     (%lambda-checked lambda-checked (body ...) () () (arg . args)))
+    ((_ (args ...) body ...)
+     (%lambda-checked lambda-checked (body ...) () () args ...))
     ;; Case of arg->list lambda, no-op.
     ((_ arg body ...)
      (lambda arg body ...))))
@@ -110,69 +110,109 @@
 (define-syntax define-checked
   (syntax-rules ()
     ;; Procedure
-    ((_ (name . args) body ...)
-     (define name (%lambda-checked name (body ...) () () args)))
+    ((_ (name args ...) body ...)
+     (define name (%lambda-checked name (body ...) () () args ...)))
     ;; Variable
     ((_ name pred value)
      (define name (values-checked (pred) value)))))
 
 (define-syntax %case-lambda-checked
-  (syntax-rules ()
+  (syntax-rules (=>)
+    ;; Terminal case, generate the actual case-lambda
     ((_ (clauses-so-far ...)
         ()
-        args-so-far (checks-so-far ...) (body ...) ())
+        args-so-far (checks-so-far ...) (body ...))
      (case-lambda
-      clauses-so-far ...
-      (args-so-far
-       checks-so-far ...
-       body ...)))
+       clauses-so-far ...
+       (args-so-far
+        checks-so-far ...
+        body ...)))
+    ;; Empty arglist with returns
+    ((_ (clauses-so-far ...)
+        ((() => (returns ...) body-to-process ...) clauses-to-process ...)
+        args-so-far (checks-so-far ...) (body ...))
+     (%case-lambda-checked
+      (clauses-so-far ... (args-so-far checks-so-far ... body ...))
+      (clauses-to-process ...)
+      () () ((values-checked (returns ...) (begin body-to-process ...)))))
+    ;; Empty args without returns
     ((_ (clauses-so-far ...)
         ((() body-to-process ...) clauses-to-process ...)
-        args-so-far (checks-so-far ...) (body ...) ())
+        args-so-far (checks-so-far ...) (body ...))
      (%case-lambda-checked
       (clauses-so-far ... (args-so-far checks-so-far ... body ...))
       (clauses-to-process ...)
-      () () (body-to-process ...) ()))
+      () () (body-to-process ...)))
+    ;; Regular args with returns
     ((_ (clauses-so-far ...)
-        (((arg . args-to-process) body-to-process ...) clauses-to-process ...)
-        args-so-far (checks-so-far ...) (body ...) ())
+        (((args ...) => (returns ...) body-to-process ...) clauses-to-process ...)
+        args-so-far (checks-so-far ...) (body ...))
      (%case-lambda-checked
       (clauses-so-far ... (args-so-far checks-so-far ... body ...))
       (clauses-to-process ...)
-      () () (body-to-process ...) (arg . args-to-process)))
+      () () ((values-checked (returns ...) (begin body-to-process ...))) args ...))
+    ;; Regular args without returns
+    ((_ (clauses-so-far ...)
+        (((args ...) body-to-process ...) clauses-to-process ...)
+        args-so-far (checks-so-far ...) (body ...))
+     (%case-lambda-checked
+      (clauses-so-far ... (args-so-far checks-so-far ... body ...))
+      (clauses-to-process ...)
+      () () (body-to-process ...) args ...))
+    ;; Rest arg with returns
+    ((_ (clauses-so-far ...)
+        ((arg-to-process => (returns ...) body-to-process ...) clauses-to-process ...)
+        args-so-far (checks-so-far ...) (body ...))
+     (%case-lambda-checked
+      (clauses-so-far ... (args-so-far checks-so-far ... body ...))
+      (clauses-to-process ...)
+      arg-to-process () ((values-checked (returns ...) (begin body-to-process ...)))))
+    ;; Rest arg without returns
     ((_ (clauses-so-far ...)
         ((arg-to-process body-to-process ...) clauses-to-process ...)
-        args-so-far (checks-so-far ...) (body ...) ())
+        args-so-far (checks-so-far ...) (body ...))
      (%case-lambda-checked
       (clauses-so-far ... (args-so-far checks-so-far ... body ...))
       (clauses-to-process ...)
-      arg-to-process () (body-to-process ...) ()))
+      arg-to-process () (body-to-process ...)))
+    ;; Consume arg with predicate / check
     ((_ (clauses-so-far ...) (clauses-to-process ...)
-        (args-so-far ...) (checks-so-far ...) (body ...) ((arg pred) . args))
+        (args-so-far ...) (checks-so-far ...) (body ...) (arg pred) . args)
      (%case-lambda-checked
       (clauses-so-far ...) (clauses-to-process ...)
       (args-so-far ... arg)
       (checks-so-far ... (check-arg pred arg 'case-lambda-checked))
-      (body ...) args))
+      (body ...) . args))
+    ;; Consume regular arg
     ((_ (clauses-so-far ...) (clauses-to-process ...)
-        (args-so-far ...) (checks-so-far ...) (body ...) (arg . args))
+        (args-so-far ...) (checks-so-far ...) (body ...) arg args ...)
      (%case-lambda-checked
       (clauses-so-far ...) (clauses-to-process ...)
-      (args-so-far ... arg) (checks-so-far ...) (body ...) args))
-    ((_ (clauses-so-far ...) (clauses-to-process ...)
-        (args-so-far ...) (checks-so-far ...) (body ...) arg)
-     (%case-lambda-checked
-      (clauses-so-far ...) (clauses-to-process ...)
-      (args-so-far ... . arg) (checks-so-far ...) (body ...) ()))))
+      (args-so-far ... arg) (checks-so-far ...) (body ...) args ...))))
 
 (define-syntax case-lambda-checked
-  (syntax-rules ()
+  (syntax-rules (=>)
+    ;; First clause: empty args with returns
+    ((_ (() => (returns ...) first-body ...) rest-clauses ...)
+     (%case-lambda-checked () (rest-clauses ...) () () ((values-checked (returns ...) (begin first-body ...)))))
+    ;; First clause: empty args without returns
     ((_ (() first-body ...) rest-clauses ...)
-     (%case-lambda-checked () (rest-clauses ...) () () (first-body ...) ()))
-    ((_ ((first-arg . first-args) first-body ...) rest-clauses ...)
-     (%case-lambda-checked () (rest-clauses ...) () () (first-body ...) (first-arg . first-args)))
+     (%case-lambda-checked () (rest-clauses ...) () () (first-body ...)))
+    ;; First clause: args with returns
+    ((_ ((args ...) => (returns ...) first-body ...) rest-clauses ...)
+     (%case-lambda-checked
+      () (rest-clauses ...) () ()
+      ((values-checked (returns ...) (begin first-body ...)))
+      args ...))
+    ;; First clause: args without returns
+    ((_ ((args ...) first-body ...) rest-clauses ...)
+     (%case-lambda-checked () (rest-clauses ...) () () (first-body ...) args ...))
+    ;; First clause: rest arg with returns
+    ((_ (args-var => (returns ...) first-body ...) rest-clauses ...)
+     (%case-lambda-checked () (rest-clauses ...) args-var () ((values-checked (returns ...) (begin first-body ...)))))
+    ;; First clause: rest arg without returns
     ((_ (args-var first-body ...) rest-clauses ...)
-     (%case-lambda-checked () (rest-clauses ...) args-var () (first-body ...) ()))))
+     (%case-lambda-checked () (rest-clauses ...) args-var () (first-body ...)))))
 
 ;; define-record-type-checked
 
@@ -193,7 +233,7 @@
       (fields ... (field internal-accessor internal-modifier))
       (field-wrappers
        ...
-       (define-checked (accessor (record predicate))
+       (define-checked (accessor (record predicate)) => (pred)
          (internal-accessor record))
        (define-checked (modifier (record predicate) (val pred))
          (internal-modifier record val)))

--- a/tests/include/srfi-253-test.scm
+++ b/tests/include/srfi-253-test.scm
@@ -134,6 +134,11 @@
 (test-assert ((lambda-checked (a (b integer?)) #t) "hello" 3))
 (test-error ((lambda-checked ((a integer?)) #t) "hello"))
 (test-error ((lambda-checked (a (b integer?)) #t) "hello" "hi"))
+;; SRFI 273
+(test-assert ((lambda-checked ((b integer?)) => (integer?) 2) 1))
+(test-error ((lambda-checked ((b integer?)) => (integer?) #t) 1))
+(test-error ((lambda-checked () => (integer?) #t)))
+(test-error ((lambda-checked args => (integer?) #t) 1 2 3))
 ;; Rest args. Sample implementation doesn't reliably pass this.
 ;; (test-assert (lambda-checked (a . c) #t))
 ;; (test-assert (lambda-checked ((a integer?) . c) #t))
@@ -174,13 +179,30 @@
    (() #t)
    (((a integer?)) #t)
    ((a (b string?)) #t)
-   (((a string?) b . rest) #t)))
+   (rest #t)))
 (test-assert (checked-case-lambda))
 (test-assert (checked-case-lambda 3))
 (test-error (checked-case-lambda "hello"))
 (test-assert (checked-case-lambda 3 "hello"))
 (test-assert (checked-case-lambda "hi" "hello"))
 (test-error (checked-case-lambda 3 3 3))
+;; SRFI 273 return value checks
+(define good-return-checked-case-lambda
+  (case-lambda-checked
+   (() => (integer?) 1)
+   (((a integer?)) => (integer?) 1)
+   (args => (integer?) 1)))
+(test-assert (good-return-checked-case-lambda 1))
+(test-assert (good-return-checked-case-lambda))
+(test-assert (good-return-checked-case-lambda 1 2 3))
+(define bad-return-checked-case-lambda
+  (case-lambda-checked
+   (() => (integer?) #t)
+   (((a integer?)) => (integer?) #t)
+   (args => (integer?) #t)))
+(test-error (bad-return-checked-case-lambda 1))
+(test-error (bad-return-checked-case-lambda))
+(test-error (bad-return-checked-case-lambda 1 2 3))
 (test-end "case-lambda-checked")
 
 


### PR DESCRIPTION
Hello and thanks for integrating SRFI 253 into Gauche! I’ve made a follow-up SRFI to 253, [SRFI 273](https://srfi.schemers.org/srfi-273/srfi-273.html). In it, one significant addition is [procedure return type checks](https://srfi.schemers.org/srfi-273/srfi-273.html#spec--return-value). In this PR, I’ve implemented it, cleaning up the code in the process.

-------------------------------------

Another significant addition that’s likely to persist in SRFI 273 up to finalization is [check-impl? auxiliary syntax](https://srfi.schemers.org/srfi-273/srfi-273.html#spec--check-impl). In short, it might allow providing implementation-specific types if standard predicates don’t fit the data. Something like 
``` scheme
(check-arg (check-impl? <fixnum>) 3)
(define-checked (a [b (check-impl? <short>)] [c (check-impl? <short>)])
  (+ b c))
;; etc.
```
I’m not sure how to implement this one. It seems like `check-arg` is the most intuitive place to implement that, but I don’t want to pollute this generic macro with such specific details. What do you think?