### PR TITLE
Fix compare to consult object-compare for distinct unrelated classes (#1225)

### DIFF
--- a/src/compare.c
+++ b/src/compare.c
@@ -37,6 +37,11 @@
 #include "gauche/priv/configP.h"
 #include "gauche/priv/compareP.h"
 
+/* The object-compare generic, defined in class.c.  We consult it directly
+   in Scm_Compare to honor object-compare methods defined for two distinct
+   classes that are not in a subclass relationship. */
+extern ScmGeneric Scm_GenericObjectCompare;
+
 /*
  * Comparator
  */
@@ -151,6 +156,27 @@ int Scm_Compare(ScmObj x, ScmObj y)
         if (cy->compare) return cy->compare(x, y, FALSE);
     } else if (Scm_SubclassP(cy, cx)) {
         if (cx->compare) return cx->compare(x, y, FALSE);
+    } else if (cx->compare == Scm_ObjectCompare
+               || cy->compare == Scm_ObjectCompare) {
+        /* x and y are of distinct, unrelated classes, but at least one of
+           them delegates comparison to the object-compare generic.  Honor
+           an object-compare method defined for this pair (e.g. cross-type
+           methods, or a method on a common ancestor).
+           object-compare has a universal (<top> <top>) catch-all method
+           (see libomega.scm) that raises "not comparable", so we must not
+           call Scm_ObjectCompare unconditionally---doing so would turn the
+           no-method fall-through into an error.  We dispatch only when a
+           method more specific than the catch-all is applicable, i.e. the
+           applicable-methods list has more than one element. */
+        ScmObj argv[2];
+        argv[0] = x;
+        argv[1] = y;
+        ScmObj applicable =
+            Scm_ComputeApplicableMethods(&Scm_GenericObjectCompare,
+                                         argv, 2, FALSE);
+        if (SCM_PAIRP(applicable) && SCM_PAIRP(SCM_CDR(applicable))) {
+            return Scm_ObjectCompare(x, y, FALSE);
+        }
     }
     if (cx == cy) {
         /* x and y are of the same type, and they can't be ordered. */

--- a/tests/compare.scm
+++ b/tests/compare.scm
@@ -122,6 +122,61 @@
                (compare ay bx)
                (compare bx ay))))
 
+;; object-compare must be consulted for two distinct classes that are not
+;; in a subclass relationship, when a method is defined for the pair.
+;; https://github.com/shirok/Gauche/issues/1225
+(define-class <foo> () ())
+(define-class <bar> () ())
+(define-method object-compare ((_ <foo>) (_ <foo>)) 0)
+(define-method object-compare ((_ <bar>) (_ <bar>)) 0)
+(define-method object-compare ((_ <foo>) (_ <bar>)) -1)
+(define-method object-compare ((_ <bar>) (_ <foo>)) 1)
+
+(let ((foo (make <foo>))
+      (bar (make <bar>))
+      (foo2 (make <foo>)))
+  (test* "object-compare (distinct)"
+         '(-1 1 0)
+         (list (compare foo bar)
+               (compare bar foo)
+               (compare foo foo2))))
+
+;; A method defined on a common ancestor must be used for sibling classes.
+(define-class <base> ()
+  ((value :init-keyword :value)))
+
+(define-method object-compare ((self <base>) (other <base>))
+  (compare (slot-ref self 'value)
+           (slot-ref other 'value)))
+
+(define-class <derived-a> (<base>) ())
+(define-class <derived-b> (<base>) ())
+
+(let ((a1 (make <derived-a> :value 1))
+      (a2 (make <derived-a> :value 2))
+      (b1 (make <derived-b> :value 1))
+      (b2 (make <derived-b> :value 2)))
+  (test* "object-compare (inheritance)"
+         '(-1 -1)
+         (list (compare a1 a2)
+               (compare b1 b2)))
+  (test* "object-compare (inheritance, cross)"
+         '(-1 1)
+         (list (compare a1 b2)
+               (compare a2 b1))))
+
+;; Regression: two distinct classes with no applicable object-compare method
+;; must still fall through to the default ordering (by class name) and order
+;; deterministically, without raising "not comparable".
+(define-class <no-cmp-x> () ())
+(define-class <no-cmp-y> () ())
+(let ((x (make <no-cmp-x>))
+      (y (make <no-cmp-y>)))
+  (test* "object-compare (no method falls through)"
+         '(-1 1)
+         (list (compare x y)
+               (compare y x))))
+
 (test-section "builtin comparators")
 
 (let ()


### PR DESCRIPTION
Fixes #1225.

Root cause: `Scm_Compare` (`src/compare.c`) only dispatches to a class's compare slot when one class is a subclass of the other (the two `Scm_SubclassP` branches). Two distinct, unrelated classes therefore skip `object-compare` entirely and fall through to the SRFI-114 default, which orders "other" objects by class name -- even when a cross-type `object-compare` method (or a method on a common ancestor) is defined.

Fix: after the two subclass branches, when either operand delegates to the `object-compare` generic, consult it -- but only when an applicable method more specific than its universal `(<top> <top>)` catch-all exists. The catch-all (`libomega.scm`) raises "not comparable", so an unguarded `Scm_ObjectCompare` call would turn the no-method case into an error; `Scm_ComputeApplicableMethods` (list length > 1) is the guard that keeps the no-method case falling through to the default ordering instead of raising. This also covers #1074, which has the same cause.

Credit to @gengar for diagnosing the exact location and providing the tests, which are included in `tests/compare.scm` (distinct cross-type methods, common-ancestor inheritance, and a no-method regression case).

Red-green verified with a from-source bootstrap build: reverting the fix reproduces the class-name ordering (`(1 -1 0)` / `(-1 -1)`); with the fix, `tests/compare.scm`, `tests/object.scm` and `tests/sort.scm` all pass with no compiler warnings.

---
This change was prepared with AI assistance and reviewed by me before submission.