### PR TITLE
Add SRFI 273 check-impl? to SRFI 253 code

### DIFF
--- a/lib/srfi/253.scm
+++ b/lib/srfi/253.scm
@@ -60,7 +60,7 @@
      (values (values-checked (predicate) value) ...))))
 
 (define-syntax %check-case
-  (syntax-rules (else)
+  (syntax-rules (else check-impl?)
     ((_ val (clause ...) (else body ...))
      (cond
       clause ...

--- a/lib/srfi/253.scm
+++ b/lib/srfi/253.scm
@@ -35,12 +35,18 @@
 (define-module srfi.253
   (use gauche.record)
   (export check-arg                     ;builtin
+          check-impl?
           values-checked check-case
           lambda-checked define-checked
           case-lambda-checked
           define-record-type-checked))
 
 (select-module srfi.253)
+
+(define-syntax check-impl?
+  (syntax-rules ()
+    ((_ type)
+     type)))
 
 ;; Below this line are the helpers from the generic sample implementation.
 
@@ -66,6 +72,11 @@
       (else (assume (or clause-check ...)
                     "at least one branch of check-case should be true"
                     'clause-check ...))))
+    ((_ val (clause ...) ((check-impl? type) body ...) rest ...)
+     (%check-case
+      val
+      (clause ... ((of-type? val type) body ...))
+      rest ...))
     ((_ val (clause ...) (pred body ...) rest ...)
      (%check-case
       val

--- a/tests/include/srfi-253-test.scm
+++ b/tests/include/srfi-253-test.scm
@@ -59,6 +59,13 @@
 (test-assert (check-arg-true string? ""))
 (test-assert (check-arg-true string? "hello"))
 (test-assert (check-arg-true symbol? 'hello))
+;; Checks with check-impl? types
+(test-assert (check-arg-true (check-impl? <number>) 3))
+(test-assert (check-arg-true (check-impl? <number>) 3+2i))
+(test-assert (check-arg-true (check-impl? <number>) 3.8))
+(test-assert (check-arg-true (check-impl? <pair>) '(1 2 3)))
+(test-assert (check-arg-true (check-impl? <string>) "hello"))
+(test-assert (check-arg-true (check-impl? <symbol>) 'hello))
 ;; Only enable on implementations supporting symbol->keyword
 ;; (test-assert (check-arg-true keyword? (symbol->keyword 'hello)))
 (test-assert (check-arg-true vector? #(1 2 3)))


### PR DESCRIPTION
This adds a [check-impl? auxiliary syntax from SRFI 273](https://srfi.schemers.org/srfi-273/srfi-273.html#spec--check-impl) to SRFI 253 code. Given that Gauche `check-arg` allows types as checks and SRFI 253 almost exclusively relies on `check-arg`, this is a safe and composable change.

Despite coming from SRFI 273, this change belongs to SRFI 253 as it’s an aux syntax for SRFi 253 forms.