### PR TITLE
Fix flonum reader misrounding at decimal exponent ±23

### DIFF
--- a/src/number.c
+++ b/src/number.c
@@ -3829,7 +3829,7 @@ static double dexpt2_minus_53  = 0.0;  /* 2.0^-53 */
 
 /* max N where 10.0^N can be representable exactly in double.
    it is max N where N * log2(5) < 53. */
-#define MAX_EXACT_10_EXP  23
+#define MAX_EXACT_10_EXP  22
 
 /* fast 10^n for limited cases */
 static inline ScmObj iexpt10(int e)
@@ -3860,26 +3860,26 @@ static inline u_long ipow(int r, int n)
 
 /* X * 10.0^N by double.
    10.0^N can be represented _exactly_ in double-precision floating point
-   number in the range 0 <= N <= 23.
+   number in the range 0 <= N <= MAX_EXACT_10_EXP.
    If N is out of this range, a rounding error occurs, which will be
    corrected in the algorithmR routine below. */
 static double raise_pow10(double x, int n)
 {
-    static double dpow10[] = { 1.0, 1.0e1, 1.0e2, 1.0e3, 1.0e4,
-                               1.0e5, 1.0e6, 1.0e7, 1.0e8, 1.0e9,
-                               1.0e10, 1.0e11, 1.0e12, 1.0e13, 1.0e14,
-                               1.0e15, 1.0e16, 1.0e17, 1.0e18, 1.0e19,
-                               1.0e20, 1.0e21, 1.0e22, 1.0e23 };
+    static const double dpow10[MAX_EXACT_10_EXP + 1] = {
+        1.0,    1.0e1,  1.0e2,  1.0e3,  1.0e4,  1.0e5,  1.0e6,  1.0e7,  1.0e8,
+        1.0e9,  1.0e10, 1.0e11, 1.0e12, 1.0e13, 1.0e14, 1.0e15, 1.0e16, 1.0e17,
+        1.0e18, 1.0e19, 1.0e20, 1.0e21, 1.0e22,
+    };
     if (n >= 0) {
-        while (n > 23) {
-            x *= 1.0e24;
-            n -= 24;
+        while (n > MAX_EXACT_10_EXP) {
+            x *= dpow10[MAX_EXACT_10_EXP];
+            n -= MAX_EXACT_10_EXP;
         }
         return x*dpow10[n];
     } else {
-        while (n < -23) {
-            x /= 1.0e24;
-            n += 24;
+        while (n < -MAX_EXACT_10_EXP) {
+            x /= dpow10[MAX_EXACT_10_EXP];
+            n += MAX_EXACT_10_EXP;
         }
         return x/dpow10[-n];
     }

--- a/tests/number.scm
+++ b/tests/number.scm
@@ -400,6 +400,38 @@
        (list (= 0.0 (string->number "0e324"))
              (= 0.0 (string->number "0e325"))))
 
+;; The reader must return the double *nearest* the exact decimal value.
+;; See https://github.com/shirok/Gauche/pull/1302
+(define (correctly-rounded? s)
+  (let* ([got (string->number s)]
+         [ex  (string->number (string-append "#e" s))] ; exact, unrounded
+         [v   (decode-float got)]
+         [m   (vector-ref v 0)]
+         [k   (expt 2 (vector-ref v 1))]
+         [sgn (vector-ref v 2)]
+         ;; distance from the exact value to the double with significand mm
+         [d   (^[mm] (abs (- (* sgn mm k) ex)))])
+    (and (<= (d m) (d (+ m 1)))
+         (<= (d m) (d (- m 1))))))
+
+;; Three witnesses per exponent sign: raise_pow10 multiplies for e = +23 and
+;; divides for e = -23, and roughly half of all exact mantissas misround, so
+;; a single literal per branch is a thin net.
+(dolist [s '("1e-23"                    ; minimal case: one significant digit
+             "1.658087549245532e-08"
+             "-3.031704146171012e-08"
+             "1.375848893331631e+38"
+             "2.293669867200266e+38"
+             "-4.487259214067599e+38")]
+  (test* (format "flonum reader correctly rounded ~s" s) #t
+         (correctly-rounded? s)))
+
+;; Same defect seen from the other side: these name adjacent, distinct
+;; doubles, and used to collapse onto one value.
+(test* "flonum reader (adjacent doubles stay distinct)" #f
+       (= (string->number "1.658087549245532e-8")
+          (string->number "1.6580875492455322e-8")))
+
 ;; We used to allow 1#1 to be read as a symbol.  As of 0.9.4, it is an error.
 (test* "padding" '(10.0 #t) (flonum-test "1#"))
 (test* "padding" '(10.0 #t) (flonum-test "1#."))


### PR DESCRIPTION
`MAX_EXACT_10_EXP` was 23, but its own comment states the rule that gives 22:
max *N* where *N* · log₂(5) < 53, and 5²² < 2⁵³ ≤ 5²³. So 10²³ is the first
power of ten not exactly representable in binary64.

With 23, a mantissa that is itself exact (≤ 2⁵²) and a decimal exponent of
exactly ±23 took the fast path in `read_real` and skipped `algorithmR`, while
`raise_pow10` scaled it by a `dpow10[23]` entry that is already rounded.
Rounding twice puts the result up to 1 ulp off the nearest double:

```scheme
(string->number "1e-23")  ⇒  1.0000000000000001e-23
```

Mantissas above 2⁵² missed the fast path and were already correct, which is why
this was confined to |*e*| = 23 with short mantissas. Setting the constant to 22
lets |*e*| = 23 fall through to `algorithmR`, which already corrects the inexact
seeds it gets for |*e*| ≥ 24.

Round-trip tests could not catch this: read/print/read is a fixed point, and a
wrong-but-stable reader passes it by construction. The added tests compare
against the exactly-read decimal (`#e` prefix) instead, via `decode-float`.

---

(Disclosure: the issue was found and later fixed by a LLM, with myself providing only minor guidance).