### PR TITLE
Fix memory leaks of partial continuation, etc.

### DIFF
--- a/lib/gauche/partcont.scm
+++ b/lib/gauche/partcont.scm
@@ -11,7 +11,7 @@
      (%reset (^[] expr ...))]))
 
 (define (call/pc proc)
-  (%call/pc (^k (proc (^ args (reset (apply k args)))))))
+  (%call/pc (^k (proc (^ args (%reset (^[] (apply k args))))))))
 
 (define-syntax shift
   (syntax-rules ()

--- a/src/gauche/priv/vmP.h
+++ b/src/gauche/priv/vmP.h
@@ -168,8 +168,8 @@ typedef struct ScmEscapePointRec {
     int contType;               /* continuation type
                                      CONT_TYPE_FULL
                                        - full continuation
-                                     CONT_TYPE_COMPOSABLE
-                                       - composable partial continuation
+                                     CONT_TYPE_PARTIAL
+                                       - partial continuation
                                 */
 
     /* The following fields are used for new implementation of partial cont. */

--- a/src/gauche/priv/vmP.h
+++ b/src/gauche/priv/vmP.h
@@ -74,7 +74,7 @@ struct ScmPromptTagRec {
 typedef struct ScmPromptDataRec {
     ScmWord dummy;              /* RET insn */
     ScmObj abortHandler;        /* abort handler */
-    ScmObj dynamicHandlers;     /* dynamic-wind handler chain */
+    ScmEscapePoint *escapePoint; /* escape point */
 } ScmPromptData;
 
 #define PROMPT_DATA_SIZE       sizeof(ScmPromptData)/sizeof(ScmWord)
@@ -132,6 +132,12 @@ SCM_CLASS_DECL(Scm_DynamicHandlerClass);
  *  EscapePoint (EP) structure is a saved continuation.  It grabs
  *  a head of continuation chain with some auxiliary data.
  */
+
+enum {
+    CONT_TYPE_FULL = 0,
+    CONT_TYPE_PARTIAL = 1,
+};
+
 typedef struct ScmEscapePointRec {
     SCM_HEADER;
     ScmObj ehandler;            /* handler closure */
@@ -159,11 +165,18 @@ typedef struct ScmEscapePointRec {
                                    with-error-handler uses the latter model,
                                    but SRFI-34's guard needs the former model.
                                 */
+    int contType;               /* continuation type
+                                     CONT_TYPE_FULL
+                                       - full continuation
+                                     CONT_TYPE_COMPOSABLE
+                                       - composable partial continuation
+                                */
 
     /* The following fields are used for new implementation of partial cont. */
-    ScmObj promptTag;
-    ScmObj abortHandler;
-    struct ScmEscapePointRec *bottom;
+    ScmObj promptTag;           /* prompt tag */
+    ScmObj abortHandler;        /* abort handler */
+    ScmObj abortArgs;           /* abort handler's arguments */
+    struct ScmEscapePointRec *bottom; /* (not used now) */
 } ScmEscapePoint;
 
 SCM_CLASS_DECL(Scm_EscapePointClass);

--- a/src/gauche/vm.h
+++ b/src/gauche/vm.h
@@ -527,16 +527,9 @@ struct ScmVMRec {
 #endif
 
     /* Escape handling */
-    ScmObj floatingEscapePoints; /* List of escapePoints that point to
-                                    in-stack continuation frames.  We only need
-                                    it so that we can adjust pointers to cont
-                                    frames when they are moved to the heap.
-                                    The list is cleared once cont frames
-                                    are moved to the heap.
-                                 */
     int escapeReason;            /* temporary storage to pass data across
                                     longjmp(). */
-    void *escapeData[2];         /* ditto. */
+    void *escapeData[3];         /* ditto. */
     int errorHandlerContinuable; /* A transient flag, set by the error handler
                                     as a result of 'guard' expansion to tell
                                     that the control should return to 'raise'
@@ -577,14 +570,10 @@ struct ScmVMRec {
     ScmCodeCache *codeCache;
 
     /* for reset/shift */
-    ScmContinuationPrompt *currentPrompt;
     ScmObj resetChain;          /* list of reset information,
                                    where reset information is
-                                   (delimited . <dynamic handlers chain>).
-                                   the delimited flag is set when 'shift'
-                                   appears in 'reset' and the end marker of
-                                   partial continuation is set. */
-
+                                   (reserved . escapePoint).
+                                */
 };
 
 SCM_EXTERN ScmVM *Scm_NewVM(ScmVM *proto, ScmObj name);

--- a/src/libproc.scm
+++ b/src/libproc.scm
@@ -78,8 +78,14 @@
 
 (select-module gauche.internal)
 ;; for partial continuation.  See lib/gauche/partcont.scm
-(define-cproc %call/pc (proc) (return (Scm_VMCallPC proc)))
-(define-cproc %reset (proc) (return (Scm_VMReset proc)))
+(define-cproc %call/pc (proc) Scm_VMCallPC)
+(define-cproc %reset (proc) Scm_VMReset)
+
+(select-module gauche.internal)
+(define-cproc %call-with-continuation-prompt (thunk
+                                              :optional (prompt-tag #f)
+                                                        (abort-handler #f))
+  Scm_VMCallWithContinuationPrompt)
 
 ;; Continuaton prompts
 (select-module gauche)
@@ -90,10 +96,23 @@
 (define-cproc continuation-prompt-tag? (obj) ::<boolean>
   SCM_PROMPT_TAG_P)
 
-(define-cproc call-with-continuation-prompt (thunk
-                                             :optional (prompt-tag #f)
+(define (call-with-continuation-prompt thunk :optional (prompt-tag #f)
                                                        (abort-handler #f))
-  Scm_VMCallWithContinuationPrompt)
+  (if abort-handler
+    ((with-module gauche.internal %call-with-continuation-prompt)
+     thunk
+     prompt-tag
+     abort-handler)
+    ((with-module gauche.internal %call-with-continuation-prompt)
+     thunk
+     prompt-tag
+     (lambda (continuation-thunk)
+       (unless (and (procedure? continuation-thunk)
+                    (eqv? (arity continuation-thunk) 0))
+         (errorf "default abort-handler requires exactly one argument, \
+                  which must be a thunk, but got: ~S"
+                 continuation-thunk))
+       (call-with-continuation-prompt continuation-thunk prompt-tag #f)))))
 (define-cproc abort-current-continuation (prompt-tag :rest objs)
   Scm_VMAbortCurrentContinuation)
 

--- a/src/vm.c
+++ b/src/vm.c
@@ -3539,7 +3539,7 @@ static ScmObj throw_continuation(ScmObj *argframe,
         hdlist = throw_cont_calculate_handlers(ep->dynamicHandlers,
                                                currentHandlers);
     } else {
-        /* for composable partial continuation */
+        /* for partial continuation */
         /* NB: this avoids redundant calls of dynamic handlers */
         hdlist =
             throw_cont_calculate_handlers(Scm_Append2(ep->partHandlers,

--- a/src/vm.c
+++ b/src/vm.c
@@ -86,20 +86,27 @@ struct ScmContinuationPromptRec {
     struct ScmContinuationPromptRec *prev;
 };
 
-/* bitflags for ScmContFrame->marker */
+/* bitflags for ScmContFrame->marker
+ *
+ *  BOUNDARY - this is a user_eval_inner boundary; when RETURN_OP encounters
+ *             this frame, run_loop returns control to the surrounding C
+ *             stack.  Boundary frames are also PROMPT frames.
+ *  PROMPT   - this is a prompt cont frame.  Both boundary frames and frames
+ *             pushed by call-with-continuation-prompt carry this.
+ */
 enum {
-      SCM_CONT_SHIFT_MARKER = (1L<<0),
-      SCM_CONT_RESET_MARKER = (1L<<1)
+    SCM_CONT_BOUNDARY_MARKER = (1L<<0),
+    SCM_CONT_PROMPT_MARKER   = (1L<<1),
 };
 
 static void push_prompt_cont(ScmVM*, ScmObj, ScmObj);
 static void push_boundary_cont(ScmVM*, ScmObj, ScmObj);
 
-/* return true if cont is a boundary continuation frame */
-#define BOUNDARY_FRAME_P(cont) ((cont)->marker & SCM_CONT_RESET_MARKER)
+/* return true if cont is a boundary continuation frame (C-stack boundary) */
+#define BOUNDARY_FRAME_P(cont) ((cont)->marker & SCM_CONT_BOUNDARY_MARKER)
 
-/* return true if cont has the end marker of partial continuation */
-#define MARKER_FRAME_P(cont)   ((cont)->marker & SCM_CONT_SHIFT_MARKER)
+/* return true if cont is a prompt cont frame */
+#define PROMPT_FRAME_P(cont)   ((cont)->marker & SCM_CONT_PROMPT_MARKER)
 
 /* A stub VM code to make VM return immediately */
 static ScmWord return_code[] = { SCM_VM_INSN(SCM_VM_RET) };
@@ -113,17 +120,6 @@ static ScmEnvFrame ccEnvMark = {
 };
 
 #define C_CONTINUATION_P(cont)  ((cont)->env == &ccEnvMark)
-
-/* If you have ScmContFrame *cont and you'll do something that can trigger
-   saving frames, you have to call this first to ensure that your
-   cont frame keeps pointing a valid frame. */
-#define ENSURE_SAVE_CONT(cont)                  \
-    do {                                        \
-        save_cont(vm);                          \
-        if (FORWARDED_CONT_P(cont)) {           \
-            cont = FORWARDED_CONT(cont);        \
-        }                                       \
-    } while (0)
 
 /* IN_STACK_P(ptr) returns true if ptr points into the active stack area.
    IN_FULL_STACK_P(ptr) returns true if ptr points into any part of the stack.
@@ -317,10 +313,10 @@ ScmVM *Scm_NewVM(ScmVM *proto, ScmObj name)
 
     v->dynamicHandlers = SCM_NIL;
 
-    v->floatingEscapePoints = SCM_NIL;
     v->escapeReason = SCM_VM_ESCAPE_NONE;
     v->escapeData[0] = NULL;
     v->escapeData[1] = NULL;
+    v->escapeData[2] = NULL;
     v->errorHandlerContinuable = FALSE;
     v->customErrorReporter = (proto? proto->customErrorReporter : SCM_FALSE);
 #if GAUCHE_SPLIT_STACK
@@ -354,7 +350,6 @@ ScmVM *Scm_NewVM(ScmVM *proto, ScmObj name)
                     : NULL);
     v->codeCache = NULL;
 
-    v->currentPrompt = NULL;
     v->resetChain = SCM_NIL;
 
     Scm_RegisterFinalizer(SCM_OBJ(v), vm_finalize, NULL);
@@ -438,10 +433,10 @@ ScmVM *Scm_VMTakeSnapshot(ScmVM *vm)
     v->denv = vm->denv;
     v->dynamicHandlers = vm->dynamicHandlers;
 
-    v->floatingEscapePoints = vm->floatingEscapePoints;
     v->escapeReason = vm->escapeReason;
     v->escapeData[0] = vm->escapeData[0];
     v->escapeData[1] = vm->escapeData[1];
+    v->escapeData[2] = vm->escapeData[2];
     v->errorHandlerContinuable = vm->errorHandlerContinuable;
     v->customErrorReporter = vm->customErrorReporter;
 #if GAUCHE_SPLIT_STACK
@@ -473,8 +468,8 @@ ScmVM *Scm_VMTakeSnapshot(ScmVM *vm)
     v->codeCache = NULL;        /* We might need to copy this as well
                                    if we want to debug JIT code cache */
 
-    v->currentPrompt = vm->currentPrompt;
     v->resetChain = vm->resetChain;
+
     /* NB: We don't register the finalizer vm_finalize to the snapshot,
        for we do not want the associated system resources to be cleaned
        up when the snapshot is GCed. */
@@ -810,10 +805,6 @@ static void vm_unregister(ScmVM *vm)
     do {                                                \
         if (CONT == NULL || BOUNDARY_FRAME_P(CONT)) {   \
             return; /* no more continuations */         \
-        } else if (MARKER_FRAME_P(CONT)) {              \
-            POP_CONT();                                 \
-            /* the end of partial continuation */       \
-            vm->cont = NULL;                            \
         } else {                                        \
             POP_CONT();                                 \
         }                                               \
@@ -1251,8 +1242,8 @@ static void save_cont_1(ScmVM *vm, ScmContFrame *c)
             }
         }
 
-        /* for boundary frame, we also need to copy promptdata */
-        if (BOUNDARY_FRAME_P(c)) {
+        /* for prompt frame, we also need to copy promptdata */
+        if (PROMPT_FRAME_P(c)) {
             ScmPromptData *psrc = (ScmPromptData*)c->cpc;
             ScmPromptData *psave = SCM_NEW(ScmPromptData);
             *psave = *psrc;
@@ -1301,18 +1292,6 @@ static void save_cont(ScmVM *vm)
         if (FORWARDED_CONT_P(cstk->cont)) {
             cstk->cont = FORWARDED_CONT(cstk->cont);
         }
-    }
-    {
-        ScmObj eps;
-        SCM_FOR_EACH(eps, vm->floatingEscapePoints) {
-            ScmObj ep = SCM_CAR(eps);
-            SCM_ASSERT(SCM_ESCAPE_POINT_P(ep));
-            ScmEscapePoint *e = SCM_ESCAPE_POINT(ep);
-            if (FORWARDED_CONT_P(e->cont)) {
-                e->cont = FORWARDED_CONT(e->cont);
-            }
-        }
-        vm->floatingEscapePoints = SCM_NIL;
     }
 }
 
@@ -1957,9 +1936,17 @@ SCM_DEFINE_BUILTIN_CLASS(Scm_EscapePointClass,
 static ScmEscapePoint *new_ep(ScmVM *vm,
                               ScmObj errorHandler,
                               int rewindBefore,
+                              int contType,
                               ScmObj promptTag,
                               ScmObj abortHandler)
 {
+    /* save continuation to heap before capturing escape point */
+    /*
+       NB: This avoids ep->cont remains pointing to the stack
+           after vm->cont has moved to heap.
+    */
+    save_cont(vm);
+
     ScmEscapePoint *ep = SCM_NEW(ScmEscapePoint);
     SCM_SET_CLASS(ep, SCM_CLASS_ESCAPE_POINT);
     ep->ehandler = errorHandler;
@@ -1973,10 +1960,34 @@ static ScmEscapePoint *new_ep(ScmVM *vm,
     ep->errorReporting =
         SCM_VM_RUNTIME_FLAG_IS_SET(vm, SCM_ERROR_BEING_REPORTED);
     ep->rewindBefore = rewindBefore;
+    ep->contType = contType;
     ep->promptTag = promptTag;
     ep->abortHandler = abortHandler;
+    ep->abortArgs = SCM_NIL;
     ep->bottom = NULL;
     return ep;
+}
+
+static ScmEscapePoint *copy_ep(ScmEscapePoint *ep)
+{
+    ScmEscapePoint *ep2 = SCM_NEW(ScmEscapePoint);
+    SCM_SET_CLASS(ep2, SCM_CLASS_ESCAPE_POINT);
+    ep2->ehandler = ep->ehandler;
+    ep2->cont = ep->cont;
+    ep2->denv = ep->denv;
+    ep2->dynamicHandlers = ep->dynamicHandlers;
+    ep2->cstack = ep->cstack;
+    ep2->xhandler = ep->xhandler;
+    ep2->resetChain = ep->resetChain;
+    ep2->partHandlers = ep->partHandlers;
+    ep2->errorReporting = ep->errorReporting;
+    ep2->rewindBefore = ep->rewindBefore;
+    ep2->contType = ep->contType;
+    ep2->promptTag = ep->promptTag;
+    ep2->abortHandler = ep->abortHandler;
+    ep2->abortArgs = ep->abortArgs;
+    ep2->bottom = ep->bottom;
+    return ep2;
 }
 
 /*-------------------------------------------------------------
@@ -2017,8 +2028,8 @@ static ScmObj user_eval_inner(ScmObj program,
     }
 
     /* Push extra continuation.  This continuation frame is a 'boundary
-       frame' and marked by marker == SCM_CONT_RESET_MARKER.   VM loop knows
-       it should return to C frame when it sees a boundary frame.
+       frame' and marked by marker == SCM_CONT_BOUNDARY_MARKER.   VM loop
+       knows it should return to C frame when it sees a boundary frame.
        A boundary frame also keeps the unfinished argument frame at
        the point when Scm_Eval or Scm_Apply is called. */
     push_boundary_cont(vm, promptTag, abortHandler);
@@ -2081,16 +2092,16 @@ static ScmObj user_eval_inner(ScmObj program,
     } else {
         /* An escape situation happened. */
         if (vm->escapeReason == SCM_VM_ESCAPE_CONT) {
-            ScmEscapePoint *ep = (ScmEscapePoint*)vm->escapeData[0];
+            ScmObj hdlist = SCM_OBJ(vm->escapeData[0]);
+            ScmEscapePoint *ep = (ScmEscapePoint*)vm->escapeData[1];
+            ScmObj args = SCM_OBJ(vm->escapeData[2]);
             if (ep->cstack == vm->cstack) {
-                ScmObj handlers =
-                    throw_cont_calculate_handlers(ep->dynamicHandlers,
-                                                  get_dynamic_handlers(vm));
                 /* force popping continuation when restarted */
                 vm->pc = PC_TO_RETURN;
-                vm->val0 = throw_cont_body(handlers, ep, vm->escapeData[1]);
+                vm->val0 = throw_cont_body(hdlist, ep, args);
                 goto restart;
             } else {
+                /* rewind cstack */
                 SCM_ASSERT(vm->cstack && vm->cstack->prev);
                 vm->cont = cstack.cont;
                 POP_CONT();
@@ -2104,7 +2115,9 @@ static ScmObj user_eval_inner(ScmObj program,
                 vm->denv = ep->denv;
                 vm->pc = PC_TO_RETURN;
                 /* restore reset-chain for reset/shift */
-                if (ep->cstack) vm->resetChain = ep->resetChain;
+                if (ep->contType == CONT_TYPE_FULL) {
+                    vm->resetChain = ep->resetChain;
+                }
                 goto restart;
             } else if (vm->cstack->prev == NULL) {
                 /* This loop is the outermost C stack, and nobody will
@@ -2155,16 +2168,24 @@ void push_prompt_cont(ScmVM *vm, ScmObj promptTag, ScmObj abortHandler)
 
     a->dummy = SCM_VM_INSN(SCM_VM_RET);
     a->abortHandler = abortHandler;
-    a->dynamicHandlers = get_dynamic_handlers(vm);
+    a->escapePoint = NULL;
     PUSH_CONT(SCM_PROMPT_TAG_PC(promptTag));
     CONT->cpc = &a->dummy;
+    CONT->marker |= SCM_CONT_PROMPT_MARKER;
+
+    /* save escape point to prompt */
+    ScmEscapePoint *ep = new_ep(vm, SCM_FALSE, FALSE, CONT_TYPE_FULL,
+                                promptTag, abortHandler);
+    ScmPromptData *pd = (ScmPromptData*)vm->cont->cpc;
+    SCM_ASSERT(pd->dummy == SCM_VM_INSN(SCM_VM_RET));
+    pd->escapePoint = ep;
 }
 
 void push_boundary_cont(ScmVM *vm, ScmObj promptTag, ScmObj abortHandler)
 {
-    /* Boundary continuation is a prompt cont with CONT_RESET_MARKER */
+    /* Boundary continuation is a prompt cont with SCM_CONT_BOUNDARY_MARKER */
     push_prompt_cont(vm, promptTag, abortHandler);
-    CONT->marker = SCM_CONT_RESET_MARKER;
+    CONT->marker |= SCM_CONT_BOUNDARY_MARKER;
 }
 
 /* API for recursive call to VM.  Exceptions are not captured.
@@ -2541,7 +2562,9 @@ static void call_after_thunk(ScmVM *vm, ScmObj handler_entry)
     SCM_ASSERT(SCM_DYNAMIC_HANDLER_P(handler_entry));
     ScmDynamicHandler *dh = SCM_DYNAMIC_HANDLER(handler_entry);
     vm->denv = dh->denv;
-    Scm_ApplyRec(dh->after, dh->args);
+    if (!SCM_FALSEP(dh->after)) {
+        Scm_ApplyRec(dh->after, dh->args);
+    }
 }
 
 static ScmObj vm_call_before_thunk(ScmVM *vm, ScmObj handler_entry)
@@ -2561,7 +2584,11 @@ static ScmObj vm_call_after_thunk(ScmVM *vm, ScmObj handler_entry)
     SCM_ASSERT(SCM_DYNAMIC_HANDLER_P(handler_entry));
     ScmDynamicHandler *dh = SCM_DYNAMIC_HANDLER(handler_entry);
     vm->denv = dh->denv;
-    return Scm_VMApply(dh->after, dh->args);
+    if (!SCM_FALSEP(dh->after)) {
+        return Scm_VMApply(dh->after, dh->args);
+    } else {
+        return SCM_UNDEFINED;
+    }
 }
 /* End of handler-chain internal API */
 
@@ -2644,20 +2671,37 @@ static ScmObj dynwind_body_cc(ScmVM *vm, ScmObj result, ScmObj *data)
        actually gets slightly slower.  More branches may have a negative
        effect.  So we keep it simple here.
      */
-    int nvals = vm->numVals;
-    if (nvals > 1) {
-        ScmObj *vals = SCM_NEW_ARRAY(ScmObj, nvals-1);
-        memcpy(vals, vm->vals, sizeof(ScmObj)*(nvals-1));
-        ScmObj *d = Scm_pc_PushCC(vm, dynwind_after_cc, 3);
-        d[0] = result;
-        d[1] = SCM_OBJ((intptr_t)nvals);
-        d[2] = SCM_OBJ(vals);
+    if (SCM_FALSEP(after)) {
+        /* we can skip application of 'after' */
+        ScmObj d[3];
+        int nvals = vm->numVals;
+        if (nvals > 1) {
+            ScmObj *vals = SCM_NEW_ARRAY(ScmObj, nvals-1);
+            memcpy(vals, vm->vals, sizeof(ScmObj)*(nvals-1));
+            d[0] = result;
+            d[1] = SCM_OBJ((intptr_t)nvals);
+            d[2] = SCM_OBJ(vals);
+        } else {
+            d[0] = result;
+            d[1] = SCM_OBJ((intptr_t)nvals);
+        }
+        return dynwind_after_cc(vm, SCM_UNDEFINED, d);
     } else {
-        ScmObj *d = Scm_pc_PushCC(vm, dynwind_after_cc, 2);
-        d[0] = result;
-        d[1] = SCM_OBJ((intptr_t)nvals);
+        int nvals = vm->numVals;
+        if (nvals > 1) {
+            ScmObj *vals = SCM_NEW_ARRAY(ScmObj, nvals-1);
+            memcpy(vals, vm->vals, sizeof(ScmObj)*(nvals-1));
+            ScmObj *d = Scm_pc_PushCC(vm, dynwind_after_cc, 3);
+            d[0] = result;
+            d[1] = SCM_OBJ((intptr_t)nvals);
+            d[2] = SCM_OBJ(vals);
+        } else {
+            ScmObj *d = Scm_pc_PushCC(vm, dynwind_after_cc, 2);
+            d[0] = result;
+            d[1] = SCM_OBJ((intptr_t)nvals);
+        }
+        return Scm_VMApply0(after);
     }
-    return Scm_VMApply0(after);
 }
 
 static ScmObj dynwind_after_cc(ScmVM *vm, ScmObj result SCM_UNUSED,
@@ -2847,7 +2891,9 @@ static ScmObj handle_escape(ScmObj e, ScmEscapePoint *ep)
         SCM_VM_RUNTIME_FLAG_SET(vm, SCM_ERROR_BEING_REPORTED);
     }
     /* restore reset-chain for reset/shift */
-    if (ep->cstack) vm->resetChain = ep->resetChain;
+    if (ep->contType == CONT_TYPE_FULL) {
+        vm->resetChain = ep->resetChain;
+    }
 
     SCM_ASSERT(vm->cstack);
     vm->escapeReason = SCM_VM_ESCAPE_ERROR;
@@ -2984,37 +3030,16 @@ ScmObj Scm_VMThrowException(ScmVM *vm, ScmObj exception, u_long raise_flags)
 /*
  * with-error-handler
  */
-static ScmObj discard_ehandler(ScmObj *args SCM_UNUSED,
-                               int nargs SCM_UNUSED,
-                               void *data)
-{
-    /* restore floatingEscapePoints when necessary */
-    ScmObj eps = SCM_OBJ(data);
-    if (SCM_PAIRP(eps)) {
-        ScmVM *vm = theVM;
-        ScmContFrame *c = SCM_ESCAPE_POINT(SCM_CAR(eps))->cont;
-        if (IN_STACK_P((ScmObj*)c)) {
-            /* Those cont frames are not saved yet, so keep them
-               in the chain. */
-            theVM->floatingEscapePoints = eps;
-        }
-    }
-    return SCM_UNDEFINED;
-}
-
 static ScmObj with_error_handler(ScmVM *vm, ScmObj handler,
                                  ScmObj thunk, int rewindBefore)
 {
-    ScmEscapePoint *ep = new_ep(vm, handler, rewindBefore,
+    ScmEscapePoint *ep = new_ep(vm, handler, rewindBefore, CONT_TYPE_FULL,
                                 SCM_FALSE, SCM_FALSE);
 
     ScmObj ehandler = make_escape_handler(ep);
     Scm_VMPushExceptionHandler(ehandler);
     SCM_VM_RUNTIME_FLAG_CLEAR(theVM, SCM_ERROR_BEING_REPORTED);
-    ScmObj prev_fep = vm->floatingEscapePoints;
-    vm->floatingEscapePoints = Scm_Cons(SCM_OBJ(ep), prev_fep);
-    ScmObj after  = Scm_MakeSubr(discard_ehandler, prev_fep, 0, 0, SCM_FALSE);
-    return Scm_VMDynamicWind(SCM_FALSE, thunk, after);
+    return Scm_VMDynamicWind(SCM_FALSE, thunk, SCM_FALSE);
 }
 
 ScmObj Scm_VMWithErrorHandler(ScmObj handler, ScmObj thunk)
@@ -3147,12 +3172,17 @@ ScmObj Scm_VMCallWithContinuationPrompt(ScmObj thunk,
                                         ScmObj promptTag,
                                         ScmObj abortHandler)
 {
-    if (SCM_FALSEP(promptTag)) promptTag = Scm_DefaultPromptTag();
-    else if (!SCM_PROMPT_TAG_P(promptTag)) {
+    ScmVM *vm = theVM;
+
+    if (SCM_FALSEP(promptTag)) {
+        promptTag = Scm_DefaultPromptTag();
+    } else if (!SCM_PROMPT_TAG_P(promptTag)) {
         SCM_TYPE_ERROR(promptTag, "prompt tag or #f");
     }
 
-    push_prompt_cont(Scm_VM(), promptTag, abortHandler);
+    /* push prompt continuation */
+    push_prompt_cont(vm, promptTag, abortHandler);
+
     return Scm_VMApply0(thunk);
 }
 
@@ -3163,59 +3193,23 @@ static ScmContFrame *find_prompt_frame(ScmVM *vm, ScmObj promptTag)
     for (ScmContFrame *c = vm->cont; c; c = c->prev) {
         if (c->pc == pc) {
             return c;
-         }
-     }
-     return NULL;
-}
-
-
-static ScmObj vm_abort_cc(ScmObj val0, void *data[]);
-
-static ScmObj vm_abort_body(ScmContFrame *abortTo, ScmObj args)
-{
-    ScmPromptData *pd = (ScmPromptData*)abortTo->cpc;
-    ScmObj abortHandler = pd->abortHandler;
-
-    if (SCM_FALSEP(abortHandler)) {
-        if (!(Scm_Length(args) == 1
-              && SCM_PROCEDUREP(SCM_CAR(args))
-              && SCM_PROCEDURE_REQUIRED(SCM_CAR(args)) == 0)) {
-            Scm_Error("default abort-handler requires exactly one argument, "
-                      "which must be a thunk, but got: %S", args);
         }
-        return Scm_VMApply0(SCM_CAR(args));
-    } else {
-        /* TODO: In this case, we should run abortHandler _after_ the
-           abortTo frame is popped.  We need some more tweaks to realize it.
-        */
-        return Scm_VMApply(abortHandler, args);
     }
+    return NULL;
 }
 
-static ScmObj vm_abort_cc(ScmObj val0 SCM_UNUSED, void *data[])
-{
-    ScmContFrame *abortTo = data[0];
-    ScmPromptData *pd = (ScmPromptData*)abortTo->cpc;
-    ScmObj targetHandlers = pd->dynamicHandlers;
-    ScmVM *vm = theVM;
-    ScmObj currentHandlers = get_dynamic_handlers(vm);
-    if (targetHandlers != currentHandlers && SCM_PAIRP(currentHandlers)) {
-        Scm_VMPushCC(vm_abort_cc, data, 2);
-        ScmObj handler_entry = pop_dynamic_handlers(vm);
-        return vm_call_after_thunk(vm, handler_entry);
-    } else {
-        ScmObj args = SCM_OBJ(data[1]);
-        return vm_abort_body(abortTo, args);
-    }
-}
 
+static ScmObj throw_continuation(ScmObj *argframe, int nargs, void *data);
 
 ScmObj Scm_VMAbortCurrentContinuation(ScmObj promptTag, ScmObj args)
 {
-    if (!(SCM_PROMPT_TAG_P(promptTag) || SCM_FALSEP(promptTag))) {
-        SCM_TYPE_ERROR(promptTag, "prompt tag or #f");
-    }
     ScmVM *vm = theVM;
+
+    if (!SCM_PROMPT_TAG_P(promptTag)) {
+        SCM_TYPE_ERROR(promptTag, "prompt tag");
+    }
+
+    /* find nearest prompt */
     ScmContFrame *abortTo = find_prompt_frame(vm, promptTag);
     if (abortTo == NULL) {
         Scm_RaiseCondition(SCM_OBJ(SCM_CLASS_CONTINUATION_ERROR),
@@ -3225,28 +3219,18 @@ ScmObj Scm_VMAbortCurrentContinuation(ScmObj promptTag, ScmObj args)
                            promptTag);
     }
 
+    /* get escape point on prompt */
     ScmPromptData *pd = (ScmPromptData*)abortTo->cpc;
     SCM_ASSERT(pd->dummy == SCM_VM_INSN(SCM_VM_RET));
-    ScmObj targetHandlers = pd->dynamicHandlers;
+    ScmEscapePoint *ep = pd->escapePoint;
 
-    /* Discard continuation, and reinstate abortTo frame and its
-       dynamic environment. */
-    CONT = abortTo;
-    DENV = abortTo->denv;
-
-    ScmObj currentHandlers = get_dynamic_handlers(vm);
-    if (targetHandlers != currentHandlers && SCM_PAIRP(currentHandlers)) {
-        ENSURE_SAVE_CONT(abortTo);
-
-        void *data[2];
-        data[0] = abortTo;
-        data[1] = args;
-        Scm_VMPushCC(vm_abort_cc, data, 2);
-        ScmObj handler_entry = pop_dynamic_handlers(vm);
-        return vm_call_after_thunk(vm, handler_entry);
-    } else {
-        return vm_abort_body(abortTo, args);
-    }
+    /* call continuation procedure to abort */
+    ScmEscapePoint *ep2 = copy_ep(ep);
+    ep2->cont = abortTo;
+    ep2->abortArgs = args;
+    ScmObj contproc = Scm_MakeSubr(throw_continuation, ep2, 0, 1,
+                                   continuation_symbol);
+    return Scm_VMApply(contproc, SCM_NIL);
 }
 
 /*
@@ -3443,16 +3427,14 @@ void Scm_VMFlushDynamicHandlers()
 }
 
 
-static ScmObj throw_cont_cc(ScmObj, void **);
+static ScmObj throw_cont_cc(ScmObj result, void **data);
+static ScmObj vm_abort_to_cc(ScmObj result, void **data);
 
 static ScmObj throw_cont_body(ScmObj hdlist,      /*((flag . handler-chain)...)*/
                               ScmEscapePoint *ep, /* target continuation */
                               ScmObj args)        /* args to pass to the
                                                      target continuation */
 {
-    void *data[4];
-    int nargs;
-    ScmObj ap;
     ScmVM *vm = theVM;
 
     /*
@@ -3463,6 +3445,7 @@ static ScmObj throw_cont_body(ScmObj hdlist,      /*((flag . handler-chain)...)*
         ScmObj before_flag = SCM_CAAR(hdlist);
         ScmObj chain       = SCM_CDAR(hdlist);
 
+        void *data[4];
         data[0] = (void*)SCM_CDR(hdlist);
         data[1] = (void*)ep;
         data[2] = (void*)args;
@@ -3479,22 +3462,6 @@ static ScmObj throw_cont_body(ScmObj hdlist,      /*((flag . handler-chain)...)*
     }
 
     /*
-     * If the target continuation is a full continuation, we can abandon
-     * the current continuation.  However, if the target continuation is
-     * partial, we must return to the current continuation after executing
-     * the partial continuation.  The returning part is handled by
-     * user_level_inner, but we have to make sure that our current continuation
-     * won't be overwritten by execution of the partial continuation.
-     *
-     * NB: As an exception case, if we'll jump into reset,
-     * we might reach to the end of partial continuation even though
-     * the target continuation is a full continuation.
-     */
-    if (ep->cstack == NULL || SCM_PAIRP(ep->resetChain)) {
-        save_cont(vm);
-    }
-
-    /*
      * now, install the target continuation
      */
     vm->pc = PC_TO_RETURN;
@@ -3502,10 +3469,21 @@ static ScmObj throw_cont_body(ScmObj hdlist,      /*((flag . handler-chain)...)*
     vm->denv = ep->denv;
 
     /* restore reset-chain for reset/shift */
-    if (ep->cstack) vm->resetChain = ep->resetChain;
+    if (ep->contType == CONT_TYPE_FULL) {
+        vm->resetChain = ep->resetChain;
+    }
 
-    nargs = Scm_Length(args);
+    /* if abort handler exists, push abort handler continuation */
+    if (!SCM_FALSEP(ep->abortHandler)) {
+        void *data[2];
+        data[0] = (void*)ep->abortHandler;
+        data[1] = (void*)ep->abortArgs;
+        Scm_VMPushCC(vm_abort_to_cc, data, 2);
+    }
+
+    int nargs = Scm_Length(args);
     if (nargs == 1) {
+        vm->numVals = 1;
         return SCM_CAR(args);
     } else if (nargs < 1) {
         vm->numVals = 0;
@@ -3514,7 +3492,7 @@ static ScmObj throw_cont_body(ScmObj hdlist,      /*((flag . handler-chain)...)*
         Scm_Error("too many values passed to the continuation");
     }
 
-    ap = SCM_CDR(args);
+    ScmObj ap = SCM_CDR(args);
     for (int i=0; SCM_PAIRP(ap); i++, ap=SCM_CDR(ap)) {
         vm->vals[i] = SCM_CAR(ap);
     }
@@ -3537,6 +3515,14 @@ static ScmObj throw_cont_cc(ScmObj result SCM_UNUSED, void **data)
     return throw_cont_body(hdlist, ep, args);
 }
 
+static ScmObj vm_abort_to_cc(ScmObj result SCM_UNUSED, void **data)
+{
+    ScmObj abortHandler = SCM_OBJ(data[0]);
+    ScmObj abortArgs = SCM_OBJ(data[1]);
+
+    return Scm_VMApply(abortHandler, abortArgs);
+}
+
 /* Body of the continuation SUBR */
 static ScmObj throw_continuation(ScmObj *argframe,
                                  int nargs SCM_UNUSED, void *data)
@@ -3545,10 +3531,26 @@ static ScmObj throw_continuation(ScmObj *argframe,
     ScmObj args = argframe[0];
     ScmVM *vm = theVM;
 
+    /* calculate dynamic handlers to call */
+    ScmObj hdlist = SCM_NIL;
+    ScmObj currentHandlers = get_dynamic_handlers(vm);
+    if (ep->contType == CONT_TYPE_FULL) {
+        /* for full continuation */
+        hdlist = throw_cont_calculate_handlers(ep->dynamicHandlers,
+                                               currentHandlers);
+    } else {
+        /* for composable partial continuation */
+        /* NB: this avoids redundant calls of dynamic handlers */
+        hdlist =
+            throw_cont_calculate_handlers(Scm_Append2(ep->partHandlers,
+                                                      currentHandlers),
+                                          currentHandlers);
+    }
+
     /* First, check to see if we need to rewind C stack.
-       NB: If we are invoking a partial continuation (ep->cstack == NULL),
+       NB: If we are invoking a partial continuation,
        we execute it on the current cstack. */
-    if (ep->cstack && vm->cstack != ep->cstack) {
+    if (ep->contType == CONT_TYPE_FULL && vm->cstack != ep->cstack) {
         ScmCStack *cs;
         for (cs = vm->cstack; cs; cs = cs->prev) {
             if (ep->cstack == cs) break;
@@ -3558,8 +3560,9 @@ static ScmObj throw_continuation(ScmObj *argframe,
            to the captured stack first. */
         if (cs != NULL) {
             vm->escapeReason = SCM_VM_ESCAPE_CONT;
-            vm->escapeData[0] = ep;
-            vm->escapeData[1] = args;
+            vm->escapeData[0] = hdlist;
+            vm->escapeData[1] = ep;
+            vm->escapeData[2] = args;
             siglongjmp(vm->cstack->jbuf, 1);
         }
         /* If we're here, the continuation is 'ghost'---it was captured on
@@ -3579,25 +3582,6 @@ static ScmObj throw_continuation(ScmObj *argframe,
         save_cont(vm);
     }
 
-    /* check reset-chain to avoid the wrong return from partial
-       continuation */
-    if (ep->cstack == NULL && !SCM_PAIRP(ep->resetChain)) {
-        Scm_Error("reset missing.");
-    }
-
-    ScmObj hdlist;
-    ScmObj currentHandlers = get_dynamic_handlers(vm);
-    if (ep->cstack) {
-        /* for full continuation */
-        hdlist = throw_cont_calculate_handlers(ep->dynamicHandlers,
-                                               currentHandlers);
-    } else {
-        /* for partial continuation */
-        hdlist
-            = throw_cont_calculate_handlers(Scm_Append2(ep->partHandlers,
-                                                        currentHandlers),
-                                            currentHandlers);
-    }
     return throw_cont_body(hdlist, ep, args);
 }
 
@@ -3605,9 +3589,8 @@ ScmObj Scm_VMCallCC(ScmObj proc)
 {
     ScmVM *vm = theVM;
 
-    save_cont(vm);
-
-    ScmEscapePoint *ep = new_ep(vm, SCM_FALSE, FALSE, SCM_FALSE, SCM_FALSE);
+    ScmEscapePoint *ep = new_ep(vm, SCM_FALSE, FALSE, CONT_TYPE_FULL,
+                                SCM_FALSE, SCM_FALSE);
     ScmObj contproc = Scm_MakeSubr(throw_continuation, ep, 0, 1,
                                    continuation_symbol);
     return Scm_VMApply1(proc, contproc);
@@ -3626,84 +3609,98 @@ ScmObj Scm_VMCallPC(ScmObj proc)
 {
     ScmVM *vm = theVM;
 
-    /* save the continuation.  we only need to save the portion above the
-       latest boundary frame (+environmentns pointed from them), but for now,
-       we save everything to make things easier.  If we want to squeeze
-       performance we'll optimize it later. */
-    save_cont(vm);
-
-    /* find the latest boundary frame */
-    ScmContFrame *c, *cp;
-    for (c = vm->cont, cp = NULL;
-         c && !BOUNDARY_FRAME_P(c);
-         cp = c, c = c->prev)
-        /*empty*/;
-
-    /* set the end marker of partial continuation */
-    if (cp && !MARKER_FRAME_P(cp)) {
-        cp->marker |= SCM_CONT_SHIFT_MARKER;
-        /* also set the delimited flag in reset information */
-        if (SCM_PAIRP(vm->resetChain)) {
-            SCM_SET_CAR_UNCHECKED(SCM_CAR(vm->resetChain), SCM_TRUE);
-        }
-    }
-
     /* We need some special setup of EscapePoint for partial continaution.
        Hoping these tricks won't be necessary once we ovehauled partcont
        handling. */
-    ScmEscapePoint *ep = new_ep(vm, SCM_FALSE, FALSE, SCM_FALSE, SCM_FALSE);
-    ep->cont = (cp? vm->cont : NULL);
-    ep->denv = c? c->denv : (cp? cp->denv : SCM_NIL);
+    ScmEscapePoint *ep = new_ep(vm, SCM_FALSE, FALSE, CONT_TYPE_PARTIAL,
+                                SCM_FALSE, SCM_FALSE);
     ep->dynamicHandlers = SCM_NIL; /* don't use for partial continuation */
     ep->cstack = NULL; /* so that the partial continuation can be run
                           on any cstack state. */
-    ep->resetChain = (SCM_PAIRP(vm->resetChain)?
-                      Scm_Cons(Scm_Cons(SCM_FALSE, SCM_NIL), SCM_NIL) :
-                      SCM_NIL); /* used only to detect reset missing */
+    ep->resetChain = SCM_NIL;      /* don't use for partial continuation */
 
-    /* get the dynamic handlers chain saved on reset */
-    ScmObj reset_handlers = (SCM_PAIRP(vm->resetChain)?
-                             SCM_CDAR(vm->resetChain) : SCM_NIL);
+    /* get escape point on reset */
+    ScmEscapePoint *ep2 = (SCM_PAIRP(vm->resetChain)?
+                           (ScmEscapePoint *)SCM_CDAR(vm->resetChain) : NULL);
+    if (ep2 == NULL) {
+        Scm_Error("reset missing.");
+    }
 
-    /* cut the dynamic handlers chain from current to reset */
+    /* get dynamic handlers chain on reset */
+    ScmObj targetHandlers = ep2->dynamicHandlers;
+
+    /* cut dynamic handlers chain from current to reset */
+    /* NB: this avoids redundant calls of dynamic handlers */
     ScmObj h = SCM_NIL, t = SCM_NIL, p;
     SCM_FOR_EACH(p, get_dynamic_handlers(vm)) {
-        if (p == reset_handlers) break;
+        if (p == targetHandlers) { break; }
         SCM_APPEND1(h, t, SCM_CAR(p));
     }
     ep->partHandlers = h;
 
-    /* call dynamic handlers for exiting reset */
-    call_dynamic_handlers(vm, reset_handlers, get_dynamic_handlers(vm));
-
+    /* make continuation procedure */
     ScmObj contproc = Scm_MakeSubr(throw_continuation, ep, 0, 1,
                                    continuation_symbol);
-    /* Remove the saved continuation chain.
-       NB: vm->cont can be NULL if we've been executing a partial continuation.
-           It's ok, for a continuation pointed by cstack will be restored
-           in user_eval_inner.
-       NB: If the delimited flag in reset information is not set,
-           we can consider we've been executing a partial continuation. */
-    if (cp && (SCM_PAIRP(vm->resetChain) &&
-               SCM_FALSEP(SCM_CAAR(vm->resetChain)))) {
-        vm->cont = NULL;
-    } else {
-        vm->cont = c;
-    }
-    vm->denv = c? c->denv : (cp? cp->denv : SCM_NIL);
 
-    return Scm_VMApply1(proc, contproc);
+    /* abort to reset */
+    ScmEscapePoint *ep3 = copy_ep(ep2);
+    ep3->abortHandler = proc;
+    ep3->abortArgs = SCM_LIST1(contproc);
+    ScmObj contproc2 = Scm_MakeSubr(throw_continuation, ep3, 0, 1,
+                                    continuation_symbol);
+    return Scm_VMApply(contproc2, SCM_NIL);
+}
+
+static ScmObj reset_wrapper_cc(ScmObj result, void **data SCM_UNUSED)
+{
+    return result;
+}
+
+static ScmObj reset_wrapper_proc(ScmObj *args SCM_UNUSED, int nargs SCM_UNUSED, void *data)
+{
+    ScmVM *vm = theVM;
+    ScmObj proc = SCM_OBJ(data);
+
+    /* set the end of partial continuation */
+    /*
+       NB: Cutting the continuation here by NULL is important to avoid
+           memory leak of partial continuation.
+       See:
+       https://okmij.org/ftp/continuations/against-callcc.html#memory-leak
+    */
+    vm->cont = NULL;
+
+    /* Add a continuation frame so that the end of partial continuation
+       (vm->cont=NULL) can be set. */
+    Scm_VMPushCC(reset_wrapper_cc, NULL, 0);
+
+    /* save escape point to reset-chain */
+    ScmEscapePoint *ep = new_ep(vm, SCM_FALSE, FALSE, CONT_TYPE_FULL,
+                                SCM_FALSE, SCM_FALSE);
+    SCM_ASSERT(SCM_PAIRP(vm->resetChain));
+    ScmObj resetInfo = SCM_CAR(vm->resetChain);
+    SCM_SET_CDR_UNCHECKED(resetInfo, SCM_OBJ(ep));
+
+    return Scm_VMApply0(proc);
 }
 
 ScmObj Scm_VMReset(ScmObj proc)
 {
     ScmVM *vm = theVM;
-    /* push/pop reset-chain for reset/shift */
-    vm->resetChain = Scm_Cons(Scm_Cons(SCM_FALSE, get_dynamic_handlers(vm)),
+
+    /* push reset-chain for reset/shift */
+    vm->resetChain = Scm_Cons(Scm_Cons(SCM_FALSE, NULL),
                               vm->resetChain);
-    ScmObj ret = Scm_ApplyRec(proc, SCM_NIL);
+
+    /* We call a wrapper procedure which adds a continuation frame so that
+       the end of partial continuation (vm->cont=NULL) can be set. */
+    ScmObj proc1 = Scm_MakeSubr(reset_wrapper_proc, proc, 0, 0, SCM_FALSE);
+    ScmObj ret = Scm_ApplyRec(proc1, SCM_NIL);
+
+    /* pop reset-chain for reset/shift */
     SCM_ASSERT(SCM_PAIRP(vm->resetChain));
     vm->resetChain = SCM_CDR(vm->resetChain);
+
     return ret;
 }
 

--- a/tests/continuation.scm
+++ b/tests/continuation.scm
@@ -497,7 +497,7 @@
             (lambda ()
               (abort-current-continuation tag1 'foo))))))
 
-'(let ([tag (make-continuation-prompt-tag 'tag)])
+(let ([tag (make-continuation-prompt-tag 'tag)])
   (test* "abort-current-continuation crosses cstack boundary"
          '(a)
          (call-with-continuation-prompt
@@ -521,6 +521,28 @@
                 (^[] (push! r 'after))))
             tag1
             (^[x] (push! r x))))))
+
+(let ([tag1 (make-continuation-prompt-tag 'tag1)]
+      [tag2 (make-continuation-prompt-tag 'tag2)])
+  (test* "abort-current-continuation (two tags)"
+         "[p01][p02][a01][p05]"
+         (with-output-to-string
+           (lambda ()
+             (call-with-continuation-prompt
+              (lambda ()
+                (display "[p01]")
+                (call-with-continuation-prompt
+                 (lambda ()
+                   (display "[p02]")
+                   (abort-current-continuation
+                    tag2
+                    (lambda ()
+                      (display "[a01]")))
+                   (display "[p03]"))
+                 tag1)
+                (display "[p04]"))
+              tag2)
+             (display "[p05]")))))
 
 ;;-----------------------------------------------------------------------
 ;; Parameterizations
@@ -580,6 +602,60 @@
       (^[] (+ 1 (reset (+ 2 (shift k (+ 3 (k 5) (k 1))))))))
 (test "calling pc multi" '(1 3 2 2 4)
       (^[] (cons 1 (reset (cons 2 (shift k (cons 3 (k (k (cons 4 '()))))))))))
+
+;; Cf. https://reinyannyan.hatenadiary.org/entry/20090623/p1
+(test* "reset / shift (for-each)"
+       '(1 2 3)
+       (reset
+        (for-each
+         (lambda (x) (shift k (cons x (k 'next))))
+         '(1 2 3))
+        '()))
+
+;; from SRFI-226 document
+(test* "reset / shift 1" 4  (+ 1 (reset 3)))
+(test* "reset / shift 2" 5  (+ 1 (reset (* 2 (shift k 4)))))
+(test* "reset / shift 3" 9  (+ 1 (reset (* 2 (shift k (k 4))))))
+(test* "reset / shift 4" 17 (+ 1 (reset (* 2 (shift k (k (k 4)))))))
+(test* "reset / shift 5" 25 (+ 1 (reset (* 2 (shift k1 (* 3 (shift k2 (k1 (k2 4)))))))))
+
+;; Cf. https://gengar.hatenadiary.org/entry/20140406/1396795808
+(let ()
+  (define d display)
+  (define (d$ x) (lambda () (d x)))
+  (define (%dw x thunk) (dynamic-wind (d$ `(,x before)) thunk (d$ `(,x after))))
+  (define-syntax dw (syntax-rules () ((_ x body ...) (%dw x (lambda () body ...)))))
+
+  '(test* "call/comp 1" '(a b c b) (cons 'a (reset (cons 'b (call/comp (lambda (k) (cons 'c (k '()))))))))
+  (test* "call/cc 1"   '(a b)     (cons 'a (reset (cons 'b (call/cc (lambda (k) (cons 'c (k '()))))))))
+
+  ;; Racket result is '(a b c b) instead of '(a b)
+  (test* "call/cc 2"   '(a b)     (cons 'a (reset (cons 'b (call/cc (lambda (k) (cons 'c (reset (k '())))))))))
+
+  (test* "call/cc 3"   '(c b)
+         (let ((k #f))
+           (cons 'a (reset (cons 'b (call/cc (lambda (k1) (set! k k1) '())))))
+           (cons 'c (reset (cons 'd (k '()))))))
+  (test* "dw"
+         "(0 before)body(0 after)"
+         (with-output-to-string
+           (lambda ()
+             (dw 0 (d 'body)))))
+  (test* "dw + let/cc"
+         "(0 before)(0 after)42"
+         (with-output-to-string
+           (lambda ()
+             (d (let/cc return (dw 0 (return 42)))))))
+  (test* "dw + call/cc"
+         ;; due to the difference in call/cc specs
+         ;"(0 before)a(0 after)(1 before)(1 after)b"
+         "(0 before)a(0 after)(1 before)(1 after)(0 before)b(0 after)"
+         (with-output-to-string
+           (lambda ()
+             (let ((k #f))
+               (dw 0 (reset (d (call/cc (lambda (k1) (set! k k1) 'a)))))
+               (reset (dw 1 (k 'b)))))))
+  )
 
 ;; 'amb' example in Gasbichler&Sperber ICFP2002 paper
 (let ()

--- a/tests/partcont.scm
+++ b/tests/partcont.scm
@@ -127,7 +127,7 @@
             (display "[s01]")
             (call/cc (lambda (k) (set! k2 k)))
             ;; empty after call/cc
-                                        ;(display "[s02]")
+            ;(display "[s02]")
             )
            (k1)
            (reset (reset (k2))))))
@@ -176,7 +176,7 @@
            (dynamic-wind
              (lambda () (display "[d01]"))
              (lambda () (display "[d02]")
-                     (display (reset (reset (k2)))))
+                        (display (reset (reset (k2)))))
              (lambda () (display "[d03]"))))))
 
 ;; native : [r01][s01][s01]
@@ -198,37 +198,41 @@
            (k2)
            (reset (k1)))))
 
-;; native : error
+;; native : ""
 ;; meta   : ""
-;; srfi226: no error
+;; srfi226: ""
 ;; racket : -
 (gauche-only
  (test* "reset/shift + call/cc error 1"
-        (test-error)
+        ;(test-error)
+        ""
         (with-output-to-string
           (lambda ()
             (define k1 #f)
             (define k2 #f)
-            (define (f1) (call/cc (lambda (k) (set! k1 k)))
+            (define (f1)
+              (call/cc (lambda (k) (set! k1 k)))
               (shift k (set! k2 k))
               (display "[f01]"))
             (define (f2) (display "[f02]"))
             (reset (f1) (f2))
             (reset (k1))))))
 
-;; native : error
+;; native : ""
 ;; meta   : ""
-;; srfi226: no error
+;; srfi226: ""
 ;; racket : -
 (gauche-only
  (test* "reset/shift + call/cc error 2"
-        (test-error)
+        ;(test-error)
+        ""
         (with-output-to-string
           (lambda ()
             (define k1 #f)
             (define k2 #f)
             (define k3 #f)
-            (define (f1) (call/cc (lambda (k) (set! k1 k)))
+            (define (f1)
+              (call/cc (lambda (k) (set! k1 k)))
               (shift k (set! k2 k))
               (display "[f01]"))
             (define (f2) (display "[f02]"))
@@ -244,7 +248,8 @@
  ;; Avoid running with partcont-meta, for it hangs.
  (unless (provided? "gauche/partcont-meta")
    (test* "reset/shift + call/cc error 3"
-          (test-error)
+          ;(test-error)
+          ""
           (with-output-to-string
             (lambda ()
               (define k1 #f)
@@ -253,7 +258,7 @@
                (call/cc (lambda (k) (set! k1 k)))
                (shift k (set! k2 k)))
               (k2)
-              (k1))))))
+              (reset (k1)))))))
 
 (gauche-only
  ;; Avoid running with partcont-meta, for something weird happnes.
@@ -270,15 +275,15 @@
              (shift k (display (p)) (cont k))
              (display (p)))))))
      ;; native : 010
-     ;; meta   :
-     ;; srfi226:
+     ;; meta   : -
+     ;; srfi226: -
      ;; racket : -
      (test* "reset/shift + call/cc + parameterize" "010"
             (with-output-to-string
               (lambda () (set! c (foo)))))
      ;; native : 1
-     ;; meta   :
-     ;; srfi226:
+     ;; meta   : -
+     ;; srfi226: -
      ;; racket : -
      (test* "reset/shift + call/cc + parameterize" "1"
             (with-output-to-string c)))))
@@ -295,10 +300,10 @@
          (shift k (display (p)) (set! c k))
          (display (p)))
        (display (p)))))
-  ;; native : 232
-  ;; meta   : 232
-  ;; srfi226: 232
-  ;; racket : 23#<void>
+  ;; native : "232"
+  ;; meta   : "232"
+  ;; srfi226: "232"
+  ;; racket : "23"#<void>
   (test* "reset/shift + temporarily + parameterize" "232"
          (with-output-to-string foo))
   ;; native : "32"
@@ -346,6 +351,61 @@
                 (lambda () (display "[D01]"))
                 next
                 (lambda () (display "[D02]"))))))))
+
+;; native : "catch error!!"
+;; meta   : "catch error!!"
+;; srfi226: "catch error!!"
+;; racket : "catch error!!"
+;; ( https://github.com/shirok/Gauche/pull/848 )
+(test* "reset/shift + guard 2"
+       "catch error!!"
+       (let ((k1 #f))
+         (reset
+          (guard (e [else "catch error!!"])
+            (shift k (set! k1 k))
+            (error "err")))
+         (k1 100)))
+
+;; native : 42
+;; meta   : 42
+;; srfi226: -
+;; racket : -
+;; ( https://github.com/shirok/Gauche/pull/848 )
+(gauche-only
+ (test* "reset/shift + eval 1"
+        42
+        (reset (eval '(shift k (k 42)) (current-module)))))
+
+;; native : 42
+;; meta   : 42
+;; srfi226: -
+;; racket : -
+;; ( https://github.com/shirok/Gauche/pull/848 )
+(gauche-only
+ (test* "reset/shift + eval 2"
+        42
+        (reset (eval '(+ (shift k (k 42))) (current-module)))))
+
+;; native : 42
+;; meta   : 42
+;; srfi226: -
+;; racket : -
+;; ( https://github.com/shirok/Gauche/pull/848 )
+(gauche-only
+ (test* "reset/shift + eval 3"
+        42
+        (reset (+ (eval '(shift k (k 42)) (current-module))))))
+
+;; native : (42 43 44)
+;; meta   : (42 43 44)
+;; srfi226: -
+;; racket : -
+;; ( https://github.com/shirok/Gauche/pull/848 )
+(gauche-only
+ (test* "reset/shift + eval 4"
+        '(42 43 44)
+        (receive vals (reset (eval '(shift k (k 42 43 44)) (current-module)))
+          vals)))
 
 ;; native : [d01][d02][d03][d04]
 ;; meta   : [d01][d02][d04][d01][d03][d04]


### PR DESCRIPTION
**＜＜本件は、急いでマージする必用はありません。＞＞**

- 現状ベースで、reset / shift の処理を見直したものです。
  機能の追加はありません。

- reset の時点で、vm->cont = NULL として切断するようにしました。
  今まで、メモリリークは特定のケースのみ対応していましたが、
  他のケースでもリークしなくなりました。
  (ただ、このために、reset を超えて prompt-tag を検索することはできなくなっています。
  例えば、reset 内で abort-current-continuation を実行すると、
  タグが見つからないというエラーになります。
  (ただ、今までも過去のルートの方を検索しにいっていたので、正しいわけではなかった))

- shift marker が不要になったため、削除しました。
  RETURN_OP() もシンプルになりました。

- #972 と 
  #1242 は、
  本 PR に統合しました。

- prompt frame の ScmPromptData が、
  save_cont_1() でヒープにコピーされない件を修正。
  (boundary frame のみをコピーするようになっていた)
  → 元 shift marker だったビットを、promot marker に割り当てて対応しました。
     (割り当ては、metacontinuation ブランチを参考にしました)

- abort-current-continuation のジャンプが、
  cstack を考慮していない件を修正。
  → throw_continuation() を使うように修正しました。
     (abort-handler がデフォルトのときに、
     「区切られた継続を改めて導入し…」という処理は、
     libproc.scm の方で実現しています)

＜テスト結果＞
(1) make check ==> OK

(2) [Gauche-effects](https://github.com/Hamayama/Gauche-effects) の effects.scm で、
    `*use-native-reset*` を #t にして、各サンプルを実行 ==> OK

(3) 以下のメモリリークのテスト ==> OK
(出典 : http://okmij.org/ftp/continuations/against-callcc.html#memory-leak )
(これは (use gauche.partcont-meta) だとメモリリークします)
```
(use gauche.partcont)
(define (leak-test1 identity-thunk)
  (let loop ((id (lambda (x) x)))
    (loop (id (identity-thunk)))))
(leak-test1 (lambda () (reset (shift k k))))
```
別ケース(今までの reset/shift ではリークする)
```
(use gauche.partcont)
(define (leak-test1 identity-thunk)
  (let loop ((id (lambda (x) x)))
    (loop (id (identity-thunk)))))
(leak-test1 (lambda () (reset (values (shift k k)))))
```

(4) Kahua の nqueen を実行 ==> OK

(5) https://practical-scheme.net/wiliki/wiliki.cgi?Gauche%3ABugs#H-2dgngv
    の pcdemo10.scm を実行 ==> OK
